### PR TITLE
simplified SlicedSeparableSum

### DIFF
--- a/src/calculus/separableSum.jl
+++ b/src/calculus/separableSum.jl
@@ -7,9 +7,9 @@ end
 function (f::SeparableSum{S}){S <: AbstractArray}(x::AbstractArray)
 	sum = 0.0
   for k in eachindex(f.fs)
-		sum += f.fs[k](x[k])
-	end
-	return sum
+	  sum += f.fs[k](x[k])
+  end
+  return sum
 end
 
 function prox!(ys::AbstractArray, fs::AbstractArray, xs::AbstractArray, gamma::Real=1.0)

--- a/src/calculus/slicedSeparableSum.jl
+++ b/src/calculus/slicedSeparableSum.jl
@@ -2,56 +2,38 @@
 
 immutable SlicedSeparableSum{S <: AbstractArray, T <: AbstractArray} <: ProximableFunction
 	fs::S
-	is::T
-	dim::Integer
-	function SlicedSeparableSum(a::S, b::T, dim::Integer)
-		if size(a) != size(b)
-			error("size(fs) must coincide with size(is)")
+	idxs::T
+	function SlicedSeparableSum(fs, idxs)
+		if size(fs) != size(idxs)
+			error("size(fs) must coincide with size(idxs)")
 		else
-			new(a, b, dim)
+			verify_idx = true
+			for i in eachindex(idxs)
+				verify_idx *=
+				all([typeof(t) <: AbstractArray{Int64,1} || 
+	                             typeof(t) <: Colon for t in idxs[i]])
+			end
+			verify_idx ? new(fs, idxs) :error("invalid index")
 		end
 	end
 end
 
-SlicedSeparableSum{S <: AbstractArray, T <: AbstractArray}(a::S, b::T, dim::Integer=1) =
-	SlicedSeparableSum{S, T}(a, b, dim)
-
-function SlicedSeparableSum{T <: Tuple}(ps::AbstractArray{T}, dim::Integer=1)
-	a = Array{ProximableFunction}(length(ps))
-	b = Array{AbstractArray}(length(ps))
-	for i in eachindex(ps)
-		a[i] = ps[i][1]
-		b[i] = ps[i][2]
-	end
-	SlicedSeparableSum{typeof(a), typeof(b)}(a, b, dim)
-end
-
-function SlicedSeparableSum{P <: Pair}(p::AbstractArray{P}, dim::Integer = 1)
-	a = Vector{ProximableFunction}(length(p))
-	b = Vector{AbstractArray}(length(p))
-	for i in eachindex(p)
-		a[i] = p[i].first
-		b[i] = p[i].second
-	end
-	return SlicedSeparableSum(a, b, dim)
-end
+SlicedSeparableSum{S <: AbstractArray, T <: AbstractArray}(a::S, b::T) =
+SlicedSeparableSum{S, T}(a, b)
 
 function (f::SlicedSeparableSum{S}){S <: AbstractArray, T <: AbstractArray}(x::T)
 	sum = 0.0
-  for k in eachindex(f.fs)
-		sum += f.fs[k](x[is[k]])
+	for k in eachindex(f.fs)
+		sum += f.fs[k](x[f.idx[k]])
 	end
 	return sum
 end
 
-function prox!{T <: RealOrComplex}(y::AbstractArray{T}, f::SlicedSeparableSum, x::AbstractArray{T}, gamma::Real=1.0)
+function prox!{T <: RealOrComplex}(y::AbstractArray{T}, 
+				   f::SlicedSeparableSum, x::AbstractArray{T}, gamma::Real=1.0)
   v = 0.0
-  nd = ndims(x)
-
-  for i in eachindex(f.fs)
-	  z = slicedim(y, f.dim, f.is[i])
-	  g = prox!(z, f.fs[i], slicedim(x, f.dim, f.is[i]), gamma)
-	  y[[ n==f.dim ? f.is[i] : indices(y, n) for n in 1:nd ]...] = z
+  for k in eachindex(f.fs)
+	  g = prox!(view(y,f.idxs[k]...), f.fs[k], view(x,f.idxs[k]...), gamma)
 	  v += g
   end
   return v

