### PR TITLE
fixed small bug on SlicedSeparableSum

### DIFF
--- a/src/calculus/postcompose.jl
+++ b/src/calculus/postcompose.jl
@@ -42,6 +42,9 @@ Postcompose{T <: ProximableFunction, R <: Real}(f::T, a::R=one(R), b::R=zero(R))
 
 Postcompose{T <: ProximableFunction, R <: Real}(f::Postcompose{T, R}, a::R=one(R), b::R=zero(R)) = Postcompose{T, R}(f.f, a*f.a, b+a*f.b)
 
+#special cases
+Postcompose{T <: ProximableFunction, C <: Conjugate{T}, R <: Real}(f::C, a::R=one(R), b::R=zero(R)) = Conjugate(Postcompose{T, R}(f.f, a, b))
+
 function (g::Postcompose){T <: RealOrComplex}(x::AbstractArray{T})
   return g.a*g.f(x) + g.b
 end

--- a/src/calculus/postcompose.jl
+++ b/src/calculus/postcompose.jl
@@ -42,9 +42,6 @@ Postcompose{T <: ProximableFunction, R <: Real}(f::T, a::R=one(R), b::R=zero(R))
 
 Postcompose{T <: ProximableFunction, R <: Real}(f::Postcompose{T, R}, a::R=one(R), b::R=zero(R)) = Postcompose{T, R}(f.f, a*f.a, b+a*f.b)
 
-#special cases
-Postcompose{T <: ProximableFunction, C <: Conjugate{T}, R <: Real}(f::C, a::R=one(R), b::R=zero(R)) = Conjugate(Postcompose{T, R}(f.f, a, b))
-
 function (g::Postcompose){T <: RealOrComplex}(x::AbstractArray{T})
   return g.a*g.f(x) + g.b
 end

