### PR TITLE
Bumping Julia requirement (bye bye 0.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
   - nightly
 matrix:
   allow_failures:
-  - julia: 1.0
   - julia: nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,22 @@
+name = "ProximalOperators"
+uuid = "a725b495-10eb-56fe-b38b-717eba820537"
+
+[deps]
+IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OSQP = "ab2f91bb-94b4-55e3-9ba0-7f65df51de79"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+TSVD = "9449cd9e-2762-5aa3-a617-5413e99d722e"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]
+
+[compat]
+julia = "1.0.0"
+IterativeSolvers = "0.8.0"
+OSQP = "0.1.4"
+TSVD = "0.3.0"

--- a/Project.toml
+++ b/Project.toml
@@ -9,14 +9,15 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 TSVD = "9449cd9e-2762-5aa3-a617-5413e99d722e"
 
+[compat]
+IterativeSolvers = "0.8.0"
+OSQP = "0.3.0"
+TSVD = "0.3.0"
+julia = "1.0.0"
+
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
-
-[compat]
-julia = "1.0.0"
-IterativeSolvers = "0.8.0"
-OSQP = "0.1.4"
-TSVD = "0.3.0"
+test = ["Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ TSVD = "9449cd9e-2762-5aa3-a617-5413e99d722e"
 
 [compat]
 IterativeSolvers = "0.8.0"
-OSQP = "0.3.0"
+OSQP = "0.3.0, 0.4.0, 0.5.0"
 TSVD = "0.3.0"
 julia = "1.0.0"
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7
-IterativeSolvers 0.8.0
-TSVD 0.3.0
-OSQP 0.1.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1
   - julia_version: nightly
 
@@ -10,7 +9,6 @@ platform:
 
 matrix:
   allow_failures:
-  - julia_version: 1
   - julia_version: nightly
 
 branches:

--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -12,13 +12,7 @@ const ArrayOrTuple{R} = Union{
 }
 
 export ProximableFunction
-export prox, prox!, gradient!
-
-if VERSION > v"0.7"
-	export gradient
-else
-	import Base: gradient
-end
+export prox, prox!, gradient, gradient!
 
 abstract type ProximableFunction end
 


### PR DESCRIPTION
While [bumping the required version of IterativeSolvers](https://github.com/kul-forbes/ProximalOperators.jl/commit/4462acafe0311e4fe4a5cba764a10b5c8598aa13) to solve #64, I realized that they moved to requiring Julia 1.0. I guess it makes sense to start doing that move here too.

In addition:
* Added Project.toml (removed REQUIRE)
* Updated Travis and AppVeyor config files
