### PR TITLE
indBallL1: simpler code and no type instability

### DIFF
--- a/src/functions/indBallL1.jl
+++ b/src/functions/indBallL1.jl
@@ -33,12 +33,7 @@ function prox!{T <: RealOrComplex}(f::IndBallL1, x::AbstractArray{T}, y::Abstrac
     return 0.0
   else # do a projection of abs(x) onto simplex then recover signs
     n = length(x)
-    p = []
-    if ndims(x) == 1
-      p = abs.(x)
-    else
-      p = abs.(x)[:]
-    end
+    p = abs.(view(x,:))
     sort!(p, rev=true)
     s = 0.0
     @inbounds for i = 1:n-1


### PR DESCRIPTION
Avoids type instability and allows for simpler code.
`p` was previously of type `Array{Any,1}` and the compiler could not know (for a matrix input) if `p` would become a vector or a matrix. 