--- a/src/calculus/slicedSeparableSum.jl
+++ b/src/calculus/slicedSeparableSum.jl
@@ -10,7 +10,7 @@ immutable SlicedSeparableSum{S <: AbstractArray, T <: AbstractArray} <: Proximab
 			verify_idx = true
 			for i in eachindex(idxs)
 				verify_idx *=
-				all([typeof(t) <: AbstractArray{Int64,1} || 
+				all([typeof(t) <: AbstractArray{Int,1} || 
 	                             typeof(t) <: Colon for t in idxs[i]])
 			end
 			verify_idx ? new(fs, idxs) :error("invalid index")

--- a/test/test_SlicedSeparableSum.jl
+++ b/test/test_SlicedSeparableSum.jl
@@ -2,54 +2,33 @@ using Base.Test
 using ProximalOperators
 
 srand(123)
-x = randn(100)
-y0 = randn(100)
+x = randn(10)
+y0 = randn(10)
 y = copy(y0)
 
 prox_col = [NormL1(0.1),IndBallL0(1)]
-ind_col = [1:50,51:100]
-M1 = ones(Bool,size(x))
-M1[51:end] = false
-M2 = M1.==false
+ind_col = [(1:5,),(6:10,)]
 
 f = SlicedSeparableSum(prox_col,ind_col)
-#test second constructor and mask
-ff = SlicedSeparableSum([(prox_col[1], M1), (prox_col[2], M2)])
-fff = SlicedSeparableSum([prox_col[1] => M1, prox_col[2] => M2])
-y,fy = prox(f,x,1.)
-yy,fyy = prox(ff,x,1.)
-yyy,fyyy = prox(fff,x,1.)
+y, fy = prox(f,x,1.)
 
-@test norm(fyy-fy)<1e-11
-@test norm(y-yy)<1e-11
-
-@test norm(fyyy-fy)<1e-11
-@test norm(y-yyy)<1e-11
-
-y1,fy1 = prox(prox_col[1],x[ind_col[1]],1.)
-y2,fy2 = prox(prox_col[2],x[ind_col[2]],1.)
+y1,fy1 = prox(prox_col[1],x[ind_col[1]...],1.)
+y2,fy2 = prox(prox_col[2],x[ind_col[2]...],1.)
 
 @test norm((fy1+fy2)-fy)<1e-11
 @test norm(y-[y1;y2])<1e-11
 
 X1,X2 = randn(10,10),randn(10,10)
-X = [X1 X2]
+X = [X1; X2]
 
-f = SlicedSeparableSum([NormL1(1.), NormL21(0.1)], [1:10,11:20], 2)
-#test second constructor
-ff = SlicedSeparableSum([(NormL1(1.),1:10), (NormL21(0.1),11:20)], 2)
+f = SlicedSeparableSum([NormL1(1.), NormL21(0.1)], [(1:10,:),(11:20,:)])
 
 y,fy = prox(f,X,1.)
-yy,fyy = prox(ff,X,1.)
-
-@test norm(fyy-fy)<1e-11
-@test norm(y-yy)<1e-11
 
 y1,fy1 = prox(NormL1(1.),X1,1.)
 y2,fy2 = prox(NormL21(0.1),X2,1.)
 
 @test norm((fy1+fy2)-fy)<1e-11
-@test norm(y-[y1 y2])<1e-11
+@test norm(y-[y1; y2])<1e-11
 
-println(ff)
-# println(SlicedSeparableSum(repmat([NormL1(1.)],6),repmat([1:10],6),2 ))
+@test_throws ErrorException SlicedSeparableSum([NormL1(1.), NormL21(0.1)], [(1.0,:),(11:20,:)])


### PR DESCRIPTION
This PR simplifies `SlicedSeparableSum`: 

* Removed multiple constructors. Here's an example of the new constructor: 
```
f = SlicedSeparableSum([NormL1(0.1),NormL1(0.2)],[(1:10, : ),(11:20,:)])
```
* While before the `SlicedSeparableSum` usage was similar to `slicedim` now it is oriented towards `getindex`    