### PR TITLE
Cubic L2 norm, typing fixes, tests cleanup

### DIFF
--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -55,6 +55,7 @@ IndZero
 ## Norms and regularization functions
 
 ```@docs
+CubeNormL2
 ElasticNet
 NormL0
 NormL1

--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -34,6 +34,7 @@ include("utilities/normdiff.jl")
 
 # Basic functions
 
+include("functions/cubeNormL2.jl")
 include("functions/elasticNet.jl")
 include("functions/huberLoss.jl")
 include("functions/indAffine.jl")

--- a/src/calculus/conjugate.jl
+++ b/src/calculus/conjugate.jl
@@ -39,36 +39,32 @@ Conjugate(f::T) where {T <: ProximableFunction} = Conjugate{T}(f)
 
 function prox!(y::AbstractArray{R}, g::Conjugate, x::AbstractArray{R}, gamma::R=one(R)) where R <: Real
   # Moreau identity
-  v = prox!(y, g.f, x/gamma, one(R)/gamma)
+  v = prox!(y, g.f, x/gamma, 1/gamma)
   if is_set(g)
     v = zero(R)
   else
-    v = dot(x,y) - gamma*dot(y,y) - v
+    v = dot(x, y) - gamma * dot(y, y) - v
   end
-  for k in eachindex(y)
-    y[k] = x[k] - gamma*y[k]
-  end
+  y .= x .- gamma .* y
   return v
 end
 
 # complex case, need to cast inner products to real
 
 function prox!(y::AbstractArray{Complex{T}}, g::Conjugate, x::AbstractArray{Complex{T}}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  v = prox!(y, g.f, x/gamma, one(R)/gamma)
+  v = prox!(y, g.f, x/gamma, 1/gamma)
   if is_set(g)
     v = zero(R)
   else
-    v = real(dot(x,y)) - gamma*real(dot(y,y)) - v
+    v = real(dot(x, y)) - gamma * real(dot(y, y)) - v
   end
-  for k in eachindex(y)
-    y[k] = x[k] - gamma*y[k]
-  end
+  y .= x .- gamma .* y
   return v
 end
 
 # naive implementation
 
-function prox_naive(g::Conjugate, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-  y, v = prox_naive(g.f, x/gamma, 1.0/gamma)
-  return x - gamma*y, real(dot(x,y)) - gamma*real(dot(y,y)) - v
+function prox_naive(g::Conjugate, x::AbstractArray{T}, gamma=one(R)) where {R, T <: RealOrComplex{R}}
+  y, v = prox_naive(g.f, x/gamma, 1/gamma)
+  return x - gamma * y, real(dot(x, y)) - gamma * real(dot(y, y)) - v
 end

--- a/src/functions/cubeNormL2.jl
+++ b/src/functions/cubeNormL2.jl
@@ -40,12 +40,12 @@ end
 
 function prox!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R, T <: RealOrComplex{R}}
     norm_x = norm(x)
-    scale = 2 / (1 + sqrt(1 + 12 * f.lambda * norm_x))
+    scale = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm_x))
     y .= scale .* x
     return f.lambda * (scale * norm_x)^3
 end
 
 function prox_naive(f::CubeNormL2{R}, x::AbstractArray{T}, gamma=one(R)) where {R, T <: RealOrComplex{R}}
-  y = 2 / (1 + sqrt(1 + 12 * f.lambda * norm(x))) * x
+  y = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm(x))) * x
   return y, f.lambda * norm(y)^3
 end

--- a/src/functions/cubeNormL2.jl
+++ b/src/functions/cubeNormL2.jl
@@ -1,0 +1,51 @@
+# cubic L2 norm (times a constant
+
+export CubeNormL2
+
+"""
+**Cubic Euclidean norm (weighted)**
+
+    CubeNormL2(λ=1.0)
+
+With a nonnegative scalar `λ`, returns the function
+```math
+f(x) = λ\\|x\\|^3.
+```
+"""
+struct CubeNormL2{R <: Real} <: ProximableFunction
+    lambda::R
+    function CubeNormL2{R}(lambda::R) where R
+        if lambda < 0
+            error("coefficient λ must be nonnegative")
+        else
+            new(lambda)
+        end
+    end
+end
+
+is_convex(f::CubeNormL2) = true
+is_smooth(f::CubeNormL2) = true
+
+CubeNormL2(lambda::R=1.0) where {R <: Real} = CubeNormL2{R}(lambda)
+
+function (f::CubeNormL2{R})(x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
+    return f.lambda * norm(x)^3
+end
+
+function gradient!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
+    norm_x = norm(x)
+    y .= (3 * f.lambda * norm_x) .* x
+    return f.lambda * norm_x^3
+end
+
+function prox!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R, T <: RealOrComplex{R}}
+    norm_x = norm(x)
+    scale = 2 / (1 + sqrt(1 + 12 * f.lambda * norm_x))
+    y .= scale .* x
+    return f.lambda * (scale * norm_x)^3
+end
+
+function prox_naive(f::CubeNormL2{R}, x::AbstractArray{T}, gamma=one(R)) where {R, T <: RealOrComplex{R}}
+  y = 2 / (1 + sqrt(1 + 12 * f.lambda * norm(x))) * x
+  return y, f.lambda * norm(y)^3
+end

--- a/src/functions/indBallL0.jl
+++ b/src/functions/indBallL0.jl
@@ -28,14 +28,14 @@ is_set(f::IndBallL0) = true
 
 IndBallL0(r::I) where {I <: Integer} = IndBallL0{I}(r)
 
-function (f::IndBallL0)(x::AbstractArray{T}) where T <: RealOrComplex
+function (f::IndBallL0)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
   if count(!isequal(0), x) > f.r
-    return +Inf
+    return R(Inf)
   end
-  return zero(T)
+  return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndBallL0, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
+function prox!(y::AbstractArray{T}, f::IndBallL0, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
   p = []
   if ndims(x) == 1
     p = partialsortperm(x, 1:f.r, by=abs, rev=true)
@@ -45,12 +45,12 @@ function prox!(y::AbstractArray{T}, f::IndBallL0, x::AbstractArray{T}, gamma::Re
   sort!(p)
   idx = 1
   for i = 1:length(p)
-    y[idx:p[i]-1] .= zero(T)
+    y[idx:p[i]-1] .= T(0)
     y[p[i]] = x[p[i]]
     idx = p[i]+1
   end
-  y[idx:end] .= zero(T)
-  return zero(T)
+  y[idx:end] .= T(0)
+  return R(0)
 end
 
 fun_name(f::IndBallL0) = "indicator of an L0 pseudo-norm ball"

--- a/src/functions/indBallL1.jl
+++ b/src/functions/indBallL1.jl
@@ -29,23 +29,23 @@ is_set(f::IndBallL1) = true
 
 IndBallL1(r::R=1.0) where {R <: Real} = IndBallL1{R}(r)
 
-function (f::IndBallL1)(x::AbstractArray{T}) where T <: RealOrComplex
-  if norm(x,1) - f.r > 1e-12
-    return +Inf
+function (f::IndBallL1)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
+  if norm(x, 1) - f.r > 1e-12
+    return R(Inf)
   end
-  return zero(T)
+  return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R<: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
   # TODO: a faster algorithm
-  if norm(x,1) - f.r < 1e-14
+  if norm(x, 1) - f.r < 1e-14
     y .= x
-    return zero(T)
+    return R(0)
   else # do a projection of abs(x) onto simplex then recover signs
     n = length(x)
     p = abs.(view(x,:))
     sort!(p, rev=true)
-    s = zero(R)
+    s = R(0)
     @inbounds for i = 1:n-1
       s = s + p[i]
       tmax = (s - f.r)/i
@@ -53,14 +53,14 @@ function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=
         @inbounds for j in eachindex(x)
           y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
         end
-        return zero(T)
+        return R(0)
       end
     end
     tmax = (s + p[n] - f.r)/n
     @inbounds for j in eachindex(x)
       y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
     end
-    return zero(T)
+    return R(0)
   end
 end
 

--- a/src/functions/indHyperslab.jl
+++ b/src/functions/indHyperslab.jl
@@ -61,10 +61,10 @@ end
 function prox_naive(f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
   s = dot(f.a, x)
   if s < f.low && f.norm_a > 0
-    return x - ((s - f.low)/norm(f.a)^2) * f.a, 0
+    return x - ((s - f.low)/norm(f.a)^2) * f.a, R(0)
   elseif s > f.upp && f.norm_a > 0
-    return x - ((s - f.upp)/norm(f.a)^2) * f.a, 0
+    return x - ((s - f.upp)/norm(f.a)^2) * f.a, R(0)
   else
-    return x, 0
+    return x, R(0)
   end
 end

--- a/src/functions/sqrNormL2.jl
+++ b/src/functions/sqrNormL2.jl
@@ -49,7 +49,7 @@ function (f::SqrNormL2{S})(x::AbstractArray{T}) where {S <: AbstractArray, T <: 
   return 0.5*sqnorm
 end
 
-function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::Real=1.0) where {S <: Real, T <: RealOrComplex}
+function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: Real, T <: RealOrComplex}
   sqnx = 0.0
   for k in eachindex(x)
     y[k] = f.lambda*x[k]
@@ -58,7 +58,7 @@ function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, ga
   return (f.lambda/2)*sqnx
 end
 
-function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::Real=1.0) where {S <: AbstractArray, T <: RealOrComplex}
+function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: AbstractArray, T <: RealOrComplex}
   sqnx = 0.0
   for k in eachindex(x)
     y[k] = f.lambda[k]*x[k]

--- a/test/test_cubeNormL2.jl
+++ b/test/test_cubeNormL2.jl
@@ -14,7 +14,10 @@ for R in [Float16, Float32, Float64]
             predicates_test(f)
             x = randn(T, shape)
             call_test(f, x)
-            prox_test(f, x, R(0.5)+rand(R))
+            gamma = R(0.5)+rand(R)
+            y, f_y = prox_test(f, x, gamma)
+            grad_f_y, f_y = gradient(f, y)
+            @test grad_f_y ≈ x - y
         end
     end
 end

--- a/test/test_cubeNormL2.jl
+++ b/test/test_cubeNormL2.jl
@@ -1,0 +1,22 @@
+using Test
+using Random
+using ProximalOperators
+
+Random.seed!(0)
+
+@testset "CubeNormL2" begin
+
+for R in [Float16, Float32, Float64]
+    for T in [R, Complex{R}]
+        for shape in [(5,), (3, 5), (3, 4, 5)]
+            lambda = R(0.1) + 5*rand(R)
+            f = CubeNormL2(lambda)
+            predicates_test(f)
+            x = randn(T, shape)
+            call_test(f, x)
+            prox_test(f, x, R(0.5)+rand(R))
+        end
+    end
+end
+
+end

--- a/test/test_cubeNormL2.jl
+++ b/test/test_cubeNormL2.jl
@@ -17,7 +17,7 @@ for R in [Float16, Float32, Float64]
             gamma = R(0.5)+rand(R)
             y, f_y = prox_test(f, x, gamma)
             grad_f_y, f_y = gradient(f, y)
-            @test grad_f_y ≈ x - y
+            @test grad_f_y ≈ (x - y)/gamma
         end
     end
 end

--- a/test/test_graph.jl
+++ b/test/test_graph.jl
@@ -100,15 +100,15 @@ for i = 1:length(stuff)
 
 ##### test calls to prox! with more signatures
     prox!(ax, ay, f, c, d)
-    @test f(ax, ay) <= TOL_ASSERT
+    @test f(ax, ay) ≈ 0
     ax_naive, ay_naive, fv_naive = ProximalOperators.prox_naive(f, c, d, 1.0)
-    @test f(ax_naive, ay_naive) <= TOL_ASSERT
+    @test f(ax_naive, ay_naive) ≈ 0
 
 
     prox!((ax, ay), f, (c, d))
-    @test f((ax, ay)) <= TOL_ASSERT
+    @test f((ax, ay)) ≈ 0
     axy_naive, fv_naive = ProximalOperators.prox_naive(f, (c, d))
-    @test f(axy_naive) <= TOL_ASSERT
+    @test f(axy_naive) ≈ 0
 
 ##### test against IndAffine
     test_against_IndAffine(f, params[1], x)

--- a/test/test_precompose.jl
+++ b/test/test_precompose.jl
@@ -1,5 +1,8 @@
 using LinearAlgebra
 
+@testset "Precompose" begin
+
+@testset "IndBallL1 w/ OM" begin
 # Indicator of L1 norm ball composed with orthogonal matrix
 
 f = IndBallL1()
@@ -39,6 +42,9 @@ x = randn(500)
 call_test(g, x)
 prox_test(g, x, 1.0)
 
+end
+
+@testset "IndBallL1 w/ OM multiple" begin
 # L1 norm composed with multiple of orthogonal matrix
 
 f = NormL1()
@@ -56,6 +62,9 @@ x = randn(50)
 call_test(g, x)
 prox_test(g, x, 1.0)
 
+end
+
+@testset "NormL2 w/ OM multiple" begin
 # L2 norm composed with multiple of orthogonal matrix
 
 f = NormL2()
@@ -73,6 +82,9 @@ x = randn(500)
 call_test(g, x)
 prox_test(g, x, 1.0)
 
+end
+
+@testset "NormL2 w/ OM + translation" begin
 # L2 norm composed with orthogonal matrix + translation
 
 f = NormL2()
@@ -91,6 +103,9 @@ x = randn(500)
 call_test(g, x)
 prox_test(g, x, 1.0)
 
+end
+
+@testset "NormL2 w/ DM + translation" begin
 # L2 norm composed with diagonal matrix + translation
 # checking that Precompose and PrecomposeDiagonal agree
 
@@ -112,6 +127,9 @@ y2, gy2 = prox_test(g2, x, 1.0)
 @test abs(gy1 - gy2) <= (1 + abs(gy1))*1e-12
 @test norm(y1 - y2) <= (1 + norm(y1))*1e-12
 
+end
+
+@testset "SqrNormL2 w/ DM + translation" begin
 # Squared L2 norm composed with diagonal matrix + translation
 # checking that Precompose and PrecomposeDiagonal agree
 # checking that weighted squared L2 norm + Translate agrees too
@@ -158,6 +176,9 @@ y3, gy3 = prox_test(g3, x, 1.0)
 @test abs(gy2 - gy3) <= (1 + abs(gy2))*1e-12
 @test norm(y2 - y3) <= (1 + norm(y2))*1e-12
 
+end
+
+@testset "IndSOC w/ [I, I, I]" begin
 # IndSOC composed with [I, I, I]
 
 f = IndSOC()
@@ -177,6 +198,9 @@ x = [0.1, 0.2, 0.4, 0.2, 0.3, 0.3, 0.3, 0.4, 0.2]
 call_test(g, x)
 y, gy = prox_test(g, x, 1.0)
 
+end
+
+@testset "ElasticNet w/ [DM, DM, DM]" begin
 # ElasticNet composed with [diag, diag, diag]
 
 f = ElasticNet()
@@ -190,3 +214,7 @@ x = randn(3*n)
 
 call_test(g, x)
 y, gy = prox_test(g, x, 1.0)
+
+end
+
+end

--- a/test/test_regularize.jl
+++ b/test/test_regularize.jl
@@ -1,3 +1,6 @@
+using ProximalOperators
+using LinearAlgebra
+
 # Nonsmooth + regularization
 
 mu, lam = 2.0, 3.0


### PR DESCRIPTION
Partially addresses #58 by adding cube Euclidean norm and tests for it, cleans some of the existing functions (in the typing and type parameters mostly), improves some of the existing tests.