### PR TITLE
Add simd to for loops

### DIFF
--- a/src/functions/normL1.jl
+++ b/src/functions/normL1.jl
@@ -60,6 +60,7 @@ function (f::NormL1{A}){A <: AbstractArray}(x::AbstractArray)
 end
 
 function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::Real=1.0)
+  @assert length(y) == length(x) == length(f.lambda)
   fy = zero(R)
   @inbounds @simd for i in eachindex(x)
     gl = gamma*f.lambda[i]
@@ -69,6 +70,7 @@ function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{R}, f::NormL1{A},
 end
 
 function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::Real=1.0)
+  @assert length(y) == length(x) == length(f.lambda)
   fy = zero(R)
   @inbounds @simd for i in eachindex(x)
     gl = gamma*f.lambda[i]
@@ -78,6 +80,7 @@ function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{Complex{R}}, f::N
 end
 
 function prox!{T <: Real, R <: Real}(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::Real=1.0)
+  @assert length(y) == length(x)
   n1y = zero(R)
   gl = gamma*f.lambda
   @inbounds @simd for i in eachindex(x)
@@ -88,6 +91,7 @@ function prox!{T <: Real, R <: Real}(y::AbstractArray{R}, f::NormL1{T}, x::Abstr
 end
 
 function prox!{T <: Real, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::Real=1.0)
+  @assert length(y) == length(x)
   gl = gamma*f.lambda
   n1y = zero(R)
   @inbounds @simd for i in eachindex(x)
@@ -98,6 +102,7 @@ function prox!{T <: Real, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{T},
 end
 
 function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::AbstractArray)
+  @assert length(y) == length(x) == length(f.lambda) == length(gamma)
   fy = zero(R)
   @inbounds @simd for i in eachindex(x)
     gl = gamma[i]*f.lambda[i]
@@ -107,6 +112,7 @@ function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{R}, f::NormL1{A},
 end
 
 function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::AbstractArray)
+  @assert length(y) == length(x) == length(f.lambda) == length(gamma)
   fy = zero(R)
   @inbounds @simd for i in eachindex(x)
     gl = gamma[i]*f.lambda[i]
@@ -116,6 +122,7 @@ function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{Complex{R}}, f::N
 end
 
 function prox!{T <: Real, R <: Real}(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::AbstractArray)
+  @assert length(y) == length(x) == length(gamma)
   n1y = zero(R)
   @inbounds @simd for i in eachindex(x)
     gl = gamma[i]*f.lambda
@@ -126,6 +133,7 @@ function prox!{T <: Real, R <: Real}(y::AbstractArray{R}, f::NormL1{T}, x::Abstr
 end
 
 function prox!{T <: Real, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::AbstractArray)
+  @assert length(y) == length(x) == length(gamma) 
   n1y = zero(R)
   @inbounds @simd for i in eachindex(x)
     gl = gamma[i]*f.lambda

--- a/src/functions/normL1.jl
+++ b/src/functions/normL1.jl
@@ -61,7 +61,7 @@ end
 
 function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::Real=1.0)
   fy = zero(R)
-  for i in eachindex(x)
+  @inbounds @simd for i in eachindex(x)
     gl = gamma*f.lambda[i]
     y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
   end
@@ -70,7 +70,7 @@ end
 
 function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::Real=1.0)
   fy = zero(R)
-  for i in eachindex(x)
+  @inbounds @simd for i in eachindex(x)
     gl = gamma*f.lambda[i]
     y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
   end
@@ -80,7 +80,7 @@ end
 function prox!{T <: Real, R <: Real}(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::Real=1.0)
   n1y = zero(R)
   gl = gamma*f.lambda
-  for i in eachindex(x)
+  @inbounds @simd for i in eachindex(x)
     y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
     n1y += y[i] > 0 ? y[i] : -y[i]
   end
@@ -90,7 +90,7 @@ end
 function prox!{T <: Real, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::Real=1.0)
   gl = gamma*f.lambda
   n1y = zero(R)
-  for i in eachindex(x)
+  @inbounds @simd for i in eachindex(x)
     y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
     n1y += abs(y[i])
   end
@@ -99,7 +99,7 @@ end
 
 function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::AbstractArray)
   fy = zero(R)
-  for i in eachindex(x)
+  @inbounds @simd for i in eachindex(x)
     gl = gamma[i]*f.lambda[i]
     y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
   end
@@ -108,7 +108,7 @@ end
 
 function prox!{A <: AbstractArray, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::AbstractArray)
   fy = zero(R)
-  for i in eachindex(x)
+  @inbounds @simd for i in eachindex(x)
     gl = gamma[i]*f.lambda[i]
     y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
   end
@@ -117,7 +117,7 @@ end
 
 function prox!{T <: Real, R <: Real}(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::AbstractArray)
   n1y = zero(R)
-  for i in eachindex(x)
+  @inbounds @simd for i in eachindex(x)
     gl = gamma[i]*f.lambda
     y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
     n1y += y[i] > 0 ? y[i] : -y[i]
@@ -127,7 +127,7 @@ end
 
 function prox!{T <: Real, R <: Real}(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::AbstractArray)
   n1y = zero(R)
-  for i in eachindex(x)
+  @inbounds @simd for i in eachindex(x)
     gl = gamma[i]*f.lambda
     y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
     n1y += abs(y[i])


### PR DESCRIPTION
A simple benchmark with `julia -O 3` shows almost double performance in some cases

Example, `prox2!` is the updated prox function with `@simd` added. Run on julia v0.6.2
```julia
using ProximalOperators
using BenchmarkTools

function prox2!{T <: Real, R <: Real}(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::Real=1.0)
  n1y = zero(R)
  gl = gamma*f.lambda
  @inbounds @simd for i in eachindex(x)
    y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
    n1y += y[i] > 0 ? y[i] : -y[i]
  end
  return f.lambda*n1y
end


f = NormL1(1.0)
x = randn(1_000_000);
y = similar(x);

julia> @benchmark prox!($y,$f,$x)

BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     2.866 ms (0.00% GC)
  median time:      2.897 ms (0.00% GC)
  mean time:        2.984 ms (0.00% GC)
  maximum time:     5.647 ms (0.00% GC)
  --------------
  samples:          1671
  evals/sample:     1

julia> @benchmark prox2!($y,$f,$x)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.456 ms (0.00% GC)
  median time:      1.479 ms (0.00% GC)
  mean time:        1.553 ms (0.00% GC)
  maximum time:     5.520 ms (0.00% GC)
  --------------
  samples:          3206
  evals/sample:     1
```