--- a/src/calculus/slicedSeparableSum.jl
+++ b/src/calculus/slicedSeparableSum.jl
@@ -28,7 +28,7 @@ struct SlicedSeparableSum{S <: Tuple, T <: AbstractArray, N} <: ProximableFuncti
 end
 
 function SlicedSeparableSum(fs::S, idxs::T) where {N,
-						   S <: NTuple{N,Union{subtypes(ProximableFunction)...}},
+						   S <: Tuple{Vararg{<:ProximableFunction,N}},
 						   M, 
 						   I <: Integer, 
 						   T1 <: NTuple{M,Union{I,

--- a/src/calculus/slicedSeparableSum.jl
+++ b/src/calculus/slicedSeparableSum.jl
@@ -32,7 +32,7 @@ function SlicedSeparableSum{S <: AbstractArray, T <: AbstractArray}(fs::S, idxs:
     error("size(fs) must coincide with size(idxs)")
   else
     for k in eachindex(idxs)
-      cond = [typeof(t) <: Integer || typeof(t) <: AbstractArray{Integer,1} || typeof(t) <: Colon || typeof(t) <: Range for t in idxs[k]]
+      cond = [typeof(t) <: Integer || typeof(t) <: AbstractArray{Int,1} || typeof(t) <: Colon || typeof(t) <: Range for t in idxs[k]]
 			!all(cond) ? error("invalid index $(k)") : nothing
     end
     ftypes = DataType[]

--- a/test/test_calls.jl
+++ b/test/test_calls.jl
@@ -262,7 +262,7 @@ stuff = [
       ),
 
   Dict( "constr" => SlicedSeparableSum,
-        "params" => ( ([NormL2(2.0), NormL1(1.5), NormL2(0.5)], [(1:5,), (6:20,), (21:30,)]), ),
+       "params" => ( ((NormL2(2.0), NormL1(1.5), NormL2(0.5)), ((1:5,), (6:20,), (21:30,))), ),
         "args"   => ( randn(30), )
       ),
 ]

--- a/test/test_postcompose.jl
+++ b/test/test_postcompose.jl
@@ -46,21 +46,3 @@ yh, hyh = prox_test(h, x, 1.3)
 @test abs(gyg-hyh)/(1+abs(gyg)) <= 1e-12
 @test norm(yg-yh, Inf)/(1+norm(yg, Inf)) <= 1e-12
 
-# test postcompose of Conjugate
-x = randn(10)
-f = NormL1()
-c = Conjugate(f)
-d = Postcompose(c,0.5)
-d2 = IndBallLinf(0.5)
-
-yd, fd = prox(d,x)
-yd2, fd2 = prox(d2,x)
-
-@test norm(fd-fd2) <= 1e-8
-@test norm(yd-yd2) <= 1e-8
-
-
-
-
-
-

--- a/test/test_postcompose.jl
+++ b/test/test_postcompose.jl
@@ -45,3 +45,22 @@ yh, hyh = prox_test(h, x, 1.3)
 
 @test abs(gyg-hyh)/(1+abs(gyg)) <= 1e-12
 @test norm(yg-yh, Inf)/(1+norm(yg, Inf)) <= 1e-12
+
+# test postcompose of Conjugate
+x = randn(10)
+f = NormL1()
+c = Conjugate(f)
+d = Postcompose(c,0.5)
+d2 = IndBallLinf(0.5)
+
+yd, fd = prox(d,x)
+yd2, fd2 = prox(d2,x)
+
+@test norm(fd-fd2) <= 1e-8
+@test norm(yd-yd2) <= 1e-8
+
+
+
+
+
+

--- a/test/test_slicedSeparableSum.jl
+++ b/test/test_slicedSeparableSum.jl
@@ -63,3 +63,25 @@ y3,fy3 = prox(f,x3,1.)
 @test vecnorm(yn-y)<1e-11
 @test abs((fy1+fy2+fy3)-Fy)<1e-11
 @test vecnorm(y-[y1 y2 y3])<1e-11
+
+# CASE 4
+
+x = randn(10)
+y0 = randn(10)
+y = copy(y0)
+
+prox_col = [NormL1(0.1),IndBallL0(1)]
+ind_col = [(collect(1:5),),(collect(6:10),)]
+
+f = SlicedSeparableSum(prox_col,ind_col)
+y, fy = prox(f,x,1.)
+yn,fyn = ProximalOperators.prox_naive(f,x,1.)
+y1,fy1 = prox(prox_col[1],x[ind_col[1]...],1.)
+y2,fy2 = prox(prox_col[2],x[ind_col[2]...],1.)
+
+@test abs(f(y)-fy)<1e-11
+@test abs(fyn-fy)<1e-11
+@test vecnorm(yn-y)<1e-11
+@test abs((fy1+fy2)-fy)<1e-11
+@test vecnorm(y-[y1;y2])<1e-11
+

--- a/test/test_slicedSeparableSum.jl
+++ b/test/test_slicedSeparableSum.jl
@@ -9,8 +9,8 @@ x = randn(10)
 y0 = randn(10)
 y = copy(y0)
 
-prox_col = [NormL1(0.1),IndBallL0(1)]
-ind_col = [(1:5,),(6:10,)]
+prox_col = (NormL1(0.1),IndBallL0(1))
+ind_col = ((1:5,),(6:10,))
 
 f = SlicedSeparableSum(prox_col,ind_col)
 y, fy = prox(f,x,1.)
@@ -29,7 +29,7 @@ y2,fy2 = prox(prox_col[2],x[ind_col[2]...],1.)
 X1,X2 = randn(10,10),randn(10,10)
 X = [X1; X2]
 
-f = SlicedSeparableSum([NormL1(1.), NormL21(0.1)], [(1:10,:),(11:20,:)])
+f = SlicedSeparableSum((NormL1(1.), NormL21(0.1)), ((1:10,:),(11:20,:)))
 
 y,fy = prox(f,X,1.)
 yn,fyn = ProximalOperators.prox_naive(f,X,1.)
@@ -42,7 +42,8 @@ y2,fy2 = prox(NormL21(0.1),X2,1.)
 @test abs((fy1+fy2)-fy)<1e-11
 @test vecnorm(y-[y1; y2])<1e-11
 
-@test_throws ErrorException SlicedSeparableSum([NormL1(1.), NormL21(0.1)], [(1.0,:),(11:20,:)])
+@test_throws MethodError SlicedSeparableSum((NormL1(1.), NormL21(0.1)), ((1.0,:),(11:20,:)))
+@test_throws MethodError SlicedSeparableSum((NormL1(1.), randn()), ((1:10,:),(11:20,:)))
 
 # CASE 3
 
@@ -50,7 +51,7 @@ x1, x2, x3 = randn(10), randn(10), randn(10)
 X = [x1 x2 x3]
 
 f = NormL2()
-F = SlicedSeparableSum(f, [[:,1],[:,2],[:,3]])
+F = SlicedSeparableSum(f, ((:,1),(:,2),(:,3)))
 
 y,Fy = prox(F,X,1.)
 yn,Fyn = ProximalOperators.prox_naive(F,X,1.)
@@ -70,8 +71,8 @@ x = randn(10)
 y0 = randn(10)
 y = copy(y0)
 
-prox_col = [NormL1(0.1),IndBallL0(1)]
-ind_col = [(collect(1:5),),(collect(6:10),)]
+prox_col = (NormL1(0.1),IndBallL0(1))
+ind_col = ((collect(1:5),),(collect(6:10),))
 
 f = SlicedSeparableSum(prox_col,ind_col)
 y, fy = prox(f,x,1.)


### PR DESCRIPTION
Small bug on `SlicedSeparableSum` when `idxs` was composed by `Array{Int,1}`. 
Apparently
```julia
julia> x = collect(1:10);

julia> typeof(x) <: AbstractArray{Integer,1}
false
```
changing `AbstractArray{Integer,1}` to `AbstractArray{Int,1}` fixed the problem.