### PR TITLE
Fixing types and indentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ matrix:
 notifications:
   email: false
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("ProximalOperators")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
   - julia -e 'using Pkg; cd(Pkg.dir("ProximalOperators")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
   - julia -e 'using Pkg; Pkg.add("Documenter"); cd(Pkg.dir("ProximalOperators")); include(joinpath("docs", "make.jl"))'

--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -6,9 +6,10 @@ using LinearAlgebra
 
 const RealOrComplex{R <: Real} = Union{R, Complex{R}}
 const HermOrSym{T, S} = Union{Hermitian{T, S}, Symmetric{T, S}}
+const TupleOfArrays{R} = Tuple{Vararg{AbstractArray{C, N} where {C <: RealOrComplex{R}, N}}}
 const ArrayOrTuple{R} = Union{
 	AbstractArray{C, N} where {C <: RealOrComplex{R}, N},
-	Tuple{Vararg{AbstractArray{C, N} where {C <: RealOrComplex{R}, N}}}
+	TupleOfArrays{R}
 }
 
 export ProximableFunction

--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -8,8 +8,8 @@ const RealOrComplex{R <: Real} = Union{R, Complex{R}}
 const HermOrSym{T, S} = Union{Hermitian{T, S}, Symmetric{T, S}}
 const TupleOfArrays{R} = Tuple{Vararg{AbstractArray{C, N} where {C <: RealOrComplex{R}, N}}}
 const ArrayOrTuple{R} = Union{
-	AbstractArray{C, N} where {C <: RealOrComplex{R}, N},
-	TupleOfArrays{R}
+    AbstractArray{C, N} where {C <: RealOrComplex{R}, N},
+    TupleOfArrays{R}
 }
 
 export ProximableFunction
@@ -91,10 +91,10 @@ include("functions/normLinf.jl")
 include("functions/sumLargest.jl")
 
 function Base.show(io::IO, f::ProximableFunction)
-	println(io, "description : ", fun_name(f))
-	println(io, "domain      : ", fun_dom(f))
-	println(io, "expression  : ", fun_expr(f))
-	print(  io, "parameters  : ", fun_params(f))
+    println(io, "description : ", fun_name(f))
+    println(io, "domain      : ", fun_dom(f))
+    println(io, "expression  : ", fun_expr(f))
+    print(  io, "parameters  : ", fun_params(f))
 end
 
 fun_name(  f) = "n/a"
@@ -117,7 +117,7 @@ is_strongly_convex(f::ProximableFunction) = false
 """
 **Proximal mapping**
 
-	y, fy = prox(f, x, γ=1.0)
+    y, fy = prox(f, x, γ=1.0)
 
 Computes
 ```math
@@ -128,15 +128,15 @@ Return values:
 * `fy`: the value ``f(y)``
 """
 function prox(f::ProximableFunction, x::ArrayOrTuple{R}, gamma=R(1)) where R
-	y = similar(x)
-	fy = prox!(y, f, x, gamma)
-	return y, fy
+    y = similar(x)
+    fy = prox!(y, f, x, gamma)
+    return y, fy
 end
 
 """
 **Proximal mapping (in-place)**
 
-	fy = prox!(y, f, x, γ=1.0)
+    fy = prox!(y, f, x, γ=1.0)
 
 Computes
 ```math
@@ -154,7 +154,7 @@ prox!
 """
 **Gradient mapping**
 
-	gradfx, fx = gradient(f, x)
+    gradfx, fx = gradient(f, x)
 
 Computes the gradient (and value) of ``f`` at ``x``. If ``f`` is only *subdifferentiable* at ``x``, then return a subgradient instead.
 
@@ -163,15 +163,15 @@ Return values:
 * `fx`: the value ``f(x)``
 """
 function gradient(f::ProximableFunction, x)
-	y = similar(x)
-	fx = gradient!(y, f, x)
-	return y, fx
+    y = similar(x)
+    fx = gradient!(y, f, x)
+    return y, fx
 end
 
 """
 **Gradient mapping (in-place)**
 
-	gradient!(gradfx, f, x)
+    gradient!(gradfx, f, x)
 
 Writes ``\\nabla f(x)`` to `gradfx`, which must be pre-allocated and have the same shape/size as `x`. If ``f`` is only *subdifferentiable* at ``x``, then writes a subgradient instead.
 

--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -127,7 +127,7 @@ Return values:
 * `y`: the proximal point ``y``
 * `fy`: the value ``f(y)``
 """
-function prox(f::ProximableFunction, x::ArrayOrTuple{R}, gamma=one(R)) where R
+function prox(f::ProximableFunction, x::ArrayOrTuple{R}, gamma=R(1)) where R
 	y = similar(x)
 	fy = prox!(y, f, x, gamma)
 	return y, fy
@@ -149,7 +149,7 @@ Return values:
 """
 prox!
 # TODO: should we put the following here instead? And remove the default value for gamma in each subtype
-# prox!(y::ArrayOrTuple{R}, f::ProximableFunction, x::ArrayOrTuple{R}) = prox!(y, f, x, one(R))
+# prox!(y::ArrayOrTuple{R}, f::ProximableFunction, x::ArrayOrTuple{R}) = prox!(y, f, x, R(1))
 
 """
 **Gradient mapping**

--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -90,10 +90,10 @@ include("functions/normLinf.jl")
 include("functions/sumLargest.jl")
 
 function Base.show(io::IO, f::ProximableFunction)
-  println(io, "description : ", fun_name(f))
-  println(io, "domain      : ", fun_dom(f))
-  println(io, "expression  : ", fun_expr(f))
-  print(  io, "parameters  : ", fun_params(f))
+	println(io, "description : ", fun_name(f))
+	println(io, "domain      : ", fun_dom(f))
+	println(io, "expression  : ", fun_expr(f))
+	print(  io, "parameters  : ", fun_params(f))
 end
 
 fun_name(  f) = "n/a"
@@ -116,7 +116,7 @@ is_strongly_convex(f::ProximableFunction) = false
 """
 **Proximal mapping**
 
-    y, fy = prox(f, x, γ=1.0)
+	y, fy = prox(f, x, γ=1.0)
 
 Computes
 ```math
@@ -127,15 +127,15 @@ Return values:
 * `fy`: the value ``f(y)``
 """
 function prox(f::ProximableFunction, x::ArrayOrTuple{R}, gamma=one(R)) where R
-  y = similar(x)
-  fy = prox!(y, f, x, gamma)
-  return y, fy
+	y = similar(x)
+	fy = prox!(y, f, x, gamma)
+	return y, fy
 end
 
 """
 **Proximal mapping (in-place)**
 
-    fy = prox!(y, f, x, γ=1.0)
+	fy = prox!(y, f, x, γ=1.0)
 
 Computes
 ```math
@@ -153,7 +153,7 @@ prox!
 """
 **Gradient mapping**
 
-    gradfx, fx = gradient(f, x)
+	gradfx, fx = gradient(f, x)
 
 Computes the gradient (and value) of ``f`` at ``x``. If ``f`` is only *subdifferentiable* at ``x``, then return a subgradient instead.
 
@@ -170,7 +170,7 @@ end
 """
 **Gradient mapping (in-place)**
 
-    gradient!(gradfx, f, x)
+	gradient!(gradfx, f, x)
 
 Writes ``\\nabla f(x)`` to `gradfx`, which must be pre-allocated and have the same shape/size as `x`. If ``f`` is only *subdifferentiable* at ``x``, then writes a subgradient instead.
 

--- a/src/calculus/conjugate.jl
+++ b/src/calculus/conjugate.jl
@@ -5,7 +5,7 @@ export Conjugate
 """
 **Convex conjugate**
 
-	Conjugate(f)
+    Conjugate(f)
 
 Returns the convex conjugate (also known as Fenchel conjugate, or Fenchel-Legendre transform) of function `f`, that is
 ```math
@@ -13,13 +13,13 @@ f^*(x) = \\sup_y \\{ \\langle y, x \\rangle - f(y) \\}.
 ```
 """
 struct Conjugate{T <: ProximableFunction} <: ProximableFunction
-	f::T
-	function Conjugate{T}(f::T) where {T<: ProximableFunction}
-		if is_convex(f) == false
-			error("`f` must be convex")
-		end
-		new(f)
-	end
+    f::T
+    function Conjugate{T}(f::T) where {T<: ProximableFunction}
+        if is_convex(f) == false
+            error("`f` must be convex")
+        end
+        new(f)
+    end
 end
 
 is_prox_accurate(f::Conjugate) = is_prox_accurate(f.f)
@@ -38,33 +38,33 @@ Conjugate(f::T) where {T <: ProximableFunction} = Conjugate{T}(f)
 # an element of the subdifferential of the conjugate
 
 function prox!(y::AbstractArray{R}, g::Conjugate, x::AbstractArray{R}, gamma::R=R(1)) where R <: Real
-	# Moreau identity
-	v = prox!(y, g.f, x/gamma, 1/gamma)
-	if is_set(g)
-		v = R(0)
-	else
-		v = dot(x, y) - gamma * dot(y, y) - v
-	end
-	y .= x .- gamma .* y
-	return v
+    # Moreau identity
+    v = prox!(y, g.f, x/gamma, 1/gamma)
+    if is_set(g)
+        v = R(0)
+    else
+        v = dot(x, y) - gamma * dot(y, y) - v
+    end
+    y .= x .- gamma .* y
+    return v
 end
 
 # complex case, need to cast inner products to real
 
 function prox!(y::AbstractArray{Complex{T}}, g::Conjugate, x::AbstractArray{Complex{T}}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	v = prox!(y, g.f, x/gamma, 1/gamma)
-	if is_set(g)
-		v = R(0)
-	else
-		v = real(dot(x, y)) - gamma * real(dot(y, y)) - v
-	end
-	y .= x .- gamma .* y
-	return v
+    v = prox!(y, g.f, x/gamma, 1/gamma)
+    if is_set(g)
+        v = R(0)
+    else
+        v = real(dot(x, y)) - gamma * real(dot(y, y)) - v
+    end
+    y .= x .- gamma .* y
+    return v
 end
 
 # naive implementation
 
 function prox_naive(g::Conjugate, x::AbstractArray{T}, gamma=R(1)) where {R, T <: RealOrComplex{R}}
-	y, v = prox_naive(g.f, x/gamma, 1/gamma)
-	return x - gamma * y, real(dot(x, y)) - gamma * real(dot(y, y)) - v
+    y, v = prox_naive(g.f, x/gamma, 1/gamma)
+    return x - gamma * y, real(dot(x, y)) - gamma * real(dot(y, y)) - v
 end

--- a/src/calculus/conjugate.jl
+++ b/src/calculus/conjugate.jl
@@ -5,7 +5,7 @@ export Conjugate
 """
 **Convex conjugate**
 
-    Conjugate(f)
+	Conjugate(f)
 
 Returns the convex conjugate (also known as Fenchel conjugate, or Fenchel-Legendre transform) of function `f`, that is
 ```math
@@ -13,13 +13,13 @@ f^*(x) = \\sup_y \\{ \\langle y, x \\rangle - f(y) \\}.
 ```
 """
 struct Conjugate{T <: ProximableFunction} <: ProximableFunction
-  f::T
-  function Conjugate{T}(f::T) where {T<: ProximableFunction}
-    if is_convex(f) == false
-      error("`f` must be convex")
-    end
-    new(f)
-  end
+	f::T
+	function Conjugate{T}(f::T) where {T<: ProximableFunction}
+		if is_convex(f) == false
+			error("`f` must be convex")
+		end
+		new(f)
+	end
 end
 
 is_prox_accurate(f::Conjugate) = is_prox_accurate(f.f)
@@ -38,33 +38,33 @@ Conjugate(f::T) where {T <: ProximableFunction} = Conjugate{T}(f)
 # an element of the subdifferential of the conjugate
 
 function prox!(y::AbstractArray{R}, g::Conjugate, x::AbstractArray{R}, gamma::R=one(R)) where R <: Real
-  # Moreau identity
-  v = prox!(y, g.f, x/gamma, 1/gamma)
-  if is_set(g)
-    v = zero(R)
-  else
-    v = dot(x, y) - gamma * dot(y, y) - v
-  end
-  y .= x .- gamma .* y
-  return v
+	# Moreau identity
+	v = prox!(y, g.f, x/gamma, 1/gamma)
+	if is_set(g)
+		v = zero(R)
+	else
+		v = dot(x, y) - gamma * dot(y, y) - v
+	end
+	y .= x .- gamma .* y
+	return v
 end
 
 # complex case, need to cast inner products to real
 
 function prox!(y::AbstractArray{Complex{T}}, g::Conjugate, x::AbstractArray{Complex{T}}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  v = prox!(y, g.f, x/gamma, 1/gamma)
-  if is_set(g)
-    v = zero(R)
-  else
-    v = real(dot(x, y)) - gamma * real(dot(y, y)) - v
-  end
-  y .= x .- gamma .* y
-  return v
+	v = prox!(y, g.f, x/gamma, 1/gamma)
+	if is_set(g)
+		v = zero(R)
+	else
+		v = real(dot(x, y)) - gamma * real(dot(y, y)) - v
+	end
+	y .= x .- gamma .* y
+	return v
 end
 
 # naive implementation
 
 function prox_naive(g::Conjugate, x::AbstractArray{T}, gamma=one(R)) where {R, T <: RealOrComplex{R}}
-  y, v = prox_naive(g.f, x/gamma, 1/gamma)
-  return x - gamma * y, real(dot(x, y)) - gamma * real(dot(y, y)) - v
+	y, v = prox_naive(g.f, x/gamma, 1/gamma)
+	return x - gamma * y, real(dot(x, y)) - gamma * real(dot(y, y)) - v
 end

--- a/src/calculus/conjugate.jl
+++ b/src/calculus/conjugate.jl
@@ -37,11 +37,11 @@ Conjugate(f::T) where {T <: ProximableFunction} = Conjugate{T}(f)
 # only prox! is provided here, call method would require being able to compute
 # an element of the subdifferential of the conjugate
 
-function prox!(y::AbstractArray{R}, g::Conjugate, x::AbstractArray{R}, gamma::R=one(R)) where R <: Real
+function prox!(y::AbstractArray{R}, g::Conjugate, x::AbstractArray{R}, gamma::R=R(1)) where R <: Real
 	# Moreau identity
 	v = prox!(y, g.f, x/gamma, 1/gamma)
 	if is_set(g)
-		v = zero(R)
+		v = R(0)
 	else
 		v = dot(x, y) - gamma * dot(y, y) - v
 	end
@@ -51,10 +51,10 @@ end
 
 # complex case, need to cast inner products to real
 
-function prox!(y::AbstractArray{Complex{T}}, g::Conjugate, x::AbstractArray{Complex{T}}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{Complex{T}}, g::Conjugate, x::AbstractArray{Complex{T}}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	v = prox!(y, g.f, x/gamma, 1/gamma)
 	if is_set(g)
-		v = zero(R)
+		v = R(0)
 	else
 		v = real(dot(x, y)) - gamma * real(dot(y, y)) - v
 	end
@@ -64,7 +64,7 @@ end
 
 # naive implementation
 
-function prox_naive(g::Conjugate, x::AbstractArray{T}, gamma=one(R)) where {R, T <: RealOrComplex{R}}
+function prox_naive(g::Conjugate, x::AbstractArray{T}, gamma=R(1)) where {R, T <: RealOrComplex{R}}
 	y, v = prox_naive(g.f, x/gamma, 1/gamma)
 	return x - gamma * y, real(dot(x, y)) - gamma * real(dot(y, y)) - v
 end

--- a/src/calculus/distL2.jl
+++ b/src/calculus/distL2.jl
@@ -5,7 +5,7 @@ export DistL2
 """
 **Distance from a convex set**
 
-	DistL2(ind_S)
+    DistL2(ind_S)
 
 Given `ind_S` the indicator function of a convex set ``S``, and an optional positive parameter `λ`, returns the (weighted) Euclidean distance from ``S``, that is function
 ```math
@@ -13,18 +13,18 @@ g(x) = λ\\mathrm{dist}_S(x) = \\min \\{ λ\\|y - x\\| : y \\in S \\}.
 ```
 """
 struct DistL2{R <: Real, T <: ProximableFunction} <: ProximableFunction
-	ind::T
-	lambda::R
-	function DistL2{R, T}(ind::T, lambda::R) where {R <: Real, T <: ProximableFunction}
-		if !is_set(ind) || !is_convex(ind)
-			error("`ind` must be a convex set")
-		end
-		if lambda < 0
-			error("parameter `λ` must be nonnegative")
-		else
-			new(ind, lambda)
-		end
-	end
+    ind::T
+    lambda::R
+    function DistL2{R, T}(ind::T, lambda::R) where {R <: Real, T <: ProximableFunction}
+        if !is_set(ind) || !is_convex(ind)
+            error("`ind` must be a convex set")
+        end
+        if lambda < 0
+            error("parameter `λ` must be nonnegative")
+        else
+            new(ind, lambda)
+        end
+    end
 end
 
 is_prox_accurate(f::DistL2) = is_prox_accurate(f.ind)
@@ -33,31 +33,31 @@ is_convex(f::DistL2) = is_convex(f.ind)
 DistL2(ind::T, lambda::R=1.0) where {R <: Real, T <: ProximableFunction} = DistL2{R, T}(ind, lambda)
 
 function (f::DistL2)(x::AbstractArray{R}) where R <: RealOrComplex
-	p, = prox(f.ind, x)
-	return f.lambda*normdiff(x,p)
+    p, = prox(f.ind, x)
+    return f.lambda*normdiff(x,p)
 end
 
 function prox!(y::AbstractArray{T}, f::DistL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	prox!(y, f.ind, x)
-	d = normdiff(x,y)
-	gamlam = (gamma*f.lambda)
-	if gamlam < d
-		gamlamd = gamlam/d
-		y .= (1-gamlamd).*x .+ gamlamd.*y
-		return f.lambda*(d-gamlam)
-	end
-	return R(0)
+    prox!(y, f.ind, x)
+    d = normdiff(x,y)
+    gamlam = (gamma*f.lambda)
+    if gamlam < d
+        gamlamd = gamlam/d
+        y .= (1-gamlamd).*x .+ gamlamd.*y
+        return f.lambda*(d-gamlam)
+    end
+    return R(0)
 end
 
 function gradient!(y::AbstractArray{T}, f::DistL2, x::AbstractArray{T}) where T <: RealOrComplex
-	prox!(y, f.ind, x) # Use y as temporary storage
-	dist = normdiff(x,y)
-	if dist > 0
-		y .= (f.lambda/dist).*(x .- y)
-	else
-		y .= 0
-	end
-	return f.lambda*dist
+    prox!(y, f.ind, x) # Use y as temporary storage
+    dist = normdiff(x,y)
+    if dist > 0
+        y .= (f.lambda/dist).*(x .- y)
+    else
+        y .= 0
+    end
+    return f.lambda*dist
 end
 
 fun_name(f::DistL2) = "Euclidean distance from a convex set"
@@ -66,11 +66,11 @@ fun_expr(f::DistL2) = "x ↦ λ inf { ||x-y|| : y ∈ S} "
 fun_params(f::DistL2) = string("λ = $(f.lambda), S = ", typeof(f.ind))
 
 function prox_naive(f::DistL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	p, = prox(f.ind, x)
-	d = norm(x-p)
-	gamlam = gamma*f.lambda
-	if d > gamlam
-		return x + gamlam/d*(p-x), f.lambda*(d-gamlam)
-	end
-	return p, R(0)
+    p, = prox(f.ind, x)
+    d = norm(x-p)
+    gamlam = gamma*f.lambda
+    if d > gamlam
+        return x + gamlam/d*(p-x), f.lambda*(d-gamlam)
+    end
+    return p, R(0)
 end

--- a/src/calculus/distL2.jl
+++ b/src/calculus/distL2.jl
@@ -5,7 +5,7 @@ export DistL2
 """
 **Distance from a convex set**
 
-    DistL2(ind_S)
+	DistL2(ind_S)
 
 Given `ind_S` the indicator function of a convex set ``S``, and an optional positive parameter `λ`, returns the (weighted) Euclidean distance from ``S``, that is function
 ```math
@@ -13,18 +13,18 @@ g(x) = λ\\mathrm{dist}_S(x) = \\min \\{ λ\\|y - x\\| : y \\in S \\}.
 ```
 """
 struct DistL2{R <: Real, T <: ProximableFunction} <: ProximableFunction
-  ind::T
-  lambda::R
-  function DistL2{R, T}(ind::T, lambda::R) where {R <: Real, T <: ProximableFunction}
-    if !is_set(ind) || !is_convex(ind)
-      error("`ind` must be a convex set")
-    end
-    if lambda < 0
-      error("parameter `λ` must be nonnegative")
-    else
-      new(ind, lambda)
-    end
-  end
+	ind::T
+	lambda::R
+	function DistL2{R, T}(ind::T, lambda::R) where {R <: Real, T <: ProximableFunction}
+		if !is_set(ind) || !is_convex(ind)
+			error("`ind` must be a convex set")
+		end
+		if lambda < 0
+			error("parameter `λ` must be nonnegative")
+		else
+			new(ind, lambda)
+		end
+	end
 end
 
 is_prox_accurate(f::DistL2) = is_prox_accurate(f.ind)
@@ -33,31 +33,31 @@ is_convex(f::DistL2) = is_convex(f.ind)
 DistL2(ind::T, lambda::R=1.0) where {R <: Real, T <: ProximableFunction} = DistL2{R, T}(ind, lambda)
 
 function (f::DistL2)(x::AbstractArray{R}) where R <: RealOrComplex
-  p, = prox(f.ind, x)
-  return f.lambda*normdiff(x,p)
+	p, = prox(f.ind, x)
+	return f.lambda*normdiff(x,p)
 end
 
 function prox!(y::AbstractArray{T}, f::DistL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  prox!(y, f.ind, x)
-  d = normdiff(x,y)
-  gamlam = (gamma*f.lambda)
-  if gamlam < d
-    gamlamd = gamlam/d
-    y .= (1-gamlamd).*x .+ gamlamd.*y
-    return f.lambda*(d-gamlam)
-  end
-  return zero(R)
+	prox!(y, f.ind, x)
+	d = normdiff(x,y)
+	gamlam = (gamma*f.lambda)
+	if gamlam < d
+		gamlamd = gamlam/d
+		y .= (1-gamlamd).*x .+ gamlamd.*y
+		return f.lambda*(d-gamlam)
+	end
+	return zero(R)
 end
 
 function gradient!(y::AbstractArray{T}, f::DistL2, x::AbstractArray{T}) where T <: RealOrComplex
-  prox!(y, f.ind, x) # Use y as temporary storage
-  dist = normdiff(x,y)
-  if dist > 0
-    y .= (f.lambda/dist).*(x .- y)
-  else
-    y .= 0
-  end
-  return f.lambda*dist
+	prox!(y, f.ind, x) # Use y as temporary storage
+	dist = normdiff(x,y)
+	if dist > 0
+		y .= (f.lambda/dist).*(x .- y)
+	else
+		y .= 0
+	end
+	return f.lambda*dist
 end
 
 fun_name(f::DistL2) = "Euclidean distance from a convex set"
@@ -66,11 +66,11 @@ fun_expr(f::DistL2) = "x ↦ λ inf { ||x-y|| : y ∈ S} "
 fun_params(f::DistL2) = string("λ = $(f.lambda), S = ", typeof(f.ind))
 
 function prox_naive(f::DistL2, x::AbstractArray{R}, gamma::Real=1.0) where R <: RealOrComplex
-  p, = prox(f.ind, x)
-  d = norm(x-p)
-  gamlam = gamma*f.lambda
-  if d > gamlam
-    return x + gamlam/d*(p-x), f.lambda*(d-gamlam)
-  end
-  return p, 0.0
+	p, = prox(f.ind, x)
+	d = norm(x-p)
+	gamlam = gamma*f.lambda
+	if d > gamlam
+		return x + gamlam/d*(p-x), f.lambda*(d-gamlam)
+	end
+	return p, 0.0
 end

--- a/src/calculus/distL2.jl
+++ b/src/calculus/distL2.jl
@@ -37,7 +37,7 @@ function (f::DistL2)(x::AbstractArray{R}) where R <: RealOrComplex
 	return f.lambda*normdiff(x,p)
 end
 
-function prox!(y::AbstractArray{T}, f::DistL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::DistL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	prox!(y, f.ind, x)
 	d = normdiff(x,y)
 	gamlam = (gamma*f.lambda)
@@ -65,7 +65,7 @@ fun_dom(f::DistL2) = fun_dom(f.ind)
 fun_expr(f::DistL2) = "x ↦ λ inf { ||x-y|| : y ∈ S} "
 fun_params(f::DistL2) = string("λ = $(f.lambda), S = ", typeof(f.ind))
 
-function prox_naive(f::DistL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::DistL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	p, = prox(f.ind, x)
 	d = norm(x-p)
 	gamlam = gamma*f.lambda

--- a/src/calculus/distL2.jl
+++ b/src/calculus/distL2.jl
@@ -46,7 +46,7 @@ function prox!(y::AbstractArray{T}, f::DistL2, x::AbstractArray{T}, gamma::R=one
 		y .= (1-gamlamd).*x .+ gamlamd.*y
 		return f.lambda*(d-gamlam)
 	end
-	return zero(R)
+	return R(0)
 end
 
 function gradient!(y::AbstractArray{T}, f::DistL2, x::AbstractArray{T}) where T <: RealOrComplex
@@ -65,12 +65,12 @@ fun_dom(f::DistL2) = fun_dom(f.ind)
 fun_expr(f::DistL2) = "x ↦ λ inf { ||x-y|| : y ∈ S} "
 fun_params(f::DistL2) = string("λ = $(f.lambda), S = ", typeof(f.ind))
 
-function prox_naive(f::DistL2, x::AbstractArray{R}, gamma::Real=1.0) where R <: RealOrComplex
+function prox_naive(f::DistL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	p, = prox(f.ind, x)
 	d = norm(x-p)
 	gamlam = gamma*f.lambda
 	if d > gamlam
 		return x + gamlam/d*(p-x), f.lambda*(d-gamlam)
 	end
-	return p, 0.0
+	return p, R(0)
 end

--- a/src/calculus/moreauEnvelope.jl
+++ b/src/calculus/moreauEnvelope.jl
@@ -3,7 +3,7 @@ export MoreauEnvelope
 """
 **Moreau envelope**
 
-    MoreauEnvelope(f, γ=1.0)
+	MoreauEnvelope(f, γ=1.0)
 
 Returns the Moreau envelope (also known as Moreau-Yosida regularization) of function `f` with parameter `γ` (positive), that is
 ```math
@@ -14,10 +14,10 @@ If ``f`` is convex, then ``f^γ`` is a smooth, convex, lower approximation to ``
 mutable struct MoreauEnvelope{R <: Real, T <: ProximableFunction} <: ProximableFunction
 	g::T
 	lambda::R
-    function MoreauEnvelope{R, T}(g::T, lambda::R) where {R, T}
-    	if lambda <= 0 error("parameter lambda must be positive") end
-    	new(g, lambda)
-    end
+	function MoreauEnvelope{R, T}(g::T, lambda::R) where {R, T}
+		if lambda <= 0 error("parameter lambda must be positive") end
+		new(g, lambda)
+	end
 end
 
 MoreauEnvelope(g::T, lambda::R=1.0) where {R <: Real, T <: ProximableFunction} = MoreauEnvelope{R, T}(g, lambda)

--- a/src/calculus/moreauEnvelope.jl
+++ b/src/calculus/moreauEnvelope.jl
@@ -3,7 +3,7 @@ export MoreauEnvelope
 """
 **Moreau envelope**
 
-	MoreauEnvelope(f, γ=1.0)
+    MoreauEnvelope(f, γ=1.0)
 
 Returns the Moreau envelope (also known as Moreau-Yosida regularization) of function `f` with parameter `γ` (positive), that is
 ```math
@@ -12,12 +12,12 @@ f^γ(x) = \\min_z \\left\\{ f(z) + \\tfrac{1}{2γ}\\|z-x\\|^2 \\right\\}.
 If ``f`` is convex, then ``f^γ`` is a smooth, convex, lower approximation to ``f``, having the same minima as the original function.
 """
 mutable struct MoreauEnvelope{R <: Real, T <: ProximableFunction} <: ProximableFunction
-	g::T
-	lambda::R
-	function MoreauEnvelope{R, T}(g::T, lambda::R) where {R, T}
-		if lambda <= 0 error("parameter lambda must be positive") end
-		new(g, lambda)
-	end
+    g::T
+    lambda::R
+    function MoreauEnvelope{R, T}(g::T, lambda::R) where {R, T}
+        if lambda <= 0 error("parameter lambda must be positive") end
+        new(g, lambda)
+    end
 end
 
 MoreauEnvelope(g::T, lambda::R=1.0) where {R <: Real, T <: ProximableFunction} = MoreauEnvelope{R, T}(g, lambda)
@@ -28,16 +28,16 @@ is_quadratic(f::MoreauEnvelope) = is_generalized_quadratic(f.g)
 is_strongly_convex(f::MoreauEnvelope) = is_strongly_convex(f.g)
 
 function (f::MoreauEnvelope)(x::AbstractArray)
-	buf = similar(x)
-	g_prox = prox!(buf, f.g, x, f.lambda)
-	return g_prox + 1/(2*f.lambda)*norm(buf .- x)^2
+    buf = similar(x)
+    g_prox = prox!(buf, f.g, x, f.lambda)
+    return g_prox + 1/(2*f.lambda)*norm(buf .- x)^2
 end
 
 function gradient!(grad::AbstractArray, f::MoreauEnvelope, x::AbstractArray)
-	g_prox = prox!(grad, f.g, x, f.lambda)
-	grad .= (x .- grad)./f.lambda
-	fx = g_prox + (f.lambda/2)*norm(grad)^2
-	return fx
+    g_prox = prox!(grad, f.g, x, f.lambda)
+    grad .= (x .- grad)./f.lambda
+    fx = g_prox + (f.lambda/2)*norm(grad)^2
+    return fx
 end
 
 fun_name(f::MoreauEnvelope,i::Int64) =

--- a/src/calculus/postcompose.jl
+++ b/src/calculus/postcompose.jl
@@ -37,9 +37,9 @@ is_quadratic(f::Postcompose) = is_quadratic(f.f)
 is_generalized_quadratic(f::Postcompose) = is_generalized_quadratic(f.f)
 is_strongly_convex(f::Postcompose) = is_strongly_convex(f.f)
 
-Postcompose(f::T, a::R=one(R), b::R=zero(R)) where {T <: ProximableFunction, R <: Real} = Postcompose{T, R}(f, a, b)
+Postcompose(f::T, a::R=R(1), b::R=R(0)) where {T <: ProximableFunction, R <: Real} = Postcompose{T, R}(f, a, b)
 
-Postcompose(f::Postcompose{T, R}, a::R=one(R), b::R=zero(R)) where {T <: ProximableFunction, R <: Real} = Postcompose{T, R}(f.f, a*f.a, b+a*f.b)
+Postcompose(f::Postcompose{T, R}, a::R=R(1), b::R=R(0)) where {T <: ProximableFunction, R <: Real} = Postcompose{T, R}(f.f, a*f.a, b+a*f.b)
 
 function (g::Postcompose)(x::AbstractArray{T}) where T <: RealOrComplex
 	return g.a*g.f(x) + g.b
@@ -51,12 +51,12 @@ function gradient!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}) whe
 	return g.a*v + g.b
 end
 
-function prox!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}, gamma=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	v = prox!(y, g.f, x, g.a*gamma)
 	return g.a*v + g.b
 end
 
-function prox_naive(g::Postcompose, x::AbstractArray{T}, gamma=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(g::Postcompose, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	y, v = prox_naive(g.f, x, g.a*gamma)
 	return y, g.a*v + g.b
 end

--- a/src/calculus/postcompose.jl
+++ b/src/calculus/postcompose.jl
@@ -51,12 +51,12 @@ function gradient!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}) whe
 	return g.a*v + g.b
 end
 
-function prox!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
+function prox!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}, gamma=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	v = prox!(y, g.f, x, g.a*gamma)
 	return g.a*v + g.b
 end
 
-function prox_naive(g::Postcompose, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
+function prox_naive(g::Postcompose, x::AbstractArray{T}, gamma=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	y, v = prox_naive(g.f, x, g.a*gamma)
 	return y, g.a*v + g.b
 end

--- a/src/calculus/postcompose.jl
+++ b/src/calculus/postcompose.jl
@@ -5,7 +5,7 @@ export Postcompose
 """
 **Postcomposition with an affine transformation**
 
-    Postcompose(f, a=1.0, b=0.0)
+	Postcompose(f, a=1.0, b=0.0)
 
 Returns the function
 ```math
@@ -13,16 +13,16 @@ g(x) = a\\cdot f(x) + b.
 ```
 """
 struct Postcompose{T <: ProximableFunction, R <: Real} <: ProximableFunction
-  f::T
-  a::R
-  b::R
-  function Postcompose{T,R}(f::T, a::R, b::R) where {T <: ProximableFunction, R <: Real}
-    if a <= 0.0
-      error("parameter `a` must be positive")
-    else
-      new(f, a, b)
-    end
-  end
+	f::T
+	a::R
+	b::R
+	function Postcompose{T,R}(f::T, a::R, b::R) where {T <: ProximableFunction, R <: Real}
+		if a <= 0.0
+			error("parameter `a` must be positive")
+		else
+			new(f, a, b)
+		end
+	end
 end
 
 is_prox_accurate(f::Postcompose) = is_prox_accurate(f.f)
@@ -42,23 +42,23 @@ Postcompose(f::T, a::R=one(R), b::R=zero(R)) where {T <: ProximableFunction, R <
 Postcompose(f::Postcompose{T, R}, a::R=one(R), b::R=zero(R)) where {T <: ProximableFunction, R <: Real} = Postcompose{T, R}(f.f, a*f.a, b+a*f.b)
 
 function (g::Postcompose)(x::AbstractArray{T}) where T <: RealOrComplex
-  return g.a*g.f(x) + g.b
+	return g.a*g.f(x) + g.b
 end
 
 function gradient!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}) where T <: RealOrComplex
-  v = gradient!(y, g.f, x)
-  y .*= g.a
-  return g.a*v + g.b
+	v = gradient!(y, g.f, x)
+	y .*= g.a
+	return g.a*v + g.b
 end
 
 function prox!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  v = prox!(y, g.f, x, g.a*gamma)
-  return g.a*v + g.b
+	v = prox!(y, g.f, x, g.a*gamma)
+	return g.a*v + g.b
 end
 
 function prox_naive(g::Postcompose, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  y, v = prox_naive(g.f, x, g.a*gamma)
-  return y, g.a*v + g.b
+	y, v = prox_naive(g.f, x, g.a*gamma)
+	return y, g.a*v + g.b
 end
 
 fun_name(f::Postcompose) = string("Postcomposition of ", fun_name(f.f))

--- a/src/calculus/postcompose.jl
+++ b/src/calculus/postcompose.jl
@@ -5,7 +5,7 @@ export Postcompose
 """
 **Postcomposition with an affine transformation**
 
-	Postcompose(f, a=1.0, b=0.0)
+    Postcompose(f, a=1.0, b=0.0)
 
 Returns the function
 ```math
@@ -13,16 +13,16 @@ g(x) = a\\cdot f(x) + b.
 ```
 """
 struct Postcompose{T <: ProximableFunction, R <: Real} <: ProximableFunction
-	f::T
-	a::R
-	b::R
-	function Postcompose{T,R}(f::T, a::R, b::R) where {T <: ProximableFunction, R <: Real}
-		if a <= 0.0
-			error("parameter `a` must be positive")
-		else
-			new(f, a, b)
-		end
-	end
+    f::T
+    a::R
+    b::R
+    function Postcompose{T,R}(f::T, a::R, b::R) where {T <: ProximableFunction, R <: Real}
+        if a <= 0.0
+            error("parameter `a` must be positive")
+        else
+            new(f, a, b)
+        end
+    end
 end
 
 is_prox_accurate(f::Postcompose) = is_prox_accurate(f.f)
@@ -42,23 +42,23 @@ Postcompose(f::T, a::R=R(1), b::R=R(0)) where {T <: ProximableFunction, R <: Rea
 Postcompose(f::Postcompose{T, R}, a::R=R(1), b::R=R(0)) where {T <: ProximableFunction, R <: Real} = Postcompose{T, R}(f.f, a*f.a, b+a*f.b)
 
 function (g::Postcompose)(x::AbstractArray{T}) where T <: RealOrComplex
-	return g.a*g.f(x) + g.b
+    return g.a*g.f(x) + g.b
 end
 
 function gradient!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}) where T <: RealOrComplex
-	v = gradient!(y, g.f, x)
-	y .*= g.a
-	return g.a*v + g.b
+    v = gradient!(y, g.f, x)
+    y .*= g.a
+    return g.a*v + g.b
 end
 
 function prox!(y::AbstractArray{T}, g::Postcompose, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	v = prox!(y, g.f, x, g.a*gamma)
-	return g.a*v + g.b
+    v = prox!(y, g.f, x, g.a*gamma)
+    return g.a*v + g.b
 end
 
 function prox_naive(g::Postcompose, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	y, v = prox_naive(g.f, x, g.a*gamma)
-	return y, g.a*v + g.b
+    y, v = prox_naive(g.f, x, g.a*gamma)
+    return y, g.a*v + g.b
 end
 
 fun_name(f::Postcompose) = string("Postcomposition of ", fun_name(f.f))

--- a/src/calculus/precompose.jl
+++ b/src/calculus/precompose.jl
@@ -5,7 +5,7 @@ export Precompose
 """
 **Precomposition with linear mapping/translation**
 
-    Precompose(f, L, μ, b)
+	Precompose(f, L, μ, b)
 
 Returns the function
 ```math
@@ -18,19 +18,19 @@ Parameter `L` defines ``L`` through the `A_mul_B!` and `Ac_mul_B!` methods. Ther
 In this case, `prox` and `prox!` are computed according to Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd edition, 2016. The same result is Prop. 23.32 in the 1st edition of the same book.
 """
 struct Precompose{T <: ProximableFunction, R <: Real, C <: Union{R, Complex{R}}, U <: Union{C, AbstractArray{C}}, V <: Union{C, AbstractArray{C}}, M} <: ProximableFunction
-  f::T
-  L::M
-  mu::U
-  b::V
-  function Precompose{T, R, C, U, V, M}(f::T, L::M, mu::U, b::V) where {T <: ProximableFunction, R <: Real, C <: Union{R, Complex{R}}, U <: Union{R, AbstractArray{R}}, V <: Union{C, AbstractArray{C}}, M}
-    if !is_convex(f)
-      error("f must be convex")
-    end
-    if any(mu .<= 0.0)
-      error("elements of μ must be positive")
-    end
-    new(f, L, mu, b)
-  end
+	f::T
+	L::M
+	mu::U
+	b::V
+	function Precompose{T, R, C, U, V, M}(f::T, L::M, mu::U, b::V) where {T <: ProximableFunction, R <: Real, C <: Union{R, Complex{R}}, U <: Union{R, AbstractArray{R}}, V <: Union{C, AbstractArray{C}}, M}
+		if !is_convex(f)
+			error("f must be convex")
+		end
+		if any(mu .<= 0.0)
+			error("elements of μ must be positive")
+		end
+		new(f, L, mu, b)
+	end
 end
 
 is_prox_accurate(f::Precompose) = is_prox_accurate(f.f)
@@ -49,40 +49,40 @@ Precompose(f::T, L::M, mu::U, b::V) where {T <: ProximableFunction, R <: Real, C
 Precompose(f::T, L::M, mu::U) where {T <: ProximableFunction, R <: Real, U <: Union{R, AbstractArray{R}}, M} = Precompose{T, R, R, U, R, M}(f, L, mu, zero(R))
 
 function (g::Precompose)(x::T) where {T <: Union{Tuple, AbstractArray}}
-  return g.f(g.L*x .+ g.b)
+	return g.f(g.L*x .+ g.b)
 end
 
 function gradient!(y::AbstractArray{T}, g::Precompose, x::AbstractArray{T}) where T <: RealOrComplex
-  res = g.L*x .+ g.b
-  gradres = similar(res)
-  v = gradient!(gradres, g.f, res)
-  mul!(y, adjoint(g.L), gradres)
-  return v
+	res = g.L*x .+ g.b
+	gradres = similar(res)
+	v = gradient!(gradres, g.f, res)
+	mul!(y, adjoint(g.L), gradres)
+	return v
 end
 
 function prox!(y::AbstractArray{C}, g::Precompose, x::AbstractArray{C}, gamma::R=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
-  # See Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd ed., 2016.
-  # The same result is Prop. 23.32 in the 1st ed. of the same book.
-  #
-  # This case has an additional translation: if f(x) = h(x + b) then
-  #   prox_f(x) = prox_h(x + b) - b
-  # Then one can apply the above mentioned result to g(x) = f(Lx).
-  #
-  res = g.L*x .+ g.b
-  proxres = similar(res)
-  v = prox!(proxres, g.f, res, g.mu.*gamma)
-  proxres .-= res
-  proxres ./= g.mu
-  mul!(y, adjoint(g.L), proxres)
-  y .+= x
-  return v
+	# See Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd ed., 2016.
+	# The same result is Prop. 23.32 in the 1st ed. of the same book.
+	#
+	# This case has an additional translation: if f(x) = h(x + b) then
+	#	 prox_f(x) = prox_h(x + b) - b
+	# Then one can apply the above mentioned result to g(x) = f(Lx).
+	#
+	res = g.L*x .+ g.b
+	proxres = similar(res)
+	v = prox!(proxres, g.f, res, g.mu.*gamma)
+	proxres .-= res
+	proxres ./= g.mu
+	mul!(y, adjoint(g.L), proxres)
+	y .+= x
+	return v
 end
 
 function prox_naive(g::Precompose, x::AbstractArray{C}, gamma::R=1.0) where {R <: Real, C <: Union{R, Complex{R}}}
-  res = g.L*x .+ g.b
-  proxres, v = prox_naive(g.f, res, g.mu .* gamma)
-  y = x + g.L'*((proxres .- res)./g.mu)
-  return y, v
+	res = g.L*x .+ g.b
+	proxres, v = prox_naive(g.f, res, g.mu .* gamma)
+	y = x + g.L'*((proxres .- res)./g.mu)
+	return y, v
 end
 
 fun_name(f::Precompose) = "Precomposition"

--- a/src/calculus/precompose.jl
+++ b/src/calculus/precompose.jl
@@ -5,7 +5,7 @@ export Precompose
 """
 **Precomposition with linear mapping/translation**
 
-	Precompose(f, L, μ, b)
+    Precompose(f, L, μ, b)
 
 Returns the function
 ```math
@@ -18,19 +18,19 @@ Parameter `L` defines ``L`` through the `mul!` method. Therefore `L` can be an `
 In this case, `prox` and `prox!` are computed according to Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd edition, 2016. The same result is Prop. 23.32 in the 1st edition of the same book.
 """
 struct Precompose{T <: ProximableFunction, R <: Real, C <: Union{R, Complex{R}}, U <: Union{C, AbstractArray{C}}, V <: Union{C, AbstractArray{C}}, M} <: ProximableFunction
-	f::T
-	L::M
-	mu::U
-	b::V
-	function Precompose{T, R, C, U, V, M}(f::T, L::M, mu::U, b::V) where {T <: ProximableFunction, R <: Real, C <: Union{R, Complex{R}}, U <: Union{R, AbstractArray{R}}, V <: Union{C, AbstractArray{C}}, M}
-		if !is_convex(f)
-			error("f must be convex")
-		end
-		if any(mu .<= 0.0)
-			error("elements of μ must be positive")
-		end
-		new(f, L, mu, b)
-	end
+    f::T
+    L::M
+    mu::U
+    b::V
+    function Precompose{T, R, C, U, V, M}(f::T, L::M, mu::U, b::V) where {T <: ProximableFunction, R <: Real, C <: Union{R, Complex{R}}, U <: Union{R, AbstractArray{R}}, V <: Union{C, AbstractArray{C}}, M}
+        if !is_convex(f)
+            error("f must be convex")
+        end
+        if any(mu .<= 0.0)
+            error("elements of μ must be positive")
+        end
+        new(f, L, mu, b)
+    end
 end
 
 is_prox_accurate(f::Precompose) = is_prox_accurate(f.f)
@@ -49,40 +49,40 @@ Precompose(f::T, L::M, mu::U, b::V) where {T <: ProximableFunction, R <: Real, C
 Precompose(f::T, L::M, mu::U) where {T <: ProximableFunction, R <: Real, U <: Union{R, AbstractArray{R}}, M} = Precompose{T, R, R, U, R, M}(f, L, mu, R(0))
 
 function (g::Precompose)(x::T) where {T <: Union{Tuple, AbstractArray}}
-	return g.f(g.L*x .+ g.b)
+    return g.f(g.L*x .+ g.b)
 end
 
 function gradient!(y::AbstractArray{T}, g::Precompose, x::AbstractArray{T}) where T <: RealOrComplex
-	res = g.L*x .+ g.b
-	gradres = similar(res)
-	v = gradient!(gradres, g.f, res)
-	mul!(y, adjoint(g.L), gradres)
-	return v
+    res = g.L*x .+ g.b
+    gradres = similar(res)
+    v = gradient!(gradres, g.f, res)
+    mul!(y, adjoint(g.L), gradres)
+    return v
 end
 
 function prox!(y::AbstractArray{C}, g::Precompose, x::AbstractArray{C}, gamma::R=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
-	# See Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd ed., 2016.
-	# The same result is Prop. 23.32 in the 1st ed. of the same book.
-	#
-	# This case has an additional translation: if f(x) = h(x + b) then
-	#	 prox_f(x) = prox_h(x + b) - b
-	# Then one can apply the above mentioned result to g(x) = f(Lx).
-	#
-	res = g.L*x .+ g.b
-	proxres = similar(res)
-	v = prox!(proxres, g.f, res, g.mu.*gamma)
-	proxres .-= res
-	proxres ./= g.mu
-	mul!(y, adjoint(g.L), proxres)
-	y .+= x
-	return v
+    # See Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd ed., 2016.
+    # The same result is Prop. 23.32 in the 1st ed. of the same book.
+    #
+    # This case has an additional translation: if f(x) = h(x + b) then
+    #     prox_f(x) = prox_h(x + b) - b
+    # Then one can apply the above mentioned result to g(x) = f(Lx).
+    #
+    res = g.L*x .+ g.b
+    proxres = similar(res)
+    v = prox!(proxres, g.f, res, g.mu.*gamma)
+    proxres .-= res
+    proxres ./= g.mu
+    mul!(y, adjoint(g.L), proxres)
+    y .+= x
+    return v
 end
 
 function prox_naive(g::Precompose, x::AbstractArray{C}, gamma::R=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
-	res = g.L*x .+ g.b
-	proxres, v = prox_naive(g.f, res, g.mu .* gamma)
-	y = x + g.L'*((proxres .- res)./g.mu)
-	return y, v
+    res = g.L*x .+ g.b
+    proxres, v = prox_naive(g.f, res, g.mu .* gamma)
+    y = x + g.L'*((proxres .- res)./g.mu)
+    return y, v
 end
 
 fun_name(f::Precompose) = "Precomposition"

--- a/src/calculus/precompose.jl
+++ b/src/calculus/precompose.jl
@@ -46,7 +46,7 @@ is_strongly_convex(f::Precompose) = is_strongly_convex(f.f)
 
 Precompose(f::T, L::M, mu::U, b::V) where {T <: ProximableFunction, R <: Real, C <: Union{R, Complex{R}}, U <: Union{R, AbstractArray{R}}, V <: Union{C, AbstractArray{C}}, M} = Precompose{T, R, C, U, V, M}(f, L, mu, b)
 
-Precompose(f::T, L::M, mu::U) where {T <: ProximableFunction, R <: Real, U <: Union{R, AbstractArray{R}}, M} = Precompose{T, R, R, U, R, M}(f, L, mu, zero(R))
+Precompose(f::T, L::M, mu::U) where {T <: ProximableFunction, R <: Real, U <: Union{R, AbstractArray{R}}, M} = Precompose{T, R, R, U, R, M}(f, L, mu, R(0))
 
 function (g::Precompose)(x::T) where {T <: Union{Tuple, AbstractArray}}
 	return g.f(g.L*x .+ g.b)
@@ -60,7 +60,7 @@ function gradient!(y::AbstractArray{T}, g::Precompose, x::AbstractArray{T}) wher
 	return v
 end
 
-function prox!(y::AbstractArray{C}, g::Precompose, x::AbstractArray{C}, gamma::R=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
+function prox!(y::AbstractArray{C}, g::Precompose, x::AbstractArray{C}, gamma::R=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
 	# See Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd ed., 2016.
 	# The same result is Prop. 23.32 in the 1st ed. of the same book.
 	#
@@ -78,7 +78,7 @@ function prox!(y::AbstractArray{C}, g::Precompose, x::AbstractArray{C}, gamma::R
 	return v
 end
 
-function prox_naive(g::Precompose, x::AbstractArray{C}, gamma::R=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
+function prox_naive(g::Precompose, x::AbstractArray{C}, gamma::R=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
 	res = g.L*x .+ g.b
 	proxres, v = prox_naive(g.f, res, g.mu .* gamma)
 	y = x + g.L'*((proxres .- res)./g.mu)

--- a/src/calculus/precompose.jl
+++ b/src/calculus/precompose.jl
@@ -13,7 +13,7 @@ g(x) = f(Lx + b)
 ```
 where ``f`` is a convex function and ``L`` is a linear mapping: this must satisfy ``LL^* = μI`` for ``μ ⩾ 0``. Furthermore, either ``f`` is separable or parameter `μ` is a scalar, for the `prox` of ``g`` to be computable.
 
-Parameter `L` defines ``L`` through the `A_mul_B!` and `Ac_mul_B!` methods. Therefore `L` can be an `AbstractMatrix` for example, but not necessarily.
+Parameter `L` defines ``L`` through the `mul!` method. Therefore `L` can be an `AbstractMatrix` for example, but not necessarily.
 
 In this case, `prox` and `prox!` are computed according to Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd edition, 2016. The same result is Prop. 23.32 in the 1st edition of the same book.
 """
@@ -78,7 +78,7 @@ function prox!(y::AbstractArray{C}, g::Precompose, x::AbstractArray{C}, gamma::R
 	return v
 end
 
-function prox_naive(g::Precompose, x::AbstractArray{C}, gamma::R=1.0) where {R <: Real, C <: Union{R, Complex{R}}}
+function prox_naive(g::Precompose, x::AbstractArray{C}, gamma::R=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
 	res = g.L*x .+ g.b
 	proxres, v = prox_naive(g.f, res, g.mu .* gamma)
 	y = x + g.L'*((proxres .- res)./g.mu)

--- a/src/calculus/precomposeDiagonal.jl
+++ b/src/calculus/precomposeDiagonal.jl
@@ -5,7 +5,7 @@ export PrecomposeDiagonal
 """
 **Precomposition with diagonal scaling/translation**
 
-    PrecomposeDiagonal(f, a, b)
+	PrecomposeDiagonal(f, a, b)
 
 Returns the function
 ```math
@@ -14,22 +14,22 @@ g(x) = f(\\mathrm{diag}(a)x + b)
 where ``f`` is a convex function. Furthermore, ``f`` must be separable, or `a` must be a scalar, for the `prox` of ``g`` to be computable. Parametes `a` and `b` can be arrays of multiple dimensions, according to the shape/size of the input `x` that will be provided to the function: the way the above expression for ``g`` should be thought of, is `g(x) = f(a.*x + b)`.
 """
 struct PrecomposeDiagonal{T <: ProximableFunction, R <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}} <: ProximableFunction
-  f::T
-  a::R
-  b::S
-  function PrecomposeDiagonal{T,R,S}(f::T, a::R, b::S) where {T <: ProximableFunction, R <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
-    if !is_convex(f)
-      error("`f` must be convex")
-    end
-    if !(eltype(a) <: Real)
-      error("`a` must have real elements")
-    end
-    if any(a == 0.0)
-      error("elements of `a` must be nonzero")
-    else
-      new(f, a, b)
-    end
-  end
+	f::T
+	a::R
+	b::S
+	function PrecomposeDiagonal{T,R,S}(f::T, a::R, b::S) where {T <: ProximableFunction, R <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
+		if !is_convex(f)
+			error("`f` must be convex")
+		end
+		if !(eltype(a) <: Real)
+			error("`a` must have real elements")
+		end
+		if any(a == 0.0)
+			error("elements of `a` must be nonzero")
+		else
+			new(f, a, b)
+		end
+	end
 end
 
 is_separable(f::PrecomposeDiagonal) = is_separable(f.f)
@@ -51,28 +51,28 @@ PrecomposeDiagonal(f::T, a::R, b::S=0.0) where {T <: ProximableFunction, R <: Ab
 PrecomposeDiagonal(f::T, a::R, b::S) where {T <: ProximableFunction, R <: Union{AbstractArray, Real}, S <: AbstractArray} = PrecomposeDiagonal{T, R, S}(f, a, b)
 
 function (g::PrecomposeDiagonal)(x::AbstractArray{T}) where T <: RealOrComplex
-  return g.f((g.a).*x .+ g.b)
+	return g.f((g.a).*x .+ g.b)
 end
 
 function gradient!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}) where T <: RealOrComplex
-  z = g.a .* x .+ g.b
-  v = gradient!(y, g.f, z)
-  y .*= g.a
-  return v
+	z = g.a .* x .+ g.b
+	v = gradient!(y, g.f, z)
+	y .*= g.a
+	return v
 end
 
 function prox!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  z = g.a .* x .+ g.b
-  v = prox!(y, g.f, z, (g.a .* g.a) .* gamma)
-  y .-= g.b
-  y ./= g.a
-  return v
+	z = g.a .* x .+ g.b
+	v = prox!(y, g.f, z, (g.a .* g.a) .* gamma)
+	y .-= g.b
+	y ./= g.a
+	return v
 end
 
 function prox_naive(g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  z = g.a .* x .+ g.b
-  y, fy = prox_naive(g.f, z, (g.a .* g.a) .* gamma)
-  return (y .- g.b)./g.a, fy
+	z = g.a .* x .+ g.b
+	y, fy = prox_naive(g.f, z, (g.a .* g.a) .* gamma)
+	return (y .- g.b)./g.a, fy
 end
 
 fun_name(f::PrecomposeDiagonal) = string("Precomposition by affine diagonal mapping of ", fun_name(f.f))

--- a/src/calculus/precomposeDiagonal.jl
+++ b/src/calculus/precomposeDiagonal.jl
@@ -5,7 +5,7 @@ export PrecomposeDiagonal
 """
 **Precomposition with diagonal scaling/translation**
 
-	PrecomposeDiagonal(f, a, b)
+    PrecomposeDiagonal(f, a, b)
 
 Returns the function
 ```math
@@ -14,22 +14,22 @@ g(x) = f(\\mathrm{diag}(a)x + b)
 where ``f`` is a convex function. Furthermore, ``f`` must be separable, or `a` must be a scalar, for the `prox` of ``g`` to be computable. Parametes `a` and `b` can be arrays of multiple dimensions, according to the shape/size of the input `x` that will be provided to the function: the way the above expression for ``g`` should be thought of, is `g(x) = f(a.*x + b)`.
 """
 struct PrecomposeDiagonal{T <: ProximableFunction, R <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}} <: ProximableFunction
-	f::T
-	a::R
-	b::S
-	function PrecomposeDiagonal{T,R,S}(f::T, a::R, b::S) where {T <: ProximableFunction, R <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
-		if !is_convex(f)
-			error("`f` must be convex")
-		end
-		if !(eltype(a) <: Real)
-			error("`a` must have real elements")
-		end
-		if any(a == 0.0)
-			error("elements of `a` must be nonzero")
-		else
-			new(f, a, b)
-		end
-	end
+    f::T
+    a::R
+    b::S
+    function PrecomposeDiagonal{T,R,S}(f::T, a::R, b::S) where {T <: ProximableFunction, R <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
+        if !is_convex(f)
+            error("`f` must be convex")
+        end
+        if !(eltype(a) <: Real)
+            error("`a` must have real elements")
+        end
+        if any(a == 0.0)
+            error("elements of `a` must be nonzero")
+        else
+            new(f, a, b)
+        end
+    end
 end
 
 is_separable(f::PrecomposeDiagonal) = is_separable(f.f)
@@ -51,28 +51,28 @@ PrecomposeDiagonal(f::T, a::R, b::S=0.0) where {T <: ProximableFunction, R <: Ab
 PrecomposeDiagonal(f::T, a::R, b::S) where {T <: ProximableFunction, R <: Union{AbstractArray, Real}, S <: AbstractArray} = PrecomposeDiagonal{T, R, S}(f, a, b)
 
 function (g::PrecomposeDiagonal)(x::AbstractArray{T}) where T <: RealOrComplex
-	return g.f((g.a).*x .+ g.b)
+    return g.f((g.a).*x .+ g.b)
 end
 
 function gradient!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}) where T <: RealOrComplex
-	z = g.a .* x .+ g.b
-	v = gradient!(y, g.f, z)
-	y .*= g.a
-	return v
+    z = g.a .* x .+ g.b
+    v = gradient!(y, g.f, z)
+    y .*= g.a
+    return v
 end
 
 function prox!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	z = g.a .* x .+ g.b
-	v = prox!(y, g.f, z, (g.a .* g.a) .* gamma)
-	y .-= g.b
-	y ./= g.a
-	return v
+    z = g.a .* x .+ g.b
+    v = prox!(y, g.f, z, (g.a .* g.a) .* gamma)
+    y .-= g.b
+    y ./= g.a
+    return v
 end
 
 function prox_naive(g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	z = g.a .* x .+ g.b
-	y, fy = prox_naive(g.f, z, (g.a .* g.a) .* gamma)
-	return (y .- g.b)./g.a, fy
+    z = g.a .* x .+ g.b
+    y, fy = prox_naive(g.f, z, (g.a .* g.a) .* gamma)
+    return (y .- g.b)./g.a, fy
 end
 
 fun_name(f::PrecomposeDiagonal) = string("Precomposition by affine diagonal mapping of ", fun_name(f.f))

--- a/src/calculus/precomposeDiagonal.jl
+++ b/src/calculus/precomposeDiagonal.jl
@@ -61,7 +61,7 @@ function gradient!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{
 	return v
 end
 
-function prox!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	z = g.a .* x .+ g.b
 	v = prox!(y, g.f, z, (g.a .* g.a) .* gamma)
 	y .-= g.b
@@ -69,7 +69,7 @@ function prox!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}, 
 	return v
 end
 
-function prox_naive(g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	z = g.a .* x .+ g.b
 	y, fy = prox_naive(g.f, z, (g.a .* g.a) .* gamma)
 	return (y .- g.b)./g.a, fy

--- a/src/calculus/precomposeDiagonal.jl
+++ b/src/calculus/precomposeDiagonal.jl
@@ -61,7 +61,7 @@ function gradient!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{
 	return v
 end
 
-function prox!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
+function prox!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	z = g.a .* x .+ g.b
 	v = prox!(y, g.f, z, (g.a .* g.a) .* gamma)
 	y .-= g.b
@@ -69,7 +69,7 @@ function prox!(y::AbstractArray{T}, g::PrecomposeDiagonal, x::AbstractArray{T}, 
 	return v
 end
 
-function prox_naive(g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
+function prox_naive(g::PrecomposeDiagonal, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	z = g.a .* x .+ g.b
 	y, fy = prox_naive(g.f, z, (g.a .* g.a) .* gamma)
 	return (y .- g.b)./g.a, fy

--- a/src/calculus/regularize.jl
+++ b/src/calculus/regularize.jl
@@ -48,7 +48,7 @@ function gradient!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}) wher
 	return v + g.rho/2*norm(x .- g.a)^2
 end
 
-function prox!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
+function prox!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	gr = g.rho*gamma
 	gr2 = 1.0 ./ (1.0 .+ gr)
 	v = prox!(y, g.f, gr2.*(x .+ gr.*g.a), gr2.*gamma)
@@ -60,7 +60,7 @@ fun_dom(f::Regularize) = fun_dom(f.f)
 fun_expr(f::Regularize) = string(fun_expr(f.f), "+(ρ/2)||x-a||²")
 fun_params(f::Regularize) = "ρ = $(f.rho), a = $( typeof(f.a) <: Real ? f.a : typeof(f.a) )"
 
-function prox_naive(g::Regularize, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
+function prox_naive(g::Regularize, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	y, v = prox_naive(g.f, x./(1.0 .+ gamma.*g.rho) .+ g.a./(1.0./(gamma.*g.rho) .+ 1.0), gamma./(1.0 .+ gamma.*g.rho))
 	return y, v + g.rho/2*norm(y .- g.a)^2
 end

--- a/src/calculus/regularize.jl
+++ b/src/calculus/regularize.jl
@@ -48,7 +48,7 @@ function gradient!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}) wher
 	return v + g.rho/2*norm(x .- g.a)^2
 end
 
-function prox!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	gr = g.rho*gamma
 	gr2 = 1.0 ./ (1.0 .+ gr)
 	v = prox!(y, g.f, gr2.*(x .+ gr.*g.a), gr2.*gamma)
@@ -60,7 +60,7 @@ fun_dom(f::Regularize) = fun_dom(f.f)
 fun_expr(f::Regularize) = string(fun_expr(f.f), "+(ρ/2)||x-a||²")
 fun_params(f::Regularize) = "ρ = $(f.rho), a = $( typeof(f.a) <: Real ? f.a : typeof(f.a) )"
 
-function prox_naive(g::Regularize, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(g::Regularize, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	y, v = prox_naive(g.f, x./(1.0 .+ gamma.*g.rho) .+ g.a./(1.0./(gamma.*g.rho) .+ 1.0), gamma./(1.0 .+ gamma.*g.rho))
 	return y, v + g.rho/2*norm(y .- g.a)^2
 end

--- a/src/calculus/regularize.jl
+++ b/src/calculus/regularize.jl
@@ -5,7 +5,7 @@ export Regularize
 """
 **Regularize**
 
-	Regularize(f, ρ=1.0, a=0.0)
+    Regularize(f, ρ=1.0, a=0.0)
 
 Given function `f`, and optional parameters `ρ` (positive) and `a`, returns
 ```math
@@ -14,16 +14,16 @@ g(x) = f(x) + \\tfrac{ρ}{2}\\|x-a\\|².
 Parameter `a` can be either an array or a scalar, in which case it is subtracted component-wise from `x` in the above expression.
 """
 struct Regularize{T <: ProximableFunction, S <: Real, A <: Union{Real, AbstractArray}} <: ProximableFunction
-	f::T
-	rho::S
-	a::A
-	function Regularize{T,S,A}(f::T, rho::S, a::A) where {T <: ProximableFunction, S <: Real, A <: Union{Real, AbstractArray}}
-		if rho <= 0.0
-			error("parameter `ρ` must be positive")
-		else
-			new(f, rho, a)
-		end
-	end
+    f::T
+    rho::S
+    a::A
+    function Regularize{T,S,A}(f::T, rho::S, a::A) where {T <: ProximableFunction, S <: Real, A <: Union{Real, AbstractArray}}
+        if rho <= 0.0
+            error("parameter `ρ` must be positive")
+        else
+            new(f, rho, a)
+        end
+    end
 end
 
 is_separable(f::Regularize) = is_separable(f.f)
@@ -39,20 +39,20 @@ Regularize(f::T, rho::S, a::A) where {T <: ProximableFunction, S <: Real, A <: A
 Regularize(f::T, rho::S=one(S), a::S=zero(S)) where {T <: ProximableFunction, S <: Real} = Regularize{T, S, S}(f, rho, a)
 
 function (g::Regularize)(x::AbstractArray{T}) where T <: RealOrComplex
-	return g.f(x) + g.rho/2*norm(x .- g.a)^2
+    return g.f(x) + g.rho/2*norm(x .- g.a)^2
 end
 
 function gradient!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}) where T <: RealOrComplex
-	v = gradient!(y, g.f, x)
-	y .+= g.rho*(x .- g.a)
-	return v + g.rho/2*norm(x .- g.a)^2
+    v = gradient!(y, g.f, x)
+    y .+= g.rho*(x .- g.a)
+    return v + g.rho/2*norm(x .- g.a)^2
 end
 
 function prox!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	gr = g.rho*gamma
-	gr2 = 1.0 ./ (1.0 .+ gr)
-	v = prox!(y, g.f, gr2.*(x .+ gr.*g.a), gr2.*gamma)
-	return v + g.rho/2*norm(y .- g.a)^2
+    gr = g.rho*gamma
+    gr2 = 1.0 ./ (1.0 .+ gr)
+    v = prox!(y, g.f, gr2.*(x .+ gr.*g.a), gr2.*gamma)
+    return v + g.rho/2*norm(y .- g.a)^2
 end
 
 fun_name(f::Regularize) = string("Regularized ", fun_name(f.f))
@@ -61,6 +61,6 @@ fun_expr(f::Regularize) = string(fun_expr(f.f), "+(ρ/2)||x-a||²")
 fun_params(f::Regularize) = "ρ = $(f.rho), a = $( typeof(f.a) <: Real ? f.a : typeof(f.a) )"
 
 function prox_naive(g::Regularize, x::AbstractArray{T}, gamma::Union{R, AbstractArray{R}}=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	y, v = prox_naive(g.f, x./(1.0 .+ gamma.*g.rho) .+ g.a./(1.0./(gamma.*g.rho) .+ 1.0), gamma./(1.0 .+ gamma.*g.rho))
-	return y, v + g.rho/2*norm(y .- g.a)^2
+    y, v = prox_naive(g.f, x./(1.0 .+ gamma.*g.rho) .+ g.a./(1.0./(gamma.*g.rho) .+ 1.0), gamma./(1.0 .+ gamma.*g.rho))
+    return y, v + g.rho/2*norm(y .- g.a)^2
 end

--- a/src/calculus/regularize.jl
+++ b/src/calculus/regularize.jl
@@ -5,7 +5,7 @@ export Regularize
 """
 **Regularize**
 
-    Regularize(f, ρ=1.0, a=0.0)
+	Regularize(f, ρ=1.0, a=0.0)
 
 Given function `f`, and optional parameters `ρ` (positive) and `a`, returns
 ```math
@@ -14,16 +14,16 @@ g(x) = f(x) + \\tfrac{ρ}{2}\\|x-a\\|².
 Parameter `a` can be either an array or a scalar, in which case it is subtracted component-wise from `x` in the above expression.
 """
 struct Regularize{T <: ProximableFunction, S <: Real, A <: Union{Real, AbstractArray}} <: ProximableFunction
-  f::T
-  rho::S
-  a::A
-  function Regularize{T,S,A}(f::T, rho::S, a::A) where {T <: ProximableFunction, S <: Real, A <: Union{Real, AbstractArray}}
-    if rho <= 0.0
-      error("parameter `ρ` must be positive")
-    else
-      new(f, rho, a)
-    end
-  end
+	f::T
+	rho::S
+	a::A
+	function Regularize{T,S,A}(f::T, rho::S, a::A) where {T <: ProximableFunction, S <: Real, A <: Union{Real, AbstractArray}}
+		if rho <= 0.0
+			error("parameter `ρ` must be positive")
+		else
+			new(f, rho, a)
+		end
+	end
 end
 
 is_separable(f::Regularize) = is_separable(f.f)
@@ -43,16 +43,16 @@ function (g::Regularize)(x::AbstractArray{T}) where T <: RealOrComplex
 end
 
 function gradient!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}) where T <: RealOrComplex
-  v = gradient!(y, g.f, x)
-  y .+= g.rho*(x .- g.a)
-  return v + g.rho/2*norm(x .- g.a)^2
+	v = gradient!(y, g.f, x)
+	y .+= g.rho*(x .- g.a)
+	return v + g.rho/2*norm(x .- g.a)^2
 end
 
 function prox!(y::AbstractArray{T}, g::Regularize, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  gr = g.rho*gamma
-  gr2 = 1.0 ./ (1.0 .+ gr)
-  v = prox!(y, g.f, gr2.*(x .+ gr.*g.a), gr2.*gamma)
-  return v + g.rho/2*norm(y .- g.a)^2
+	gr = g.rho*gamma
+	gr2 = 1.0 ./ (1.0 .+ gr)
+	v = prox!(y, g.f, gr2.*(x .+ gr.*g.a), gr2.*gamma)
+	return v + g.rho/2*norm(y .- g.a)^2
 end
 
 fun_name(f::Regularize) = string("Regularized ", fun_name(f.f))
@@ -61,6 +61,6 @@ fun_expr(f::Regularize) = string(fun_expr(f.f), "+(ρ/2)||x-a||²")
 fun_params(f::Regularize) = "ρ = $(f.rho), a = $( typeof(f.a) <: Real ? f.a : typeof(f.a) )"
 
 function prox_naive(g::Regularize, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  y, v = prox_naive(g.f, x./(1.0 .+ gamma.*g.rho) .+ g.a./(1.0./(gamma.*g.rho) .+ 1.0), gamma./(1.0 .+ gamma.*g.rho))
-  return y, v + g.rho/2*norm(y .- g.a)^2
+	y, v = prox_naive(g.f, x./(1.0 .+ gamma.*g.rho) .+ g.a./(1.0./(gamma.*g.rho) .+ 1.0), gamma./(1.0 .+ gamma.*g.rho))
+	return y, v + g.rho/2*norm(y .- g.a)^2
 end

--- a/src/calculus/separableSum.jl
+++ b/src/calculus/separableSum.jl
@@ -5,7 +5,7 @@ export SeparableSum
 """
 **Separable sum of functions**
 
-    SeparableSum(f₁,…,fₖ)
+	SeparableSum(f₁,…,fₖ)
 
 Given functions `f₁` to `fₖ`, returns their separable sum, that is
 ```math
@@ -15,11 +15,11 @@ The object `g` constructed in this way can be evaluated at `Tuple`s of length `k
 
 Example:
 
-    f = SeparableSum(NormL1(), NuclearNorm()); # separable sum of two functions
-    x = randn(10); # some random vector
-    Y = randn(20, 30); # some random matrix
-    f_xY = f((x, Y)); # evaluates f at (x, Y)
-    (u, V), f_uV = prox(f, (x, Y), 1.3); # computes prox at (x, Y)
+	f = SeparableSum(NormL1(), NuclearNorm()); # separable sum of two functions
+	x = randn(10); # some random vector
+	Y = randn(20, 30); # some random matrix
+	f_xY = f((x, Y)); # evaluates f at (x, Y)
+	(u, V), f_uV = prox(f, (x, Y), 1.3); # computes prox at (x, Y)
 """
 struct SeparableSum{T <: Tuple} <: ProximableFunction
 	fs::T
@@ -40,36 +40,36 @@ is_strongly_convex(f::SeparableSum) = all(is_strongly_convex.(f.fs))
 
 function (f::SeparableSum)(x::Tuple)
 	sum = 0.0
-  for k in eachindex(x)
-	  sum += f.fs[k](x[k])
-  end
-  return sum
+	for k in eachindex(x)
+		sum += f.fs[k](x[k])
+	end
+	return sum
 end
 
 function prox!(ys::T, fs::Tuple, xs::T, gamma::Real=1.0) where T <: Tuple
-  sum = 0.0
-  for k in eachindex(xs)
-	  sum += prox!(ys[k], fs[k], xs[k], gamma)
-  end
-  return sum
+	sum = 0.0
+	for k in eachindex(xs)
+		sum += prox!(ys[k], fs[k], xs[k], gamma)
+	end
+	return sum
 end
 
 function prox!(ys::T, fs::Tuple, xs::T, gamma::Tuple) where T <: Tuple
-  sum = 0.0
-  for k in eachindex(xs)
-	  sum += prox!(ys[k], fs[k], xs[k], gamma[k])
-  end
-  return sum
+	sum = 0.0
+	for k in eachindex(xs)
+		sum += prox!(ys[k], fs[k], xs[k], gamma[k])
+	end
+	return sum
 end
 
 prox!(ys::T, f::SeparableSum, xs::T, gamma::Union{Real, Tuple}=1.0) where {T <: Tuple} = prox!(ys, f.fs, xs, gamma)
 
 function gradient!(grad::T, fs::Tuple, x::T) where T <: Tuple
-  val = 0.0
-  for k in eachindex(fs)
-    val += gradient!(grad[k], fs[k], x[k])
-  end
-  return val
+	val = 0.0
+	for k in eachindex(fs)
+		val += gradient!(grad[k], fs[k], x[k])
+	end
+	return val
 end
 
 gradient!(grad::T, f::SeparableSum, x::T) where {T <: Tuple} = gradient!(grad, f.fs, x)
@@ -82,10 +82,10 @@ fun_params(f::SeparableSum) = "n/a"
 function prox_naive(f::SeparableSum, xs::Tuple, gamma::Union{Real, Tuple}=1.0)
 	fys = 0.0
 	ys = [];
-  for k in eachindex(xs)
-	  y, fy = prox_naive(f.fs[k], xs[k], typeof(gamma) <: Real ? gamma : gamma[k])
+	for k in eachindex(xs)
+		y, fy = prox_naive(f.fs[k], xs[k], typeof(gamma) <: Real ? gamma : gamma[k])
 		fys += fy;
 		append!(ys, [y]);
-  end
+	end
 	return Tuple(ys), fys
 end

--- a/src/calculus/separableSum.jl
+++ b/src/calculus/separableSum.jl
@@ -81,11 +81,11 @@ fun_params(f::SeparableSum) = "n/a"
 
 function prox_naive(f::SeparableSum, xs::Tuple, gamma::Union{Real, Tuple}=1.0)
 	fys = 0.0
-	ys = [];
+	ys = []
 	for k in eachindex(xs)
 		y, fy = prox_naive(f.fs[k], xs[k], typeof(gamma) <: Real ? gamma : gamma[k])
-		fys += fy;
-		append!(ys, [y]);
+		fys += fy
+		append!(ys, [y])
 	end
 	return Tuple(ys), fys
 end

--- a/src/calculus/separableSum.jl
+++ b/src/calculus/separableSum.jl
@@ -46,7 +46,7 @@ function (f::SeparableSum)(x::TupleOfArrays{R}) where R <: Real
 	return sum
 end
 
-function prox!(ys::TupleOfArrays{R}, fs::Tuple, xs::TupleOfArrays{R}, gamma::R=one(R)) where R <: Real
+function prox!(ys::TupleOfArrays{R}, fs::Tuple, xs::TupleOfArrays{R}, gamma::R=R(1)) where R <: Real
 	sum = R(0)
 	for k in eachindex(xs)
 		sum += prox!(ys[k], fs[k], xs[k], gamma)
@@ -62,7 +62,7 @@ function prox!(ys::TupleOfArrays{R}, fs::Tuple, xs::TupleOfArrays{R}, gamma::Tup
 	return sum
 end
 
-prox!(ys::TupleOfArrays{R}, f::SeparableSum, xs::TupleOfArrays{R}, gamma=one(R)) where R <: Real = prox!(ys, f.fs, xs, gamma)
+prox!(ys::TupleOfArrays{R}, f::SeparableSum, xs::TupleOfArrays{R}, gamma=R(1)) where R <: Real = prox!(ys, f.fs, xs, gamma)
 
 function gradient!(grad::TupleOfArrays{R}, fs::Tuple, x::TupleOfArrays{R}) where R <: Real
 	val = R(0)
@@ -79,7 +79,7 @@ fun_dom(f::SeparableSum) = "n/a"
 fun_expr(f::SeparableSum) = "(x₁, …, xₖ) ↦ f₁(x₁) + … + fₖ(xₖ)"
 fun_params(f::SeparableSum) = "n/a"
 
-function prox_naive(f::SeparableSum, xs::TupleOfArrays{R}, gamma::Union{R, Tuple}=one(R)) where R <: Real
+function prox_naive(f::SeparableSum, xs::TupleOfArrays{R}, gamma::Union{R, Tuple}=R(1)) where R <: Real
 	fys = R(0)
 	ys = []
 	for k in eachindex(xs)

--- a/src/calculus/separableSum.jl
+++ b/src/calculus/separableSum.jl
@@ -38,49 +38,49 @@ is_quadratic(f::SeparableSum) = all(is_quadratic.(f.fs))
 is_generalized_quadratic(f::SeparableSum) = all(is_generalized_quadratic.(f.fs))
 is_strongly_convex(f::SeparableSum) = all(is_strongly_convex.(f.fs))
 
-function (f::SeparableSum)(x::Tuple)
-	sum = 0.0
+function (f::SeparableSum)(x::TupleOfArrays{R}) where R <: Real
+	sum = R(0)
 	for k in eachindex(x)
 		sum += f.fs[k](x[k])
 	end
 	return sum
 end
 
-function prox!(ys::T, fs::Tuple, xs::T, gamma::Real=1.0) where T <: Tuple
-	sum = 0.0
+function prox!(ys::TupleOfArrays{R}, fs::Tuple, xs::TupleOfArrays{R}, gamma::R=one(R)) where R <: Real
+	sum = R(0)
 	for k in eachindex(xs)
 		sum += prox!(ys[k], fs[k], xs[k], gamma)
 	end
 	return sum
 end
 
-function prox!(ys::T, fs::Tuple, xs::T, gamma::Tuple) where T <: Tuple
-	sum = 0.0
+function prox!(ys::TupleOfArrays{R}, fs::Tuple, xs::TupleOfArrays{R}, gamma::Tuple) where R <: Real
+	sum = R(0)
 	for k in eachindex(xs)
 		sum += prox!(ys[k], fs[k], xs[k], gamma[k])
 	end
 	return sum
 end
 
-prox!(ys::T, f::SeparableSum, xs::T, gamma::Union{Real, Tuple}=1.0) where {T <: Tuple} = prox!(ys, f.fs, xs, gamma)
+prox!(ys::TupleOfArrays{R}, f::SeparableSum, xs::TupleOfArrays{R}, gamma=one(R)) where R <: Real = prox!(ys, f.fs, xs, gamma)
 
-function gradient!(grad::T, fs::Tuple, x::T) where T <: Tuple
-	val = 0.0
+function gradient!(grad::TupleOfArrays{R}, fs::Tuple, x::TupleOfArrays{R}) where R <: Real
+	val = R(0)
 	for k in eachindex(fs)
 		val += gradient!(grad[k], fs[k], x[k])
 	end
 	return val
 end
 
-gradient!(grad::T, f::SeparableSum, x::T) where {T <: Tuple} = gradient!(grad, f.fs, x)
+gradient!(grad::TupleOfArrays, f::SeparableSum, x::TupleOfArrays) = gradient!(grad, f.fs, x)
 
 fun_name(f::SeparableSum) = "separable sum"
 fun_dom(f::SeparableSum) = "n/a"
 fun_expr(f::SeparableSum) = "(x₁, …, xₖ) ↦ f₁(x₁) + … + fₖ(xₖ)"
 fun_params(f::SeparableSum) = "n/a"
 
-function prox_naive(f::SeparableSum, xs::Tuple, gamma::Union{Real, Tuple}=1.0)
-	fys = 0.0
+function prox_naive(f::SeparableSum, xs::TupleOfArrays{R}, gamma::Union{R, Tuple}=one(R)) where R <: Real
+	fys = R(0)
 	ys = []
 	for k in eachindex(xs)
 		y, fy = prox_naive(f.fs[k], xs[k], typeof(gamma) <: Real ? gamma : gamma[k])

--- a/src/calculus/separableSum.jl
+++ b/src/calculus/separableSum.jl
@@ -5,7 +5,7 @@ export SeparableSum
 """
 **Separable sum of functions**
 
-	SeparableSum(f₁,…,fₖ)
+    SeparableSum(f₁,…,fₖ)
 
 Given functions `f₁` to `fₖ`, returns their separable sum, that is
 ```math
@@ -15,14 +15,14 @@ The object `g` constructed in this way can be evaluated at `Tuple`s of length `k
 
 Example:
 
-	f = SeparableSum(NormL1(), NuclearNorm()); # separable sum of two functions
-	x = randn(10); # some random vector
-	Y = randn(20, 30); # some random matrix
-	f_xY = f((x, Y)); # evaluates f at (x, Y)
-	(u, V), f_uV = prox(f, (x, Y), 1.3); # computes prox at (x, Y)
+    f = SeparableSum(NormL1(), NuclearNorm()); # separable sum of two functions
+    x = randn(10); # some random vector
+    Y = randn(20, 30); # some random matrix
+    f_xY = f((x, Y)); # evaluates f at (x, Y)
+    (u, V), f_uV = prox(f, (x, Y), 1.3); # computes prox at (x, Y)
 """
 struct SeparableSum{T <: Tuple} <: ProximableFunction
-	fs::T
+    fs::T
 end
 
 SeparableSum(fs::Vararg{ProximableFunction}) = SeparableSum((fs...,))
@@ -39,37 +39,37 @@ is_generalized_quadratic(f::SeparableSum) = all(is_generalized_quadratic.(f.fs))
 is_strongly_convex(f::SeparableSum) = all(is_strongly_convex.(f.fs))
 
 function (f::SeparableSum)(x::TupleOfArrays{R}) where R <: Real
-	sum = R(0)
-	for k in eachindex(x)
-		sum += f.fs[k](x[k])
-	end
-	return sum
+    sum = R(0)
+    for k in eachindex(x)
+        sum += f.fs[k](x[k])
+    end
+    return sum
 end
 
 function prox!(ys::TupleOfArrays{R}, fs::Tuple, xs::TupleOfArrays{R}, gamma::R=R(1)) where R <: Real
-	sum = R(0)
-	for k in eachindex(xs)
-		sum += prox!(ys[k], fs[k], xs[k], gamma)
-	end
-	return sum
+    sum = R(0)
+    for k in eachindex(xs)
+        sum += prox!(ys[k], fs[k], xs[k], gamma)
+    end
+    return sum
 end
 
 function prox!(ys::TupleOfArrays{R}, fs::Tuple, xs::TupleOfArrays{R}, gamma::Tuple) where R <: Real
-	sum = R(0)
-	for k in eachindex(xs)
-		sum += prox!(ys[k], fs[k], xs[k], gamma[k])
-	end
-	return sum
+    sum = R(0)
+    for k in eachindex(xs)
+        sum += prox!(ys[k], fs[k], xs[k], gamma[k])
+    end
+    return sum
 end
 
 prox!(ys::TupleOfArrays{R}, f::SeparableSum, xs::TupleOfArrays{R}, gamma=R(1)) where R <: Real = prox!(ys, f.fs, xs, gamma)
 
 function gradient!(grad::TupleOfArrays{R}, fs::Tuple, x::TupleOfArrays{R}) where R <: Real
-	val = R(0)
-	for k in eachindex(fs)
-		val += gradient!(grad[k], fs[k], x[k])
-	end
-	return val
+    val = R(0)
+    for k in eachindex(fs)
+        val += gradient!(grad[k], fs[k], x[k])
+    end
+    return val
 end
 
 gradient!(grad::TupleOfArrays, f::SeparableSum, x::TupleOfArrays) = gradient!(grad, f.fs, x)
@@ -80,12 +80,12 @@ fun_expr(f::SeparableSum) = "(x₁, …, xₖ) ↦ f₁(x₁) + … + fₖ(xₖ)
 fun_params(f::SeparableSum) = "n/a"
 
 function prox_naive(f::SeparableSum, xs::TupleOfArrays{R}, gamma::Union{R, Tuple}=R(1)) where R <: Real
-	fys = R(0)
-	ys = []
-	for k in eachindex(xs)
-		y, fy = prox_naive(f.fs[k], xs[k], typeof(gamma) <: Real ? gamma : gamma[k])
-		fys += fy
-		append!(ys, [y])
-	end
-	return Tuple(ys), fys
+    fys = R(0)
+    ys = []
+    for k in eachindex(xs)
+        y, fy = prox_naive(f.fs[k], xs[k], typeof(gamma) <: Real ? gamma : gamma[k])
+        fys += fy
+        append!(ys, [y])
+    end
+    return Tuple(ys), fys
 end

--- a/src/calculus/slicedSeparableSum.jl
+++ b/src/calculus/slicedSeparableSum.jl
@@ -100,8 +100,8 @@ fun_expr(f::SlicedSeparableSum) = "hard to explain"
 fun_params(f::SlicedSeparableSum) = "n/a" # for now
 
 function prox_naive(f::SlicedSeparableSum, x::AbstractArray, gamma)
-	fy = 0;
-	y = similar(x);
+	fy = 0
+	y = similar(x)
 	for t in eachindex(f.fs)
 		for k in eachindex(f.fs[t])
 			y[f.idxs[t][k]...], fy1 = prox_naive(f.fs[t][k], x[f.idxs[t][k]...], gamma)

--- a/src/calculus/slicedSeparableSum.jl
+++ b/src/calculus/slicedSeparableSum.jl
@@ -27,17 +27,17 @@ struct SlicedSeparableSum{S <: Tuple, T <: AbstractArray, N} <: ProximableFuncti
 end
 
 function SlicedSeparableSum(fs::S, idxs::T) where {N,
-						   S <: Tuple{Vararg{<:ProximableFunction,N}},
-						   M,
-						   I <: Integer,
-						   T1 <: NTuple{M,Union{I,
-								       AbstractArray{I},
-								       Colon,
-								       AbstractRange
-								       }
-							       },
-						   T <:NTuple{N,T1}
-						   }
+                           S <: Tuple{Vararg{<:ProximableFunction,N}},
+                           M,
+                           I <: Integer,
+                           T1 <: NTuple{M,Union{I,
+                                       AbstractArray{I},
+                                       Colon,
+                                       AbstractRange
+                                       }
+                                   },
+                           T <:NTuple{N,T1}
+                           }
     ftypes = DataType[]
     fsarr = Array{Any,1}[]
     indarr = Array{eltype(idxs),1}[]
@@ -64,11 +64,11 @@ SlicedSeparableSum(([f for k in eachindex(idxs)]...,), idxs)
 
 # Unroll the loop over the different types of functions to evaluate
 @generated function (f::SlicedSeparableSum{A, B, N})(x::T) where {A, B, N, T <: AbstractArray}
-	ex = :(v = 0.0)
+    ex = :(v = 0.0)
   for i = 1:N # For each function type
     ex = quote $ex;
       for k in eachindex(f.fs[$i]) # For each function of that type
-				v += f.fs[$i][k](view(x,f.idxs[$i][k]...))
+                v += f.fs[$i][k](view(x,f.idxs[$i][k]...))
       end
     end
   end
@@ -100,13 +100,13 @@ fun_expr(f::SlicedSeparableSum) = "hard to explain"
 fun_params(f::SlicedSeparableSum) = "n/a" # for now
 
 function prox_naive(f::SlicedSeparableSum, x::AbstractArray, gamma)
-	fy = 0
-	y = similar(x)
-	for t in eachindex(f.fs)
-		for k in eachindex(f.fs[t])
-			y[f.idxs[t][k]...], fy1 = prox_naive(f.fs[t][k], x[f.idxs[t][k]...], gamma)
-			fy += fy1
-		end
-	end
-	return y, fy
+    fy = 0
+    y = similar(x)
+    for t in eachindex(f.fs)
+        for k in eachindex(f.fs[t])
+            y[f.idxs[t][k]...], fy1 = prox_naive(f.fs[t][k], x[f.idxs[t][k]...], gamma)
+            fy += fy1
+        end
+    end
+    return y, fy
 end

--- a/src/calculus/sqrDistL2.jl
+++ b/src/calculus/sqrDistL2.jl
@@ -5,7 +5,7 @@ export SqrDistL2
 """
 **Squared distance from a convex set**
 
-	SqrDistL2(ind_S, λ=1.0)
+    SqrDistL2(ind_S, λ=1.0)
 
 Given `ind_S` the indicator function of a convex set ``S``, and an optional positive parameter `λ`, returns the (weighted) squared Euclidean distance from ``S``, that is function
 ```math
@@ -13,18 +13,18 @@ g(x) = \\tfrac{λ}{2}\\mathrm{dist}_S^2(x) = \\min \\left\\{ \\tfrac{λ}{2}\\|y 
 ```
 """
 struct SqrDistL2{R <: Real, T <: ProximableFunction} <: ProximableFunction
-	ind::T
-	lambda::R
-	function SqrDistL2{R,T}(ind::T, lambda::R) where {R <: Real, T<:ProximableFunction}
-		if !is_convex(ind) || !is_set(ind)
-			error("`ind` must be the indicator of a convex set")
-		end
-		if lambda < 0
-			error("parameter λ must be nonnegative")
-		else
-			new(ind, lambda)
-		end
-	end
+    ind::T
+    lambda::R
+    function SqrDistL2{R,T}(ind::T, lambda::R) where {R <: Real, T<:ProximableFunction}
+        if !is_convex(ind) || !is_set(ind)
+            error("`ind` must be the indicator of a convex set")
+        end
+        if lambda < 0
+            error("parameter λ must be nonnegative")
+        else
+            new(ind, lambda)
+        end
+    end
 end
 
 is_prox_accurate(f::SqrDistL2) = is_prox_accurate(f.ind)
@@ -36,26 +36,26 @@ is_strongly_convex(f::SqrDistL2) = is_singleton(f.ind)
 SqrDistL2(ind::T, lambda::R=1.0) where {R <: Real, T <: ProximableFunction} = SqrDistL2{R, T}(ind, lambda)
 
 function (f::SqrDistL2)(x::AbstractArray{T}) where T <: RealOrComplex
-	p, = prox(f.ind, x)
-	return (f.lambda/2)*normdiff2(x,p)
+    p, = prox(f.ind, x)
+    return (f.lambda/2)*normdiff2(x,p)
 end
 
 function prox!(y::AbstractArray{T}, f::SqrDistL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	p, = prox(f.ind, x)
-	sqrd = (f.lambda/2)*normdiff2(x,p)
-	c1 = 1/(1+f.lambda*gamma)
-	c2 = f.lambda*gamma*c1
-	for k in eachindex(p)
-		y[k] = c1*x[k] + c2*p[k]
-	end
-	return sqrd*c1^2
+    p, = prox(f.ind, x)
+    sqrd = (f.lambda/2)*normdiff2(x,p)
+    c1 = 1/(1+f.lambda*gamma)
+    c2 = f.lambda*gamma*c1
+    for k in eachindex(p)
+        y[k] = c1*x[k] + c2*p[k]
+    end
+    return sqrd*c1^2
 end
 
 function gradient!(y::AbstractArray{T}, f::SqrDistL2, x::AbstractArray{T}) where T <: RealOrComplex
-	p, = prox(f.ind, x)
-	dist2 = normdiff2(x,p)
-	y .= f.lambda.*(x .- p)
-	return (f.lambda/2)*dist2
+    p, = prox(f.ind, x)
+    dist2 = normdiff2(x,p)
+    y .= f.lambda.*(x .- p)
+    return (f.lambda/2)*dist2
 end
 
 fun_name(f::SqrDistL2) = "squared Euclidean distance from a convex set"
@@ -64,8 +64,8 @@ fun_expr(f::SqrDistL2) = "x ↦ (λ/2) inf { ||x-y||^2 : y ∈ S} "
 fun_params(f::SqrDistL2) = string("λ = $(f.lambda), S = ", typeof(f.ind))
 
 function prox_naive(f::SqrDistL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	p, = prox(f.ind, x)
-	sqrd = (f.lambda/2)*norm(x-p)^2
-	gamlam = f.lambda*gamma
-	return 1/(1+gamlam)*x + gamlam/(1+gamlam)*p, sqrd/(1+gamlam)^2
+    p, = prox(f.ind, x)
+    sqrd = (f.lambda/2)*norm(x-p)^2
+    gamlam = f.lambda*gamma
+    return 1/(1+gamlam)*x + gamlam/(1+gamlam)*p, sqrd/(1+gamlam)^2
 end

--- a/src/calculus/sqrDistL2.jl
+++ b/src/calculus/sqrDistL2.jl
@@ -5,7 +5,7 @@ export SqrDistL2
 """
 **Squared distance from a convex set**
 
-    SqrDistL2(ind_S, λ=1.0)
+	SqrDistL2(ind_S, λ=1.0)
 
 Given `ind_S` the indicator function of a convex set ``S``, and an optional positive parameter `λ`, returns the (weighted) squared Euclidean distance from ``S``, that is function
 ```math
@@ -13,18 +13,18 @@ g(x) = \\tfrac{λ}{2}\\mathrm{dist}_S^2(x) = \\min \\left\\{ \\tfrac{λ}{2}\\|y 
 ```
 """
 struct SqrDistL2{R <: Real, T <: ProximableFunction} <: ProximableFunction
-  ind::T
-  lambda::R
-  function SqrDistL2{R,T}(ind::T, lambda::R) where {R <: Real, T<:ProximableFunction}
-    if !is_convex(ind) || !is_set(ind)
-      error("`ind` must be the indicator of a convex set")
-    end
-    if lambda < 0
-      error("parameter λ must be nonnegative")
-    else
-      new(ind, lambda)
-    end
-  end
+	ind::T
+	lambda::R
+	function SqrDistL2{R,T}(ind::T, lambda::R) where {R <: Real, T<:ProximableFunction}
+		if !is_convex(ind) || !is_set(ind)
+			error("`ind` must be the indicator of a convex set")
+		end
+		if lambda < 0
+			error("parameter λ must be nonnegative")
+		else
+			new(ind, lambda)
+		end
+	end
 end
 
 is_prox_accurate(f::SqrDistL2) = is_prox_accurate(f.ind)
@@ -36,26 +36,26 @@ is_strongly_convex(f::SqrDistL2) = is_singleton(f.ind)
 SqrDistL2(ind::T, lambda::R=1.0) where {R <: Real, T <: ProximableFunction} = SqrDistL2{R, T}(ind, lambda)
 
 function (f::SqrDistL2)(x::AbstractArray{T}) where T <: RealOrComplex
-  p, = prox(f.ind, x)
-  return (f.lambda/2)*normdiff2(x,p)
+	p, = prox(f.ind, x)
+	return (f.lambda/2)*normdiff2(x,p)
 end
 
 function prox!(y::AbstractArray{T}, f::SqrDistL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-  p, = prox(f.ind, x)
-  sqrd = (f.lambda/2)*normdiff2(x,p)
-  c1 = 1/(1+f.lambda*gamma)
-  c2 = f.lambda*gamma*c1
-  for k in eachindex(p)
-    y[k] = c1*x[k] + c2*p[k]
-  end
-  return sqrd*c1^2
+	p, = prox(f.ind, x)
+	sqrd = (f.lambda/2)*normdiff2(x,p)
+	c1 = 1/(1+f.lambda*gamma)
+	c2 = f.lambda*gamma*c1
+	for k in eachindex(p)
+		y[k] = c1*x[k] + c2*p[k]
+	end
+	return sqrd*c1^2
 end
 
 function gradient!(y::AbstractArray{T}, f::SqrDistL2, x::AbstractArray{T}) where T <: RealOrComplex
-  p, = prox(f.ind, x)
-  dist2 = normdiff2(x,p)
-  y .= f.lambda.*(x .- p)
-  return (f.lambda/2)*dist2
+	p, = prox(f.ind, x)
+	dist2 = normdiff2(x,p)
+	y .= f.lambda.*(x .- p)
+	return (f.lambda/2)*dist2
 end
 
 fun_name(f::SqrDistL2) = "squared Euclidean distance from a convex set"
@@ -64,8 +64,8 @@ fun_expr(f::SqrDistL2) = "x ↦ (λ/2) inf { ||x-y||^2 : y ∈ S} "
 fun_params(f::SqrDistL2) = string("λ = $(f.lambda), S = ", typeof(f.ind))
 
 function prox_naive(f::SqrDistL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-  p, = prox(f.ind, x)
-  sqrd = (f.lambda/2)*norm(x-p)^2
-  gamlam = f.lambda*gamma
-  return 1/(1+gamlam)*x + gamlam/(1+gamlam)*p, sqrd/(1+gamlam)^2
+	p, = prox(f.ind, x)
+	sqrd = (f.lambda/2)*norm(x-p)^2
+	gamlam = f.lambda*gamma
+	return 1/(1+gamlam)*x + gamlam/(1+gamlam)*p, sqrd/(1+gamlam)^2
 end

--- a/src/calculus/sqrDistL2.jl
+++ b/src/calculus/sqrDistL2.jl
@@ -40,7 +40,7 @@ function (f::SqrDistL2)(x::AbstractArray{T}) where T <: RealOrComplex
 	return (f.lambda/2)*normdiff2(x,p)
 end
 
-function prox!(y::AbstractArray{T}, f::SqrDistL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::SqrDistL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	p, = prox(f.ind, x)
 	sqrd = (f.lambda/2)*normdiff2(x,p)
 	c1 = 1/(1+f.lambda*gamma)
@@ -63,7 +63,7 @@ fun_dom(f::SqrDistL2) = fun_dom(f.ind)
 fun_expr(f::SqrDistL2) = "x ↦ (λ/2) inf { ||x-y||^2 : y ∈ S} "
 fun_params(f::SqrDistL2) = string("λ = $(f.lambda), S = ", typeof(f.ind))
 
-function prox_naive(f::SqrDistL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::SqrDistL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	p, = prox(f.ind, x)
 	sqrd = (f.lambda/2)*norm(x-p)^2
 	gamlam = f.lambda*gamma

--- a/src/calculus/sqrDistL2.jl
+++ b/src/calculus/sqrDistL2.jl
@@ -40,7 +40,7 @@ function (f::SqrDistL2)(x::AbstractArray{T}) where T <: RealOrComplex
 	return (f.lambda/2)*normdiff2(x,p)
 end
 
-function prox!(y::AbstractArray{T}, f::SqrDistL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
+function prox!(y::AbstractArray{T}, f::SqrDistL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	p, = prox(f.ind, x)
 	sqrd = (f.lambda/2)*normdiff2(x,p)
 	c1 = 1/(1+f.lambda*gamma)
@@ -63,7 +63,7 @@ fun_dom(f::SqrDistL2) = fun_dom(f.ind)
 fun_expr(f::SqrDistL2) = "x ↦ (λ/2) inf { ||x-y||^2 : y ∈ S} "
 fun_params(f::SqrDistL2) = string("λ = $(f.lambda), S = ", typeof(f.ind))
 
-function prox_naive(f::SqrDistL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
+function prox_naive(f::SqrDistL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	p, = prox(f.ind, x)
 	sqrd = (f.lambda/2)*norm(x-p)^2
 	gamlam = f.lambda*gamma

--- a/src/calculus/sum.jl
+++ b/src/calculus/sum.jl
@@ -32,7 +32,7 @@ is_generalized_quadratic(f::Sum) = all(is_generalized_quadratic.(f.fs))
 is_strongly_convex(f::Sum) = all(is_convex.(f.fs)) && any(is_strongly_convex.(f.fs))
 
 function (sumobj::Sum)(x::AbstractArray{T}) where {R <: Real, T <: Union{R, Complex{R}}}
-	sum = zero(R)
+	sum = R(0)
 	for f in sumobj.fs
 		sum += f(x)
 	end
@@ -41,10 +41,10 @@ end
 
 function gradient!(grad::AbstractArray{T}, sumobj::Sum, x::AbstractArray{T}) where {R <: Real, T <: Union{R, Complex{R}}}
 	# gradient of sum is sum of gradients
-	val = zero(R)
+	val = R(0)
 	# to keep track of this sum, i may not be able to
 	# avoid allocating an array
-	grad .= zero(T)
+	grad .= T(0)
 	temp = similar(grad)
 	for f in sumobj.fs
 		val += gradient!(temp, f, x)

--- a/src/calculus/sum.jl
+++ b/src/calculus/sum.jl
@@ -3,7 +3,7 @@ export Sum
 """
 **Sum of functions**
 
-    Sum(f₁,…,fₖ)
+	Sum(f₁,…,fₖ)
 
 Given functions `f₁` to `fₖ`, returns their sum
 
@@ -32,25 +32,25 @@ is_generalized_quadratic(f::Sum) = all(is_generalized_quadratic.(f.fs))
 is_strongly_convex(f::Sum) = all(is_convex.(f.fs)) && any(is_strongly_convex.(f.fs))
 
 function (sumobj::Sum)(x::AbstractArray{T}) where {R <: Real, T <: Union{R, Complex{R}}}
-    sum = zero(R)
-    for f in sumobj.fs
-        sum += f(x)
-    end
-    sum
+	sum = zero(R)
+	for f in sumobj.fs
+		sum += f(x)
+	end
+	sum
 end
 
 function gradient!(grad::AbstractArray{T}, sumobj::Sum, x::AbstractArray{T}) where {R <: Real, T <: Union{R, Complex{R}}}
-    # gradient of sum is sum of gradients
-    val = zero(R)
-    # to keep track of this sum, i may not be able to
-    # avoid allocating an array
-    grad .= zero(T)
-    temp = similar(grad)
-    for f in sumobj.fs
-        val += gradient!(temp, f, x)
-        grad .+= temp
-    end
-    return val
+	# gradient of sum is sum of gradients
+	val = zero(R)
+	# to keep track of this sum, i may not be able to
+	# avoid allocating an array
+	grad .= zero(T)
+	temp = similar(grad)
+	for f in sumobj.fs
+		val += gradient!(temp, f, x)
+		grad .+= temp
+	end
+	return val
 end
 
 fun_name(f::Sum) = "sum"

--- a/src/calculus/sum.jl
+++ b/src/calculus/sum.jl
@@ -3,7 +3,7 @@ export Sum
 """
 **Sum of functions**
 
-	Sum(f₁,…,fₖ)
+    Sum(f₁,…,fₖ)
 
 Given functions `f₁` to `fₖ`, returns their sum
 
@@ -32,25 +32,25 @@ is_generalized_quadratic(f::Sum) = all(is_generalized_quadratic.(f.fs))
 is_strongly_convex(f::Sum) = all(is_convex.(f.fs)) && any(is_strongly_convex.(f.fs))
 
 function (sumobj::Sum)(x::AbstractArray{T}) where {R <: Real, T <: Union{R, Complex{R}}}
-	sum = R(0)
-	for f in sumobj.fs
-		sum += f(x)
-	end
-	sum
+    sum = R(0)
+    for f in sumobj.fs
+        sum += f(x)
+    end
+    sum
 end
 
 function gradient!(grad::AbstractArray{T}, sumobj::Sum, x::AbstractArray{T}) where {R <: Real, T <: Union{R, Complex{R}}}
-	# gradient of sum is sum of gradients
-	val = R(0)
-	# to keep track of this sum, i may not be able to
-	# avoid allocating an array
-	grad .= T(0)
-	temp = similar(grad)
-	for f in sumobj.fs
-		val += gradient!(temp, f, x)
-		grad .+= temp
-	end
-	return val
+    # gradient of sum is sum of gradients
+    val = R(0)
+    # to keep track of this sum, i may not be able to
+    # avoid allocating an array
+    grad .= T(0)
+    temp = similar(grad)
+    for f in sumobj.fs
+        val += gradient!(temp, f, x)
+        grad .+= temp
+    end
+    return val
 end
 
 fun_name(f::Sum) = "sum"

--- a/src/calculus/tilt.jl
+++ b/src/calculus/tilt.jl
@@ -27,13 +27,13 @@ is_quadratic(f::Tilt) = is_quadratic(f.f)
 is_generalized_quadratic(f::Tilt) = is_generalized_quadratic(f.f)
 is_strongly_convex(f::Tilt) = is_strongly_convex(f.f)
 
-Tilt(f::T, a::S) where {T <: ProximableFunction, S <: AbstractArray} = Tilt{T, S, eltype(a)}(f, a, 0.0)
+Tilt(f::T, a::S) where {R <: Real, T <: ProximableFunction, S <: AbstractArray{R}} = Tilt{T, S, R}(f, a, R(0))
 
 function (g::Tilt)(x::AbstractArray{T}) where T <: RealOrComplex
 	return g.f(x) + dot(g.a, x) + g.b
 end
 
-function prox!(y::AbstractArray{T}, g::Tilt, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
+function prox!(y::AbstractArray{T}, g::Tilt, x::AbstractArray{T}, gamma=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	v = prox!(y, g.f, x .- gamma .* g.a, gamma)
 	return v + dot(g.a, y) + g.b
 end
@@ -43,7 +43,7 @@ fun_dom(f::Tilt) = fun_dom(f.f)
 fun_expr(f::Tilt) = string(fun_expr(f.f)," + a'x + b")
 fun_params(f::Tilt) = "a = $(typeof(f.a)), b = $(f.b)"
 
-function prox_naive(g::Tilt, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
+function prox_naive(g::Tilt, x::AbstractArray{T}, gamma=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	y, v = prox_naive(g.f, x .- gamma .* g.a, gamma)
 	return y, v + dot(g.a, y) + g.b
 end

--- a/src/calculus/tilt.jl
+++ b/src/calculus/tilt.jl
@@ -5,7 +5,7 @@ export Tilt
 """
 **Linear tilting**
 
-	Tilt(f, a, b=0.0)
+    Tilt(f, a, b=0.0)
 
 Given function `f`, an array `a` and a constant `b` (optional), returns function
 ```math
@@ -13,9 +13,9 @@ g(x) = f(x) + \\langle a, x \\rangle + b.
 ```
 """
 struct Tilt{T <: ProximableFunction, S <: AbstractArray, R <: Real} <: ProximableFunction
-	f::T
-	a::S
-	b::R
+    f::T
+    a::S
+    b::R
 end
 
 is_separable(f::Tilt) = is_separable(f.f)
@@ -30,12 +30,12 @@ is_strongly_convex(f::Tilt) = is_strongly_convex(f.f)
 Tilt(f::T, a::S) where {R <: Real, T <: ProximableFunction, S <: AbstractArray{R}} = Tilt{T, S, R}(f, a, R(0))
 
 function (g::Tilt)(x::AbstractArray{T}) where T <: RealOrComplex
-	return g.f(x) + dot(g.a, x) + g.b
+    return g.f(x) + dot(g.a, x) + g.b
 end
 
 function prox!(y::AbstractArray{T}, g::Tilt, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	v = prox!(y, g.f, x .- gamma .* g.a, gamma)
-	return v + dot(g.a, y) + g.b
+    v = prox!(y, g.f, x .- gamma .* g.a, gamma)
+    return v + dot(g.a, y) + g.b
 end
 
 fun_name(f::Tilt) = string("Tilted ", fun_name(f.f))
@@ -44,6 +44,6 @@ fun_expr(f::Tilt) = string(fun_expr(f.f)," + a'x + b")
 fun_params(f::Tilt) = "a = $(typeof(f.a)), b = $(f.b)"
 
 function prox_naive(g::Tilt, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	y, v = prox_naive(g.f, x .- gamma .* g.a, gamma)
-	return y, v + dot(g.a, y) + g.b
+    y, v = prox_naive(g.f, x .- gamma .* g.a, gamma)
+    return y, v + dot(g.a, y) + g.b
 end

--- a/src/calculus/tilt.jl
+++ b/src/calculus/tilt.jl
@@ -5,7 +5,7 @@ export Tilt
 """
 **Linear tilting**
 
-    Tilt(f, a, b=0.0)
+	Tilt(f, a, b=0.0)
 
 Given function `f`, an array `a` and a constant `b` (optional), returns function
 ```math
@@ -13,9 +13,9 @@ g(x) = f(x) + \\langle a, x \\rangle + b.
 ```
 """
 struct Tilt{T <: ProximableFunction, S <: AbstractArray, R <: Real} <: ProximableFunction
-  f::T
-  a::S
-  b::R
+	f::T
+	a::S
+	b::R
 end
 
 is_separable(f::Tilt) = is_separable(f.f)
@@ -30,12 +30,12 @@ is_strongly_convex(f::Tilt) = is_strongly_convex(f.f)
 Tilt(f::T, a::S) where {T <: ProximableFunction, S <: AbstractArray} = Tilt{T, S, eltype(a)}(f, a, 0.0)
 
 function (g::Tilt)(x::AbstractArray{T}) where T <: RealOrComplex
-  return g.f(x) + dot(g.a, x) + g.b
+	return g.f(x) + dot(g.a, x) + g.b
 end
 
 function prox!(y::AbstractArray{T}, g::Tilt, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  v = prox!(y, g.f, x .- gamma .* g.a, gamma)
-  return v + dot(g.a, y) + g.b
+	v = prox!(y, g.f, x .- gamma .* g.a, gamma)
+	return v + dot(g.a, y) + g.b
 end
 
 fun_name(f::Tilt) = string("Tilted ", fun_name(f.f))
@@ -44,6 +44,6 @@ fun_expr(f::Tilt) = string(fun_expr(f.f)," + a'x + b")
 fun_params(f::Tilt) = "a = $(typeof(f.a)), b = $(f.b)"
 
 function prox_naive(g::Tilt, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  y, v = prox_naive(g.f, x .- gamma .* g.a, gamma)
-  return y, v + dot(g.a, y) + g.b
+	y, v = prox_naive(g.f, x .- gamma .* g.a, gamma)
+	return y, v + dot(g.a, y) + g.b
 end

--- a/src/calculus/tilt.jl
+++ b/src/calculus/tilt.jl
@@ -33,7 +33,7 @@ function (g::Tilt)(x::AbstractArray{T}) where T <: RealOrComplex
 	return g.f(x) + dot(g.a, x) + g.b
 end
 
-function prox!(y::AbstractArray{T}, g::Tilt, x::AbstractArray{T}, gamma=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, g::Tilt, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	v = prox!(y, g.f, x .- gamma .* g.a, gamma)
 	return v + dot(g.a, y) + g.b
 end
@@ -43,7 +43,7 @@ fun_dom(f::Tilt) = fun_dom(f.f)
 fun_expr(f::Tilt) = string(fun_expr(f.f)," + a'x + b")
 fun_params(f::Tilt) = "a = $(typeof(f.a)), b = $(f.b)"
 
-function prox_naive(g::Tilt, x::AbstractArray{T}, gamma=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(g::Tilt, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	y, v = prox_naive(g.f, x .- gamma .* g.a, gamma)
 	return y, v + dot(g.a, y) + g.b
 end

--- a/src/calculus/translate.jl
+++ b/src/calculus/translate.jl
@@ -3,7 +3,7 @@ export Translate
 """
 **Translation**
 
-	Translate(f, b)
+    Translate(f, b)
 
 Returns the translated function
 ```math
@@ -11,8 +11,8 @@ g(x) = f(x + b)
 ```
 """
 struct Translate{T <: ProximableFunction, V <: Union{Number, AbstractArray, Tuple}} <: ProximableFunction
-	f::T
-	b::V
+    f::T
+    b::V
 end
 
 is_separable(f::Translate) = is_separable(f.f)
@@ -28,25 +28,25 @@ is_generalized_quadratic(f::Translate) = is_generalized_quadratic(f.f)
 is_strongly_convex(f::Translate) = is_strongly_convex(f.f)
 
 function (g::Translate)(x::T) where {T <: Union{Tuple, AbstractArray}}
-	return g.f(x .+ g.b)
+    return g.f(x .+ g.b)
 end
 
 function gradient!(y, g::Translate, x)
-	z = x .+ g.b
-	v = gradient!(y, g.f, z)
-	return v
+    z = x .+ g.b
+    v = gradient!(y, g.f, z)
+    return v
 end
 
 function prox!(y, g::Translate, x, gamma=1.0)
-	z = x .+ g.b
-	v = prox!(y, g.f, z, gamma)
-	y .-= g.b
-	return v
+    z = x .+ g.b
+    v = prox!(y, g.f, z, gamma)
+    y .-= g.b
+    return v
 end
 
 function prox_naive(g::Translate, x, gamma=1.0)
-	y, v = prox_naive(g.f, x .+ g.b, gamma)
-	return y - g.b, v
+    y, v = prox_naive(g.f, x .+ g.b, gamma)
+    return y - g.b, v
 end
 
 fun_name(f::Translate) = "Translation"

--- a/src/calculus/translate.jl
+++ b/src/calculus/translate.jl
@@ -3,7 +3,7 @@ export Translate
 """
 **Translation**
 
-    Translate(f, b)
+	Translate(f, b)
 
 Returns the translated function
 ```math
@@ -11,8 +11,8 @@ g(x) = f(x + b)
 ```
 """
 struct Translate{T <: ProximableFunction, V <: Union{Number, AbstractArray, Tuple}} <: ProximableFunction
-  f::T
-  b::V
+	f::T
+	b::V
 end
 
 is_separable(f::Translate) = is_separable(f.f)
@@ -28,25 +28,25 @@ is_generalized_quadratic(f::Translate) = is_generalized_quadratic(f.f)
 is_strongly_convex(f::Translate) = is_strongly_convex(f.f)
 
 function (g::Translate)(x::T) where {T <: Union{Tuple, AbstractArray}}
-  return g.f(x .+ g.b)
+	return g.f(x .+ g.b)
 end
 
 function gradient!(y, g::Translate, x)
-  z = x .+ g.b
-  v = gradient!(y, g.f, z)
-  return v
+	z = x .+ g.b
+	v = gradient!(y, g.f, z)
+	return v
 end
 
 function prox!(y, g::Translate, x, gamma=1.0)
-  z = x .+ g.b
-  v = prox!(y, g.f, z, gamma)
-  y .-= g.b
-  return v
+	z = x .+ g.b
+	v = prox!(y, g.f, z, gamma)
+	y .-= g.b
+	return v
 end
 
 function prox_naive(g::Translate, x, gamma=1.0)
-  y, v = prox_naive(g.f, x .+ g.b, gamma)
-  return y - g.b, v
+	y, v = prox_naive(g.f, x .+ g.b, gamma)
+	return y - g.b, v
 end
 
 fun_name(f::Translate) = "Translation"

--- a/src/functions/crossEntropy.jl
+++ b/src/functions/crossEntropy.jl
@@ -5,7 +5,7 @@ export CrossEntropy
 """
 **Cross Entropy loss**
 
-CrossEntropy(b)
+	CrossEntropy(b)
 
 Returns the function
 ```math

--- a/src/functions/crossEntropy.jl
+++ b/src/functions/crossEntropy.jl
@@ -30,7 +30,7 @@ is_smooth(f::CrossEntropy) = true
 CrossEntropy(b::T) where {R <: Real, T <: AbstractArray{R}} = CrossEntropy{R, T}(b)
 
 function (f::CrossEntropy{R})(x::AbstractArray{R}) where {R <: Real}
-	sum = zero(R)
+	sum = R(0)
 	for i in eachindex(f.b)
 		sum += f.b[i]*log(x[i])+(1-f.b[i])*log(1-x[i])
 	end
@@ -38,7 +38,7 @@ function (f::CrossEntropy{R})(x::AbstractArray{R}) where {R <: Real}
 end
 
 function (f::CrossEntropy{B})(x::AbstractArray{R}) where {B <: Bool, R <: Real}
-	sum = zero(R)
+	sum = R(0)
 	for i in eachindex(f.b)
 		sum += f.b[i] ? log(x[i]) : (1-f.b[i])*log(1-x[i])
 	end
@@ -46,7 +46,7 @@ function (f::CrossEntropy{B})(x::AbstractArray{R}) where {B <: Bool, R <: Real}
 end
 
 function gradient!(y::AbstractArray{R}, f::CrossEntropy{R}, x::AbstractArray{R}) where {R <: Real}
-	sum = zero(R)
+	sum = R(0)
 	for i in eachindex(x)
 		y[i] = 1/length(f.b)*( - f.b[i]/x[i] + (1-f.b[i])/(1-x[i]) )
 		sum += f.b[i]*log(x[i])+(1-f.b[i])*log(1-x[i])
@@ -55,7 +55,7 @@ function gradient!(y::AbstractArray{R}, f::CrossEntropy{R}, x::AbstractArray{R})
 end
 
 function gradient!(y::AbstractArray{R}, f::CrossEntropy{B}, x::AbstractArray{R}) where {R <: Real, B <: Bool}
-	sum = zero(R)
+	sum = R(0)
 	for i in eachindex(x)
 		y[i] = f.b[i] ? - 1/x[i] : 1/(1-x[i])
 		y[i] *= 1/length(f.b)
@@ -64,7 +64,7 @@ function gradient!(y::AbstractArray{R}, f::CrossEntropy{B}, x::AbstractArray{R})
 	return -1/length(f.b)*sum
 end
 
-function prox!(y::AbstractArray{R}, f::CrossEntropy, x::AbstractArray{R}, gamma::R=one(R)) where {R}
+function prox!(y::AbstractArray{R}, f::CrossEntropy, x::AbstractArray{R}, gamma::R=R(1)) where {R}
     # TODO: fill-in here
     error("not implemented")
 end

--- a/src/functions/crossEntropy.jl
+++ b/src/functions/crossEntropy.jl
@@ -5,7 +5,7 @@ export CrossEntropy
 """
 **Cross Entropy loss**
 
-	CrossEntropy(b)
+    CrossEntropy(b)
 
 Returns the function
 ```math
@@ -14,14 +14,14 @@ f(x) = -1/N \\sum_{n = 1}^{N} b \\log (x)+(1-b) \\log (1-x),
 where `b` is an array with `0 ≤ b ≤ 1`.
 """
 struct CrossEntropy{R <: Real, T <: AbstractArray{R}} <: ProximableFunction
-	b::T
-	function CrossEntropy{R, T}(b::T) where {R <: Real, T <: AbstractArray{R}}
-		if !(all(0 .<= b .<= 1. ))
-			error("b must be 0 ≤ b ≤ 1 ")
-		else
-			new(b)
-		end
-	end
+    b::T
+    function CrossEntropy{R, T}(b::T) where {R <: Real, T <: AbstractArray{R}}
+        if !(all(0 .<= b .<= 1. ))
+            error("b must be 0 ≤ b ≤ 1 ")
+        else
+            new(b)
+        end
+    end
 end
 
 is_convex(f::CrossEntropy) = true
@@ -30,38 +30,38 @@ is_smooth(f::CrossEntropy) = true
 CrossEntropy(b::T) where {R <: Real, T <: AbstractArray{R}} = CrossEntropy{R, T}(b)
 
 function (f::CrossEntropy{R})(x::AbstractArray{R}) where {R <: Real}
-	sum = R(0)
-	for i in eachindex(f.b)
-		sum += f.b[i]*log(x[i])+(1-f.b[i])*log(1-x[i])
-	end
-	return -sum/length(f.b)
+    sum = R(0)
+    for i in eachindex(f.b)
+        sum += f.b[i]*log(x[i])+(1-f.b[i])*log(1-x[i])
+    end
+    return -sum/length(f.b)
 end
 
 function (f::CrossEntropy{B})(x::AbstractArray{R}) where {B <: Bool, R <: Real}
-	sum = R(0)
-	for i in eachindex(f.b)
-		sum += f.b[i] ? log(x[i]) : (1-f.b[i])*log(1-x[i])
-	end
-	return -sum/length(f.b)
+    sum = R(0)
+    for i in eachindex(f.b)
+        sum += f.b[i] ? log(x[i]) : (1-f.b[i])*log(1-x[i])
+    end
+    return -sum/length(f.b)
 end
 
 function gradient!(y::AbstractArray{R}, f::CrossEntropy{R}, x::AbstractArray{R}) where {R <: Real}
-	sum = R(0)
-	for i in eachindex(x)
-		y[i] = 1/length(f.b)*( - f.b[i]/x[i] + (1-f.b[i])/(1-x[i]) )
-		sum += f.b[i]*log(x[i])+(1-f.b[i])*log(1-x[i])
-	end
-	return -1/length(f.b)*sum
+    sum = R(0)
+    for i in eachindex(x)
+        y[i] = 1/length(f.b)*( - f.b[i]/x[i] + (1-f.b[i])/(1-x[i]) )
+        sum += f.b[i]*log(x[i])+(1-f.b[i])*log(1-x[i])
+    end
+    return -1/length(f.b)*sum
 end
 
 function gradient!(y::AbstractArray{R}, f::CrossEntropy{B}, x::AbstractArray{R}) where {R <: Real, B <: Bool}
-	sum = R(0)
-	for i in eachindex(x)
-		y[i] = f.b[i] ? - 1/x[i] : 1/(1-x[i])
-		y[i] *= 1/length(f.b)
-		sum += f.b[i] ? log(x[i]) : log(1-x[i])
-	end
-	return -1/length(f.b)*sum
+    sum = R(0)
+    for i in eachindex(x)
+        y[i] = f.b[i] ? - 1/x[i] : 1/(1-x[i])
+        y[i] *= 1/length(f.b)
+        sum += f.b[i] ? log(x[i]) : log(1-x[i])
+    end
+    return -1/length(f.b)*sum
 end
 
 function prox!(y::AbstractArray{R}, f::CrossEntropy, x::AbstractArray{R}, gamma::R=R(1)) where {R}

--- a/src/functions/cubeNormL2.jl
+++ b/src/functions/cubeNormL2.jl
@@ -5,7 +5,7 @@ export CubeNormL2
 """
 **Cubic Euclidean norm (weighted)**
 
-	CubeNormL2(λ=1.0)
+    CubeNormL2(λ=1.0)
 
 With a nonnegative scalar `λ`, returns the function
 ```math
@@ -13,14 +13,14 @@ f(x) = λ\\|x\\|^3.
 ```
 """
 struct CubeNormL2{R <: Real} <: ProximableFunction
-	lambda::R
-	function CubeNormL2{R}(lambda::R) where R
-		if lambda < 0
-			error("coefficient λ must be nonnegative")
-		else
-			new(lambda)
-		end
-	end
+    lambda::R
+    function CubeNormL2{R}(lambda::R) where R
+        if lambda < 0
+            error("coefficient λ must be nonnegative")
+        else
+            new(lambda)
+        end
+    end
 end
 
 is_convex(f::CubeNormL2) = true
@@ -29,23 +29,23 @@ is_smooth(f::CubeNormL2) = true
 CubeNormL2(lambda::R=1.0) where {R <: Real} = CubeNormL2{R}(lambda)
 
 function (f::CubeNormL2{R})(x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-	return f.lambda * norm(x)^3
+    return f.lambda * norm(x)^3
 end
 
 function gradient!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-	norm_x = norm(x)
-	y .= (3 * f.lambda * norm_x) .* x
-	return f.lambda * norm_x^3
+    norm_x = norm(x)
+    y .= (3 * f.lambda * norm_x) .* x
+    return f.lambda * norm_x^3
 end
 
 function prox!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}, gamma::R=R(1)) where {R, T <: RealOrComplex{R}}
-	norm_x = norm(x)
-	scale = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm_x))
-	y .= scale .* x
-	return f.lambda * (scale * norm_x)^3
+    norm_x = norm(x)
+    scale = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm_x))
+    y .= scale .* x
+    return f.lambda * (scale * norm_x)^3
 end
 
 function prox_naive(f::CubeNormL2{R}, x::AbstractArray{T}, gamma=R(1)) where {R, T <: RealOrComplex{R}}
-	y = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm(x))) * x
-	return y, f.lambda * norm(y)^3
+    y = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm(x))) * x
+    return y, f.lambda * norm(y)^3
 end

--- a/src/functions/cubeNormL2.jl
+++ b/src/functions/cubeNormL2.jl
@@ -5,7 +5,7 @@ export CubeNormL2
 """
 **Cubic Euclidean norm (weighted)**
 
-    CubeNormL2(λ=1.0)
+	CubeNormL2(λ=1.0)
 
 With a nonnegative scalar `λ`, returns the function
 ```math
@@ -13,14 +13,14 @@ f(x) = λ\\|x\\|^3.
 ```
 """
 struct CubeNormL2{R <: Real} <: ProximableFunction
-    lambda::R
-    function CubeNormL2{R}(lambda::R) where R
-        if lambda < 0
-            error("coefficient λ must be nonnegative")
-        else
-            new(lambda)
-        end
-    end
+	lambda::R
+	function CubeNormL2{R}(lambda::R) where R
+		if lambda < 0
+			error("coefficient λ must be nonnegative")
+		else
+			new(lambda)
+		end
+	end
 end
 
 is_convex(f::CubeNormL2) = true
@@ -29,23 +29,23 @@ is_smooth(f::CubeNormL2) = true
 CubeNormL2(lambda::R=1.0) where {R <: Real} = CubeNormL2{R}(lambda)
 
 function (f::CubeNormL2{R})(x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-    return f.lambda * norm(x)^3
+	return f.lambda * norm(x)^3
 end
 
 function gradient!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-    norm_x = norm(x)
-    y .= (3 * f.lambda * norm_x) .* x
-    return f.lambda * norm_x^3
+	norm_x = norm(x)
+	y .= (3 * f.lambda * norm_x) .* x
+	return f.lambda * norm_x^3
 end
 
 function prox!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R, T <: RealOrComplex{R}}
-    norm_x = norm(x)
-    scale = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm_x))
-    y .= scale .* x
-    return f.lambda * (scale * norm_x)^3
+	norm_x = norm(x)
+	scale = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm_x))
+	y .= scale .* x
+	return f.lambda * (scale * norm_x)^3
 end
 
 function prox_naive(f::CubeNormL2{R}, x::AbstractArray{T}, gamma=one(R)) where {R, T <: RealOrComplex{R}}
-  y = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm(x))) * x
-  return y, f.lambda * norm(y)^3
+	y = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm(x))) * x
+	return y, f.lambda * norm(y)^3
 end

--- a/src/functions/cubeNormL2.jl
+++ b/src/functions/cubeNormL2.jl
@@ -38,14 +38,14 @@ function gradient!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}) w
 	return f.lambda * norm_x^3
 end
 
-function prox!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::CubeNormL2{R}, x::AbstractArray{T}, gamma::R=R(1)) where {R, T <: RealOrComplex{R}}
 	norm_x = norm(x)
 	scale = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm_x))
 	y .= scale .* x
 	return f.lambda * (scale * norm_x)^3
 end
 
-function prox_naive(f::CubeNormL2{R}, x::AbstractArray{T}, gamma=one(R)) where {R, T <: RealOrComplex{R}}
+function prox_naive(f::CubeNormL2{R}, x::AbstractArray{T}, gamma=R(1)) where {R, T <: RealOrComplex{R}}
 	y = 2 / (1 + sqrt(1 + 12 * gamma * f.lambda * norm(x))) * x
 	return y, f.lambda * norm(y)^3
 end

--- a/src/functions/elasticNet.jl
+++ b/src/functions/elasticNet.jl
@@ -5,7 +5,7 @@ export ElasticNet
 """
 **Elastic-net regularization**
 
-    ElasticNet(μ=1.0, λ=1.0)
+	ElasticNet(μ=1.0, λ=1.0)
 
 Returns the function
 ```math
@@ -14,15 +14,15 @@ f(x) = μ\\|x\\|_1 + (λ/2)\\|x\\|^2,
 for nonnegative parameters `μ` and `λ`.
 """
 struct ElasticNet{R <: Real} <: ProximableFunction
-  mu::R
-  lambda::R
-  function ElasticNet{R}(mu::R, lambda::R) where {R <: Real}
-    if lambda < 0 || mu < 0
-      error("parameters `μ` and `λ` must be nonnegative")
-    else
-      new(mu, lambda)
-    end
-  end
+	mu::R
+	lambda::R
+	function ElasticNet{R}(mu::R, lambda::R) where {R <: Real}
+		if lambda < 0 || mu < 0
+			error("parameters `μ` and `λ` must be nonnegative")
+		else
+			new(mu, lambda)
+		end
+	end
 end
 
 is_separable(f::ElasticNet) = true
@@ -32,67 +32,67 @@ is_convex(f::ElasticNet) = true
 ElasticNet(mu::R=1.0, lambda::R=1.0) where {R <: Real} = ElasticNet{R}(mu, lambda)
 
 function (f::ElasticNet)(x::AbstractArray{R}) where R <: RealOrComplex
-  return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
+	return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
 end
 
 function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma::R=one(R)) where R <: Real
-  sqnorm2x = zero(R)
-  norm1x = zero(R)
-  gm = gamma*f.mu
-  gl = gamma*f.lambda
-  for i in eachindex(x)
-    y[i] = (x[i] + (x[i] <= -gm ? gm : (x[i] >= gm ? -gm : -x[i])))/(1 + gl)
-    sqnorm2x += abs2(y[i])
-    norm1x += abs(y[i])
-  end
-  return f.mu*norm1x + (f.lambda/2)*sqnorm2x
+	sqnorm2x = zero(R)
+	norm1x = zero(R)
+	gm = gamma*f.mu
+	gl = gamma*f.lambda
+	for i in eachindex(x)
+		y[i] = (x[i] + (x[i] <= -gm ? gm : (x[i] >= gm ? -gm : -x[i])))/(1 + gl)
+		sqnorm2x += abs2(y[i])
+		norm1x += abs(y[i])
+	end
+	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
 function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma::AbstractArray{R}) where R <: Real
-  sqnorm2x = zero(R)
-  norm1x = zero(R)
-  for i in eachindex(x)
-    gm = gamma[i]*f.mu
-    gl = gamma[i]*f.lambda
-    y[i] = (x[i] + (x[i] <= -gm ? gm : (x[i] >= gm ? -gm : -x[i])))/(1 + gl)
-    sqnorm2x += abs2(y[i])
-    norm1x += abs(y[i])
-  end
-  return f.mu*norm1x + (f.lambda/2)*sqnorm2x
+	sqnorm2x = zero(R)
+	norm1x = zero(R)
+	for i in eachindex(x)
+		gm = gamma[i]*f.mu
+		gl = gamma[i]*f.lambda
+		y[i] = (x[i] + (x[i] <= -gm ? gm : (x[i] >= gm ? -gm : -x[i])))/(1 + gl)
+		sqnorm2x += abs2(y[i])
+		norm1x += abs(y[i])
+	end
+	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::ElasticNet{R}, x::AbstractArray{Complex{R}}, gamma::R=one(R)) where R <: Real
-  sqnorm2x = zero(R)
-  norm1x = zero(R)
-  gm = gamma*f.mu
-  gl = gamma*f.lambda
-  for i in eachindex(x)
-    y[i] = sign(x[i])*max(0, abs(x[i]) - gm)/(1 + gl)
-    sqnorm2x += abs2(y[i])
-    norm1x += abs(y[i])
-  end
-  return f.mu*norm1x + (f.lambda/2)*sqnorm2x
+	sqnorm2x = zero(R)
+	norm1x = zero(R)
+	gm = gamma*f.mu
+	gl = gamma*f.lambda
+	for i in eachindex(x)
+		y[i] = sign(x[i])*max(0, abs(x[i]) - gm)/(1 + gl)
+		sqnorm2x += abs2(y[i])
+		norm1x += abs(y[i])
+	end
+	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::ElasticNet{R}, x::AbstractArray{Complex{R}}, gamma::AbstractArray{R}) where R <: Real
-  sqnorm2x = zero(R)
-  norm1x = zero(R)
-  for i in eachindex(x)
-    gm = gamma[i]*f.mu
-    gl = gamma[i]*f.lambda
-    y[i] = sign(x[i])*max(0, abs(x[i]) - gm)/(1 + gl)
-    sqnorm2x += abs2(y[i])
-    norm1x += abs(y[i])
-  end
-  return f.mu*norm1x + (f.lambda/2)*sqnorm2x
+	sqnorm2x = zero(R)
+	norm1x = zero(R)
+	for i in eachindex(x)
+		gm = gamma[i]*f.mu
+		gl = gamma[i]*f.lambda
+		y[i] = sign(x[i])*max(0, abs(x[i]) - gm)/(1 + gl)
+		sqnorm2x += abs2(y[i])
+		norm1x += abs(y[i])
+	end
+	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
 function gradient!(y::AbstractArray{T}, f::ElasticNet{R}, x::AbstractArray{T}) where {T <: RealOrComplex, R <: Real}
-  # Gradient of 1 norm
-  y .= f.mu.*sign.(x)
-  # Gradient of 2 norm
-  y .+= f.lambda.*x
-  return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
+	# Gradient of 1 norm
+	y .= f.mu.*sign.(x)
+	# Gradient of 2 norm
+	y .+= f.lambda.*x
+	return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
 end
 
 fun_name(f::ElasticNet) = "elastic-net regularization"
@@ -101,11 +101,11 @@ fun_expr(f::ElasticNet) = "x ↦ μ||x||_1 + (λ/2)||x||²"
 fun_params(f::ElasticNet) = "μ = $(f.mu), λ = $(f.lambda)"
 
 function prox_naive(f::ElasticNet, x::AbstractArray{R}, gamma::Real=1.0) where R <: RealOrComplex
-  uz = max.(0, abs.(x) .- gamma*f.mu)/(1 + f.lambda * gamma)
-  return sign.(x) .* uz, f.mu * norm(uz,1) + (f.lambda/2) * norm(uz)^2
+	uz = max.(0, abs.(x) .- gamma*f.mu)/(1 + f.lambda * gamma)
+	return sign.(x) .* uz, f.mu * norm(uz,1) + (f.lambda/2) * norm(uz)^2
 end
 
 function prox_naive(f::ElasticNet, x::AbstractArray{R}, gamma::AbstractArray) where R <: RealOrComplex
-  uz = max.(0, abs.(x) .- gamma.*f.mu)./(1 .+ f.lambda .* gamma)
-  return sign.(x) .* uz, f.mu * norm(uz,1) + (f.lambda/2) * norm(uz)^2
+	uz = max.(0, abs.(x) .- gamma.*f.mu)./(1 .+ f.lambda .* gamma)
+	return sign.(x) .* uz, f.mu * norm(uz,1) + (f.lambda/2) * norm(uz)^2
 end

--- a/src/functions/elasticNet.jl
+++ b/src/functions/elasticNet.jl
@@ -35,9 +35,9 @@ function (f::ElasticNet)(x::AbstractArray{R}) where R <: RealOrComplex
 	return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
 end
 
-function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma::R=one(R)) where R <: Real
-	sqnorm2x = zero(R)
-	norm1x = zero(R)
+function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma::R=R(1)) where R <: Real
+	sqnorm2x = R(0)
+	norm1x = R(0)
 	gm = gamma*f.mu
 	gl = gamma*f.lambda
 	for i in eachindex(x)
@@ -49,8 +49,8 @@ function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma
 end
 
 function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma::AbstractArray{R}) where R <: Real
-	sqnorm2x = zero(R)
-	norm1x = zero(R)
+	sqnorm2x = R(0)
+	norm1x = R(0)
 	for i in eachindex(x)
 		gm = gamma[i]*f.mu
 		gl = gamma[i]*f.lambda
@@ -61,9 +61,9 @@ function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma
 	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
-function prox!(y::AbstractArray{Complex{R}}, f::ElasticNet{R}, x::AbstractArray{Complex{R}}, gamma::R=one(R)) where R <: Real
-	sqnorm2x = zero(R)
-	norm1x = zero(R)
+function prox!(y::AbstractArray{Complex{R}}, f::ElasticNet{R}, x::AbstractArray{Complex{R}}, gamma::R=R(1)) where R <: Real
+	sqnorm2x = R(0)
+	norm1x = R(0)
 	gm = gamma*f.mu
 	gl = gamma*f.lambda
 	for i in eachindex(x)
@@ -75,8 +75,8 @@ function prox!(y::AbstractArray{Complex{R}}, f::ElasticNet{R}, x::AbstractArray{
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::ElasticNet{R}, x::AbstractArray{Complex{R}}, gamma::AbstractArray{R}) where R <: Real
-	sqnorm2x = zero(R)
-	norm1x = zero(R)
+	sqnorm2x = R(0)
+	norm1x = R(0)
 	for i in eachindex(x)
 		gm = gamma[i]*f.mu
 		gl = gamma[i]*f.lambda

--- a/src/functions/elasticNet.jl
+++ b/src/functions/elasticNet.jl
@@ -5,7 +5,7 @@ export ElasticNet
 """
 **Elastic-net regularization**
 
-	ElasticNet(μ=1.0, λ=1.0)
+    ElasticNet(μ=1.0, λ=1.0)
 
 Returns the function
 ```math
@@ -14,15 +14,15 @@ f(x) = μ\\|x\\|_1 + (λ/2)\\|x\\|^2,
 for nonnegative parameters `μ` and `λ`.
 """
 struct ElasticNet{R <: Real} <: ProximableFunction
-	mu::R
-	lambda::R
-	function ElasticNet{R}(mu::R, lambda::R) where {R <: Real}
-		if lambda < 0 || mu < 0
-			error("parameters `μ` and `λ` must be nonnegative")
-		else
-			new(mu, lambda)
-		end
-	end
+    mu::R
+    lambda::R
+    function ElasticNet{R}(mu::R, lambda::R) where {R <: Real}
+        if lambda < 0 || mu < 0
+            error("parameters `μ` and `λ` must be nonnegative")
+        else
+            new(mu, lambda)
+        end
+    end
 end
 
 is_separable(f::ElasticNet) = true
@@ -32,67 +32,67 @@ is_convex(f::ElasticNet) = true
 ElasticNet(mu::R=1.0, lambda::R=1.0) where {R <: Real} = ElasticNet{R}(mu, lambda)
 
 function (f::ElasticNet)(x::AbstractArray{R}) where R <: RealOrComplex
-	return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
+    return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
 end
 
 function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma::R=R(1)) where R <: Real
-	sqnorm2x = R(0)
-	norm1x = R(0)
-	gm = gamma*f.mu
-	gl = gamma*f.lambda
-	for i in eachindex(x)
-		y[i] = (x[i] + (x[i] <= -gm ? gm : (x[i] >= gm ? -gm : -x[i])))/(1 + gl)
-		sqnorm2x += abs2(y[i])
-		norm1x += abs(y[i])
-	end
-	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
+    sqnorm2x = R(0)
+    norm1x = R(0)
+    gm = gamma*f.mu
+    gl = gamma*f.lambda
+    for i in eachindex(x)
+        y[i] = (x[i] + (x[i] <= -gm ? gm : (x[i] >= gm ? -gm : -x[i])))/(1 + gl)
+        sqnorm2x += abs2(y[i])
+        norm1x += abs(y[i])
+    end
+    return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
 function prox!(y::AbstractArray{R}, f::ElasticNet{R}, x::AbstractArray{R}, gamma::AbstractArray{R}) where R <: Real
-	sqnorm2x = R(0)
-	norm1x = R(0)
-	for i in eachindex(x)
-		gm = gamma[i]*f.mu
-		gl = gamma[i]*f.lambda
-		y[i] = (x[i] + (x[i] <= -gm ? gm : (x[i] >= gm ? -gm : -x[i])))/(1 + gl)
-		sqnorm2x += abs2(y[i])
-		norm1x += abs(y[i])
-	end
-	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
+    sqnorm2x = R(0)
+    norm1x = R(0)
+    for i in eachindex(x)
+        gm = gamma[i]*f.mu
+        gl = gamma[i]*f.lambda
+        y[i] = (x[i] + (x[i] <= -gm ? gm : (x[i] >= gm ? -gm : -x[i])))/(1 + gl)
+        sqnorm2x += abs2(y[i])
+        norm1x += abs(y[i])
+    end
+    return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::ElasticNet{R}, x::AbstractArray{Complex{R}}, gamma::R=R(1)) where R <: Real
-	sqnorm2x = R(0)
-	norm1x = R(0)
-	gm = gamma*f.mu
-	gl = gamma*f.lambda
-	for i in eachindex(x)
-		y[i] = sign(x[i])*max(0, abs(x[i]) - gm)/(1 + gl)
-		sqnorm2x += abs2(y[i])
-		norm1x += abs(y[i])
-	end
-	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
+    sqnorm2x = R(0)
+    norm1x = R(0)
+    gm = gamma*f.mu
+    gl = gamma*f.lambda
+    for i in eachindex(x)
+        y[i] = sign(x[i])*max(0, abs(x[i]) - gm)/(1 + gl)
+        sqnorm2x += abs2(y[i])
+        norm1x += abs(y[i])
+    end
+    return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::ElasticNet{R}, x::AbstractArray{Complex{R}}, gamma::AbstractArray{R}) where R <: Real
-	sqnorm2x = R(0)
-	norm1x = R(0)
-	for i in eachindex(x)
-		gm = gamma[i]*f.mu
-		gl = gamma[i]*f.lambda
-		y[i] = sign(x[i])*max(0, abs(x[i]) - gm)/(1 + gl)
-		sqnorm2x += abs2(y[i])
-		norm1x += abs(y[i])
-	end
-	return f.mu*norm1x + (f.lambda/2)*sqnorm2x
+    sqnorm2x = R(0)
+    norm1x = R(0)
+    for i in eachindex(x)
+        gm = gamma[i]*f.mu
+        gl = gamma[i]*f.lambda
+        y[i] = sign(x[i])*max(0, abs(x[i]) - gm)/(1 + gl)
+        sqnorm2x += abs2(y[i])
+        norm1x += abs(y[i])
+    end
+    return f.mu*norm1x + (f.lambda/2)*sqnorm2x
 end
 
 function gradient!(y::AbstractArray{T}, f::ElasticNet{R}, x::AbstractArray{T}) where {T <: RealOrComplex, R <: Real}
-	# Gradient of 1 norm
-	y .= f.mu.*sign.(x)
-	# Gradient of 2 norm
-	y .+= f.lambda.*x
-	return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
+    # Gradient of 1 norm
+    y .= f.mu.*sign.(x)
+    # Gradient of 2 norm
+    y .+= f.lambda.*x
+    return f.mu*norm(x,1) + (f.lambda/2)*norm(x,2)^2
 end
 
 fun_name(f::ElasticNet) = "elastic-net regularization"
@@ -101,11 +101,11 @@ fun_expr(f::ElasticNet) = "x ↦ μ||x||_1 + (λ/2)||x||²"
 fun_params(f::ElasticNet) = "μ = $(f.mu), λ = $(f.lambda)"
 
 function prox_naive(f::ElasticNet, x::AbstractArray{R}, gamma::Real=1.0) where R <: RealOrComplex
-	uz = max.(0, abs.(x) .- gamma*f.mu)/(1 + f.lambda * gamma)
-	return sign.(x) .* uz, f.mu * norm(uz,1) + (f.lambda/2) * norm(uz)^2
+    uz = max.(0, abs.(x) .- gamma*f.mu)/(1 + f.lambda * gamma)
+    return sign.(x) .* uz, f.mu * norm(uz,1) + (f.lambda/2) * norm(uz)^2
 end
 
 function prox_naive(f::ElasticNet, x::AbstractArray{R}, gamma::AbstractArray) where R <: RealOrComplex
-	uz = max.(0, abs.(x) .- gamma.*f.mu)./(1 .+ f.lambda .* gamma)
-	return sign.(x) .* uz, f.mu * norm(uz,1) + (f.lambda/2) * norm(uz)^2
+    uz = max.(0, abs.(x) .- gamma.*f.mu)./(1 .+ f.lambda .* gamma)
+    return sign.(x) .* uz, f.mu * norm(uz,1) + (f.lambda/2) * norm(uz)^2
 end

--- a/src/functions/hingeLoss.jl
+++ b/src/functions/hingeLoss.jl
@@ -5,7 +5,7 @@ export HingeLoss
 """
 **Hinge loss**
 
-  HingeLoss(y, μ=1.0)
+	HingeLoss(y, μ=1.0)
 
 Returns the function
 ```math

--- a/src/functions/hingeLoss.jl
+++ b/src/functions/hingeLoss.jl
@@ -5,7 +5,7 @@ export HingeLoss
 """
 **Hinge loss**
 
-	HingeLoss(y, μ=1.0)
+    HingeLoss(y, μ=1.0)
 
 Returns the function
 ```math

--- a/src/functions/huberLoss.jl
+++ b/src/functions/huberLoss.jl
@@ -7,27 +7,27 @@ export HuberLoss
 """
 **Huber loss**
 
-    HuberLoss(ρ=1.0, μ=1.0)
+	HuberLoss(ρ=1.0, μ=1.0)
 
 Returns the function
 ```math
 f(x) = \\begin{cases}
-  \\tfrac{μ}{2}\\|x\\|^2 & \\text{if}\\ \\|x\\| ⩽ ρ \\\\
-  ρμ(\\|x\\| - \\tfrac{ρ}{2}) & \\text{otherwise},
+	\\tfrac{μ}{2}\\|x\\|^2 & \\text{if}\\ \\|x\\| ⩽ ρ \\\\
+	ρμ(\\|x\\| - \\tfrac{ρ}{2}) & \\text{otherwise},
 \\end{cases}
 ```
 where `ρ` and `μ` are positive parameters.
 """
 struct HuberLoss{R <: Real} <: ProximableFunction
-  rho::R
-  mu::R
-  function HuberLoss{R}(rho::R, mu::R) where {R <: Real}
-    if rho <= 0.0 || mu <= 0.0
-      error("parameters rho and mu must be positive")
-    else
-      new(rho, mu)
-    end
-  end
+	rho::R
+	mu::R
+	function HuberLoss{R}(rho::R, mu::R) where {R <: Real}
+		if rho <= 0.0 || mu <= 0.0
+			error("parameters rho and mu must be positive")
+		else
+			new(rho, mu)
+		end
+	end
 end
 
 is_convex(f::HuberLoss) = true
@@ -36,39 +36,39 @@ is_smooth(f::HuberLoss) = true
 HuberLoss(rho::R=1.0, mu::R=1.0) where {R <: Real} = HuberLoss{R}(rho, mu)
 
 function (f::HuberLoss)(x::AbstractArray{T}) where T <: Union{Real, Complex}
-  normx = norm(x)
-  if normx <= f.rho
-    return (f.mu/2)*normx^2
-  else
-    return f.rho*f.mu*(normx-f.rho/2)
-  end
+	normx = norm(x)
+	if normx <= f.rho
+		return (f.mu/2)*normx^2
+	else
+		return f.rho*f.mu*(normx-f.rho/2)
+	end
 end
 
 function gradient!(y::AbstractArray{T}, f::HuberLoss, x::AbstractArray{T}) where T <: Union{Real, Complex}
-  normx = norm(x)
-  if normx <= f.rho
-    y .= f.mu .* x
-    v = (f.mu/2)*normx^2
-  else
-    y .= (f.mu*f.rho)/normx .* x
-    v = f.rho*f.mu*(normx-f.rho/2)
-  end
-  return v
+	normx = norm(x)
+	if normx <= f.rho
+		y .= f.mu .* x
+		v = (f.mu/2)*normx^2
+	else
+		y .= (f.mu*f.rho)/normx .* x
+		v = f.rho*f.mu*(normx-f.rho/2)
+	end
+	return v
 end
 
 function prox!(y::AbstractArray{T}, f::HuberLoss, x::AbstractArray{T}, gamma::Real=1.0) where T <: Union{Real, Complex}
-  normx = norm(x)
-  mugam = f.mu*gamma
-  scal = (1-min(mugam/(1+mugam), mugam*f.rho/(normx)))
-  for k in eachindex(y)
-    y[k] = scal*x[k]
-  end
-  normy = scal*normx
-  if normy <= f.rho
-    return (f.mu/2)*normy^2
-  else
-    return f.rho*f.mu*(normy-f.rho/2)
-  end
+	normx = norm(x)
+	mugam = f.mu*gamma
+	scal = (1-min(mugam/(1+mugam), mugam*f.rho/(normx)))
+	for k in eachindex(y)
+		y[k] = scal*x[k]
+	end
+	normy = scal*normx
+	if normy <= f.rho
+		return (f.mu/2)*normy^2
+	else
+		return f.rho*f.mu*(normy-f.rho/2)
+	end
 end
 
 fun_name(f::HuberLoss) = "Huber loss"
@@ -77,10 +77,10 @@ fun_expr(f::HuberLoss) = "x ↦ (μ/2)||x||² if ||x||⩽ρ, μρ(||x||-ρ/2) ot
 fun_params(f::HuberLoss) = string("ρ = $(f.rho), μ = $(f.mu)")
 
 function prox_naive(f::HuberLoss, x::AbstractArray{T}, gamma::Real=1.0) where T <: Union{Real, Complex}
-  y = (1-min(f.mu*gamma/(1+f.mu*gamma), f.mu*gamma*f.rho/(norm(x))))*x
-  if norm(y) <= f.rho
-    return y, (f.mu/2)*norm(y)^2
-  else
-    return y, f.rho*f.mu*(norm(y)-f.rho/2)
-  end
+	y = (1-min(f.mu*gamma/(1+f.mu*gamma), f.mu*gamma*f.rho/(norm(x))))*x
+	if norm(y) <= f.rho
+		return y, (f.mu/2)*norm(y)^2
+	else
+		return y, f.rho*f.mu*(norm(y)-f.rho/2)
+	end
 end

--- a/src/functions/huberLoss.jl
+++ b/src/functions/huberLoss.jl
@@ -7,27 +7,27 @@ export HuberLoss
 """
 **Huber loss**
 
-	HuberLoss(ρ=1.0, μ=1.0)
+    HuberLoss(ρ=1.0, μ=1.0)
 
 Returns the function
 ```math
 f(x) = \\begin{cases}
-	\\tfrac{μ}{2}\\|x\\|^2 & \\text{if}\\ \\|x\\| ⩽ ρ \\\\
-	ρμ(\\|x\\| - \\tfrac{ρ}{2}) & \\text{otherwise},
+    \\tfrac{μ}{2}\\|x\\|^2 & \\text{if}\\ \\|x\\| ⩽ ρ \\\\
+    ρμ(\\|x\\| - \\tfrac{ρ}{2}) & \\text{otherwise},
 \\end{cases}
 ```
 where `ρ` and `μ` are positive parameters.
 """
 struct HuberLoss{R <: Real} <: ProximableFunction
-	rho::R
-	mu::R
-	function HuberLoss{R}(rho::R, mu::R) where {R <: Real}
-		if rho <= 0.0 || mu <= 0.0
-			error("parameters rho and mu must be positive")
-		else
-			new(rho, mu)
-		end
-	end
+    rho::R
+    mu::R
+    function HuberLoss{R}(rho::R, mu::R) where {R <: Real}
+        if rho <= 0.0 || mu <= 0.0
+            error("parameters rho and mu must be positive")
+        else
+            new(rho, mu)
+        end
+    end
 end
 
 is_convex(f::HuberLoss) = true
@@ -36,39 +36,39 @@ is_smooth(f::HuberLoss) = true
 HuberLoss(rho::R=1.0, mu::R=1.0) where {R <: Real} = HuberLoss{R}(rho, mu)
 
 function (f::HuberLoss)(x::AbstractArray{T}) where T <: Union{Real, Complex}
-	normx = norm(x)
-	if normx <= f.rho
-		return (f.mu/2)*normx^2
-	else
-		return f.rho*f.mu*(normx-f.rho/2)
-	end
+    normx = norm(x)
+    if normx <= f.rho
+        return (f.mu/2)*normx^2
+    else
+        return f.rho*f.mu*(normx-f.rho/2)
+    end
 end
 
 function gradient!(y::AbstractArray{T}, f::HuberLoss, x::AbstractArray{T}) where T <: Union{Real, Complex}
-	normx = norm(x)
-	if normx <= f.rho
-		y .= f.mu .* x
-		v = (f.mu/2)*normx^2
-	else
-		y .= (f.mu*f.rho)/normx .* x
-		v = f.rho*f.mu*(normx-f.rho/2)
-	end
-	return v
+    normx = norm(x)
+    if normx <= f.rho
+        y .= f.mu .* x
+        v = (f.mu/2)*normx^2
+    else
+        y .= (f.mu*f.rho)/normx .* x
+        v = f.rho*f.mu*(normx-f.rho/2)
+    end
+    return v
 end
 
 function prox!(y::AbstractArray{T}, f::HuberLoss, x::AbstractArray{T}, gamma::Real=1.0) where T <: Union{Real, Complex}
-	normx = norm(x)
-	mugam = f.mu*gamma
-	scal = (1-min(mugam/(1+mugam), mugam*f.rho/(normx)))
-	for k in eachindex(y)
-		y[k] = scal*x[k]
-	end
-	normy = scal*normx
-	if normy <= f.rho
-		return (f.mu/2)*normy^2
-	else
-		return f.rho*f.mu*(normy-f.rho/2)
-	end
+    normx = norm(x)
+    mugam = f.mu*gamma
+    scal = (1-min(mugam/(1+mugam), mugam*f.rho/(normx)))
+    for k in eachindex(y)
+        y[k] = scal*x[k]
+    end
+    normy = scal*normx
+    if normy <= f.rho
+        return (f.mu/2)*normy^2
+    else
+        return f.rho*f.mu*(normy-f.rho/2)
+    end
 end
 
 fun_name(f::HuberLoss) = "Huber loss"
@@ -77,10 +77,10 @@ fun_expr(f::HuberLoss) = "x ↦ (μ/2)||x||² if ||x||⩽ρ, μρ(||x||-ρ/2) ot
 fun_params(f::HuberLoss) = string("ρ = $(f.rho), μ = $(f.mu)")
 
 function prox_naive(f::HuberLoss, x::AbstractArray{T}, gamma::Real=1.0) where T <: Union{Real, Complex}
-	y = (1-min(f.mu*gamma/(1+f.mu*gamma), f.mu*gamma*f.rho/(norm(x))))*x
-	if norm(y) <= f.rho
-		return y, (f.mu/2)*norm(y)^2
-	else
-		return y, f.rho*f.mu*(norm(y)-f.rho/2)
-	end
+    y = (1-min(f.mu*gamma/(1+f.mu*gamma), f.mu*gamma*f.rho/(norm(x))))*x
+    if norm(y) <= f.rho
+        return y, (f.mu/2)*norm(y)^2
+    else
+        return y, f.rho*f.mu*(norm(y)-f.rho/2)
+    end
 end

--- a/src/functions/indAffine.jl
+++ b/src/functions/indAffine.jl
@@ -20,7 +20,7 @@ fun_name(f::IndAffine) = "Indicator of an affine subspace"
 """
 **Indicator of an affine subspace**
 
-    IndAffine(A, b; iterative=false)
+	IndAffine(A, b; iterative=false)
 
 If `A` is a matrix (dense or sparse) and `b` is a vector, returns the indicator function of the set
 ```math
@@ -34,11 +34,11 @@ By default, a direct method (QR factorization of matrix `A'`) is used to evaluat
 If `iterative=true`, then `prox!` is evaluated approximately using an iterative method instead.
 """
 function IndAffine(A::M, b::V; iterative=false) where {M, V}
-  if iterative == false
-    IndAffineDirect(A, b)
-  else
-    IndAffineIterative(A, b)
-  end
+	if iterative == false
+		IndAffineDirect(A, b)
+	else
+		IndAffineIterative(A, b)
+	end
 end
 
 ### INCLUDE CONCRETE TYPES

--- a/src/functions/indAffine.jl
+++ b/src/functions/indAffine.jl
@@ -20,7 +20,7 @@ fun_name(f::IndAffine) = "Indicator of an affine subspace"
 """
 **Indicator of an affine subspace**
 
-	IndAffine(A, b; iterative=false)
+    IndAffine(A, b; iterative=false)
 
 If `A` is a matrix (dense or sparse) and `b` is a vector, returns the indicator function of the set
 ```math
@@ -34,11 +34,11 @@ By default, a direct method (QR factorization of matrix `A'`) is used to evaluat
 If `iterative=true`, then `prox!` is evaluated approximately using an iterative method instead.
 """
 function IndAffine(A::M, b::V; iterative=false) where {M, V}
-	if iterative == false
-		IndAffineDirect(A, b)
-	else
-		IndAffineIterative(A, b)
-	end
+    if iterative == false
+        IndAffineDirect(A, b)
+    else
+        IndAffineIterative(A, b)
+    end
 end
 
 ### INCLUDE CONCRETE TYPES

--- a/src/functions/indAffineDirect.jl
+++ b/src/functions/indAffineDirect.jl
@@ -4,20 +4,20 @@
 using LinearAlgebra: QRCompactWY
 
 struct IndAffineDirect{R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}, F <: Factorization} <: IndAffine
-	A::M
-	b::V
-	fact::F
-	res::V
-	function IndAffineDirect{R, T, M, V, F}(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}, F <: Factorization}
-		if size(A, 1) > size(A, 2)
-			error("A must be full row rank")
-		end
-		normrowsinv = 1 ./ vec(sqrt.(sum(abs2.(A); dims=2)))
-		A = normrowsinv.*A # normalize rows of A
-		b = normrowsinv.*b # and b accordingly
-		fact = qr(M(A'))
-		new(A, b, fact, similar(b))
-	end
+    A::M
+    b::V
+    fact::F
+    res::V
+    function IndAffineDirect{R, T, M, V, F}(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}, F <: Factorization}
+        if size(A, 1) > size(A, 2)
+            error("A must be full row rank")
+        end
+        normrowsinv = 1 ./ vec(sqrt.(sum(abs2.(A); dims=2)))
+        A = normrowsinv.*A # normalize rows of A
+        b = normrowsinv.*b # and b accordingly
+        fact = qr(M(A'))
+        new(A, b, fact, similar(b))
+    end
 end
 
 is_cone(f::IndAffineDirect) = norm(f.b) == 0.0
@@ -29,46 +29,46 @@ IndAffineDirect(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, I <: Intege
 IndAffineDirect(a::V, b::T) where {R <: Real, T <: RealOrComplex{R}, V <: AbstractVector{T}} = IndAffineDirect(reshape(a,1,:), [b])
 
 function (f::IndAffineDirect{R, T, M, V, F})(x::V) where {R, T, M, V, F}
-	mul!(f.res, f.A, x)
-	f.res .= f.b .- f.res
-	# the tolerance in the following line should be customizable
-	if norm(f.res, Inf) <= 1e-12
-		return R(0)
-	end
-	return typemax(R)
+    mul!(f.res, f.A, x)
+    f.res .= f.b .- f.res
+    # the tolerance in the following line should be customizable
+    if norm(f.res, Inf) <= 1e-12
+        return R(0)
+    end
+    return typemax(R)
 end
 
 function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=R(1)) where {R, T, M, V, F <: QRCompactWY}
-	mul!(f.res, f.A, x)
-	f.res .= f.b .- f.res
-	Rfact = view(f.fact.factors, 1:length(f.b), 1:length(f.b))
-	LinearAlgebra.LAPACK.trtrs!('U', 'C', 'N', Rfact, f.res)
-	LinearAlgebra.LAPACK.trtrs!('U', 'N', 'N', Rfact, f.res)
-	mul!(y, adjoint(f.A), f.res)
-	y .+= x
-	return R(0)
+    mul!(f.res, f.A, x)
+    f.res .= f.b .- f.res
+    Rfact = view(f.fact.factors, 1:length(f.b), 1:length(f.b))
+    LinearAlgebra.LAPACK.trtrs!('U', 'C', 'N', Rfact, f.res)
+    LinearAlgebra.LAPACK.trtrs!('U', 'N', 'N', Rfact, f.res)
+    mul!(y, adjoint(f.A), f.res)
+    y .+= x
+    return R(0)
 end
 
 function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=R(1)) where {R, T, M, V, F <: SuiteSparse.SPQR.Factorization}
-	mul!(f.res, f.A, x)
-	f.res .= f.b .- f.res
-	##############################################################################
-	# We need to solve for z: AA'z = res
-	# We have: QR=PA'S so A'=P'QRS' and AA'=SR'Q'PP'QRS'=SR'RS'
-	# So: z = S'\R\R'\S\res
-	# TODO: the following lines should be made more efficient
-	temp = f.res[f.fact.pcol]
-	temp = LowerTriangular(adjoint(f.fact.R))\temp
-	temp = UpperTriangular(f.fact.R)\temp
-	RRres = similar(temp)
-	RRres[f.fact.pcol] .= temp
-	##############################################################################
-	mul!(y, adjoint(f.A), RRres)
-	y .+= x
-	return R(0)
+    mul!(f.res, f.A, x)
+    f.res .= f.b .- f.res
+    ##############################################################################
+    # We need to solve for z: AA'z = res
+    # We have: QR=PA'S so A'=P'QRS' and AA'=SR'Q'PP'QRS'=SR'RS'
+    # So: z = S'\R\R'\S\res
+    # TODO: the following lines should be made more efficient
+    temp = f.res[f.fact.pcol]
+    temp = LowerTriangular(adjoint(f.fact.R))\temp
+    temp = UpperTriangular(f.fact.R)\temp
+    RRres = similar(temp)
+    RRres[f.fact.pcol] .= temp
+    ##############################################################################
+    mul!(y, adjoint(f.A), RRres)
+    y .+= x
+    return R(0)
 end
 
 function prox_naive(f::IndAffineDirect, x::AbstractArray{T,1}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
-	return y, R(0)
+    y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
+    return y, R(0)
 end

--- a/src/functions/indAffineDirect.jl
+++ b/src/functions/indAffineDirect.jl
@@ -4,20 +4,20 @@
 using LinearAlgebra: QRCompactWY
 
 struct IndAffineDirect{R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}, F <: Factorization} <: IndAffine
-  A::M
-  b::V
-  fact::F
-  res::V
-  function IndAffineDirect{R, T, M, V, F}(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}, F <: Factorization}
-    if size(A, 1) > size(A, 2)
-      error("A must be full row rank")
-    end
-    normrowsinv = 1 ./ vec(sqrt.(sum(abs2.(A); dims=2)))
-    A = normrowsinv.*A # normalize rows of A
-    b = normrowsinv.*b # and b accordingly
-    fact = qr(M(A'))
-    new(A, b, fact, similar(b))
-  end
+	A::M
+	b::V
+	fact::F
+	res::V
+	function IndAffineDirect{R, T, M, V, F}(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}, F <: Factorization}
+		if size(A, 1) > size(A, 2)
+			error("A must be full row rank")
+		end
+		normrowsinv = 1 ./ vec(sqrt.(sum(abs2.(A); dims=2)))
+		A = normrowsinv.*A # normalize rows of A
+		b = normrowsinv.*b # and b accordingly
+		fact = qr(M(A'))
+		new(A, b, fact, similar(b))
+	end
 end
 
 is_cone(f::IndAffineDirect) = norm(f.b) == 0.0
@@ -29,46 +29,46 @@ IndAffineDirect(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, I <: Intege
 IndAffineDirect(a::V, b::T) where {R <: Real, T <: RealOrComplex{R}, V <: AbstractVector{T}} = IndAffineDirect(reshape(a,1,:), [b])
 
 function (f::IndAffineDirect{R, T, M, V, F})(x::V) where {R, T, M, V, F}
-  mul!(f.res, f.A, x)
-  f.res .= f.b .- f.res
-  # the tolerance in the following line should be customizable
-  if norm(f.res, Inf) <= 1e-12
-    return zero(R)
-  end
-  return typemax(R)
+	mul!(f.res, f.A, x)
+	f.res .= f.b .- f.res
+	# the tolerance in the following line should be customizable
+	if norm(f.res, Inf) <= 1e-12
+		return zero(R)
+	end
+	return typemax(R)
 end
 
 function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=one(R)) where {R, T, M, V, F <: QRCompactWY}
-  mul!(f.res, f.A, x)
-  f.res .= f.b .- f.res
-  Rfact = view(f.fact.factors, 1:length(f.b), 1:length(f.b))
-  LinearAlgebra.LAPACK.trtrs!('U', 'C', 'N', Rfact, f.res)
-  LinearAlgebra.LAPACK.trtrs!('U', 'N', 'N', Rfact, f.res)
-  mul!(y, adjoint(f.A), f.res)
-  y .+= x
-  return zero(R)
+	mul!(f.res, f.A, x)
+	f.res .= f.b .- f.res
+	Rfact = view(f.fact.factors, 1:length(f.b), 1:length(f.b))
+	LinearAlgebra.LAPACK.trtrs!('U', 'C', 'N', Rfact, f.res)
+	LinearAlgebra.LAPACK.trtrs!('U', 'N', 'N', Rfact, f.res)
+	mul!(y, adjoint(f.A), f.res)
+	y .+= x
+	return zero(R)
 end
 
 function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=one(R)) where {R, T, M, V, F <: SuiteSparse.SPQR.Factorization}
-  mul!(f.res, f.A, x)
-  f.res .= f.b .- f.res
-  ##############################################################################
-  # We need to solve for z: AA'z = res
-  # We have: QR=PA'S so A'=P'QRS' and AA'=SR'Q'PP'QRS'=SR'RS'
-  # So: z = S'\R\R'\S\res
-  # TODO: the following lines should be made more efficient
-  temp = f.res[f.fact.pcol]
-  temp = LowerTriangular(adjoint(f.fact.R))\temp
-  temp = UpperTriangular(f.fact.R)\temp
-  RRres = similar(temp)
-  RRres[f.fact.pcol] .= temp
-  ##############################################################################
-  mul!(y, adjoint(f.A), RRres)
-  y .+= x
-  return zero(R)
+	mul!(f.res, f.A, x)
+	f.res .= f.b .- f.res
+	##############################################################################
+	# We need to solve for z: AA'z = res
+	# We have: QR=PA'S so A'=P'QRS' and AA'=SR'Q'PP'QRS'=SR'RS'
+	# So: z = S'\R\R'\S\res
+	# TODO: the following lines should be made more efficient
+	temp = f.res[f.fact.pcol]
+	temp = LowerTriangular(adjoint(f.fact.R))\temp
+	temp = UpperTriangular(f.fact.R)\temp
+	RRres = similar(temp)
+	RRres[f.fact.pcol] .= temp
+	##############################################################################
+	mul!(y, adjoint(f.A), RRres)
+	y .+= x
+	return zero(R)
 end
 
 function prox_naive(f::IndAffineDirect, x::AbstractArray{T,1}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
-  return y, zero(R)
+	y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
+	return y, zero(R)
 end

--- a/src/functions/indAffineDirect.jl
+++ b/src/functions/indAffineDirect.jl
@@ -33,12 +33,12 @@ function (f::IndAffineDirect{R, T, M, V, F})(x::V) where {R, T, M, V, F}
 	f.res .= f.b .- f.res
 	# the tolerance in the following line should be customizable
 	if norm(f.res, Inf) <= 1e-12
-		return zero(R)
+		return R(0)
 	end
 	return typemax(R)
 end
 
-function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=one(R)) where {R, T, M, V, F <: QRCompactWY}
+function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=R(1)) where {R, T, M, V, F <: QRCompactWY}
 	mul!(f.res, f.A, x)
 	f.res .= f.b .- f.res
 	Rfact = view(f.fact.factors, 1:length(f.b), 1:length(f.b))
@@ -46,10 +46,10 @@ function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=one(R)) w
 	LinearAlgebra.LAPACK.trtrs!('U', 'N', 'N', Rfact, f.res)
 	mul!(y, adjoint(f.A), f.res)
 	y .+= x
-	return zero(R)
+	return R(0)
 end
 
-function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=one(R)) where {R, T, M, V, F <: SuiteSparse.SPQR.Factorization}
+function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=R(1)) where {R, T, M, V, F <: SuiteSparse.SPQR.Factorization}
 	mul!(f.res, f.A, x)
 	f.res .= f.b .- f.res
 	##############################################################################
@@ -65,10 +65,10 @@ function prox!(y::V, f::IndAffineDirect{R, T, M, V, F}, x::V, gamma::R=one(R)) w
 	##############################################################################
 	mul!(y, adjoint(f.A), RRres)
 	y .+= x
-	return zero(R)
+	return R(0)
 end
 
-function prox_naive(f::IndAffineDirect, x::AbstractArray{T,1}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::IndAffineDirect, x::AbstractArray{T,1}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
-	return y, zero(R)
+	return y, R(0)
 end

--- a/src/functions/indAffineIterative.jl
+++ b/src/functions/indAffineIterative.jl
@@ -1,20 +1,20 @@
 ### CONCRETE TYPE: ITERATIVE PROX EVALUATION
 
 struct IndAffineIterative{R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}} <: IndAffine
-  A::M
-  b::V
-  res::V
-  maxit::Integer
-  tol::R
-  function IndAffineIterative{R, T, M, V}(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}}
-    if size(A,1) > size(A,2)
-      error("A must be full row rank")
-    end
-    normrowsinv = 1 ./ vec(sqrt.(sum(abs2.(A); dims=2)))
-    A = normrowsinv.*A # normalize rows of A
-    b = normrowsinv.*b # and b accordingly
-    new(A, b, similar(b), 1000, 1e-8)
-  end
+	A::M
+	b::V
+	res::V
+	maxit::Integer
+	tol::R
+	function IndAffineIterative{R, T, M, V}(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}}
+		if size(A,1) > size(A,2)
+			error("A must be full row rank")
+		end
+		normrowsinv = 1 ./ vec(sqrt.(sum(abs2.(A); dims=2)))
+		A = normrowsinv.*A # normalize rows of A
+		b = normrowsinv.*b # and b accordingly
+		new(A, b, similar(b), 1000, 1e-8)
+	end
 end
 
 is_prox_accurate(f::IndAffineIterative) = false
@@ -23,35 +23,35 @@ is_cone(f::IndAffineIterative) = norm(f.b) == 0.0
 IndAffineIterative(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}} = IndAffineIterative{R, T, M, V}(A, b)
 
 function (f::IndAffineIterative{R, T, M, V})(x::V) where {R, T, M, V}
-  mul!(f.res, f.A, x)
-  f.res .= f.b .- f.res
-  # the tolerance in the following line should be customizable
-  if norm(f.res, Inf) <= f.tol
-    return zero(R)
-  end
-  return typemax(R)
+	mul!(f.res, f.A, x)
+	f.res .= f.b .- f.res
+	# the tolerance in the following line should be customizable
+	if norm(f.res, Inf) <= f.tol
+		return zero(R)
+	end
+	return typemax(R)
 end
 
 function prox!(y::V, f::IndAffineIterative{R, T, M, V}, x::V, gamma::R=one(R)) where {R, T, M, V}
-  # Von Neumann's alternating projections
-  m = size(f.A, 1)
-  y .= x
-  for k = 1:f.maxit
-    maxres = zero(R)
-    for i = 1:m
-      resi = (f.b[i] - dot(f.A[i,:], y))
-      y .= y + resi*f.A[i,:] # no need to divide: rows of A are normalized
-      absresi = resi > 0 ? resi : -resi
-      maxres = absresi > maxres ? absresi : maxres
-    end
-    if maxres < f.tol
-      break
-    end
-  end
-  return zero(R)
+	# Von Neumann's alternating projections
+	m = size(f.A, 1)
+	y .= x
+	for k = 1:f.maxit
+		maxres = zero(R)
+		for i = 1:m
+			resi = (f.b[i] - dot(f.A[i,:], y))
+			y .= y + resi*f.A[i,:] # no need to divide: rows of A are normalized
+			absresi = resi > 0 ? resi : -resi
+			maxres = absresi > maxres ? absresi : maxres
+		end
+		if maxres < f.tol
+			break
+		end
+	end
+	return zero(R)
 end
 
 function prox_naive(f::IndAffineIterative, x::AbstractArray{T,1}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
-  return y, zero(R)
+	y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
+	return y, zero(R)
 end

--- a/src/functions/indAffineIterative.jl
+++ b/src/functions/indAffineIterative.jl
@@ -1,20 +1,20 @@
 ### CONCRETE TYPE: ITERATIVE PROX EVALUATION
 
 struct IndAffineIterative{R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}} <: IndAffine
-	A::M
-	b::V
-	res::V
-	maxit::Integer
-	tol::R
-	function IndAffineIterative{R, T, M, V}(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}}
-		if size(A,1) > size(A,2)
-			error("A must be full row rank")
-		end
-		normrowsinv = 1 ./ vec(sqrt.(sum(abs2.(A); dims=2)))
-		A = normrowsinv.*A # normalize rows of A
-		b = normrowsinv.*b # and b accordingly
-		new(A, b, similar(b), 1000, 1e-8)
-	end
+    A::M
+    b::V
+    res::V
+    maxit::Integer
+    tol::R
+    function IndAffineIterative{R, T, M, V}(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}}
+        if size(A,1) > size(A,2)
+            error("A must be full row rank")
+        end
+        normrowsinv = 1 ./ vec(sqrt.(sum(abs2.(A); dims=2)))
+        A = normrowsinv.*A # normalize rows of A
+        b = normrowsinv.*b # and b accordingly
+        new(A, b, similar(b), 1000, 1e-8)
+    end
 end
 
 is_prox_accurate(f::IndAffineIterative) = false
@@ -23,35 +23,35 @@ is_cone(f::IndAffineIterative) = norm(f.b) == 0.0
 IndAffineIterative(A::M, b::V) where {R <: Real, T <: RealOrComplex{R}, M <: AbstractMatrix{T}, V <: AbstractVector{T}} = IndAffineIterative{R, T, M, V}(A, b)
 
 function (f::IndAffineIterative{R, T, M, V})(x::V) where {R, T, M, V}
-	mul!(f.res, f.A, x)
-	f.res .= f.b .- f.res
-	# the tolerance in the following line should be customizable
-	if norm(f.res, Inf) <= f.tol
-		return R(0)
-	end
-	return typemax(R)
+    mul!(f.res, f.A, x)
+    f.res .= f.b .- f.res
+    # the tolerance in the following line should be customizable
+    if norm(f.res, Inf) <= f.tol
+        return R(0)
+    end
+    return typemax(R)
 end
 
 function prox!(y::V, f::IndAffineIterative{R, T, M, V}, x::V, gamma::R=R(1)) where {R, T, M, V}
-	# Von Neumann's alternating projections
-	m = size(f.A, 1)
-	y .= x
-	for k = 1:f.maxit
-		maxres = R(0)
-		for i = 1:m
-			resi = (f.b[i] - dot(f.A[i,:], y))
-			y .= y + resi*f.A[i,:] # no need to divide: rows of A are normalized
-			absresi = resi > 0 ? resi : -resi
-			maxres = absresi > maxres ? absresi : maxres
-		end
-		if maxres < f.tol
-			break
-		end
-	end
-	return R(0)
+    # Von Neumann's alternating projections
+    m = size(f.A, 1)
+    y .= x
+    for k = 1:f.maxit
+        maxres = R(0)
+        for i = 1:m
+            resi = (f.b[i] - dot(f.A[i,:], y))
+            y .= y + resi*f.A[i,:] # no need to divide: rows of A are normalized
+            absresi = resi > 0 ? resi : -resi
+            maxres = absresi > maxres ? absresi : maxres
+        end
+        if maxres < f.tol
+            break
+        end
+    end
+    return R(0)
 end
 
 function prox_naive(f::IndAffineIterative, x::AbstractArray{T,1}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
-	return y, R(0)
+    y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
+    return y, R(0)
 end

--- a/src/functions/indAffineIterative.jl
+++ b/src/functions/indAffineIterative.jl
@@ -27,17 +27,17 @@ function (f::IndAffineIterative{R, T, M, V})(x::V) where {R, T, M, V}
 	f.res .= f.b .- f.res
 	# the tolerance in the following line should be customizable
 	if norm(f.res, Inf) <= f.tol
-		return zero(R)
+		return R(0)
 	end
 	return typemax(R)
 end
 
-function prox!(y::V, f::IndAffineIterative{R, T, M, V}, x::V, gamma::R=one(R)) where {R, T, M, V}
+function prox!(y::V, f::IndAffineIterative{R, T, M, V}, x::V, gamma::R=R(1)) where {R, T, M, V}
 	# Von Neumann's alternating projections
 	m = size(f.A, 1)
 	y .= x
 	for k = 1:f.maxit
-		maxres = zero(R)
+		maxres = R(0)
 		for i = 1:m
 			resi = (f.b[i] - dot(f.A[i,:], y))
 			y .= y + resi*f.A[i,:] # no need to divide: rows of A are normalized
@@ -48,10 +48,10 @@ function prox!(y::V, f::IndAffineIterative{R, T, M, V}, x::V, gamma::R=one(R)) w
 			break
 		end
 	end
-	return zero(R)
+	return R(0)
 end
 
-function prox_naive(f::IndAffineIterative, x::AbstractArray{T,1}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::IndAffineIterative, x::AbstractArray{T,1}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	y = x + f.A'*((f.A*f.A')\(f.b - f.A*x))
-	return y, zero(R)
+	return y, R(0)
 end

--- a/src/functions/indBallL0.jl
+++ b/src/functions/indBallL0.jl
@@ -58,10 +58,10 @@ fun_dom(f::IndBallL0) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndBallL0) = "x ↦ 0 if countnz(x) ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL0) = "r = $(f.r)"
 
-function prox_naive(f::IndBallL0, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
+function prox_naive(f::IndBallL0, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
   p = sortperm(abs.(x)[:], rev=true)
   y = similar(x)
   y[p[1:f.r]] .= x[p[1:f.r]]
-  y[p[f.r+1:end]] .= 0.0
-  return y, 0.0
+  y[p[f.r+1:end]] .= T(0)
+  return y, R(0)
 end

--- a/src/functions/indBallL0.jl
+++ b/src/functions/indBallL0.jl
@@ -5,7 +5,7 @@ export IndBallL0
 """
 **Indicator of a ``L_0`` pseudo-norm ball**
 
-    IndBallL0(r=1)
+	IndBallL0(r=1)
 
 Returns the indicator function of the set
 ```math
@@ -14,14 +14,14 @@ S = \\{ x : \\mathrm{nnz}(x) \\leq r \\}.
 Parameter `r` must be a positive integer.
 """
 struct IndBallL0{I <: Integer} <: ProximableFunction
-  r::I
-  function IndBallL0{I}(r::I) where {I <: Integer}
-    if r <= 0
-      error("parameter r must be a positive integer")
-    else
-      new(r)
-    end
-  end
+	r::I
+	function IndBallL0{I}(r::I) where {I <: Integer}
+		if r <= 0
+			error("parameter r must be a positive integer")
+		else
+			new(r)
+		end
+	end
 end
 
 is_set(f::IndBallL0) = true
@@ -29,28 +29,28 @@ is_set(f::IndBallL0) = true
 IndBallL0(r::I) where {I <: Integer} = IndBallL0{I}(r)
 
 function (f::IndBallL0)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-  if count(!isequal(0), x) > f.r
-    return R(Inf)
-  end
-  return R(0)
+	if count(!isequal(0), x) > f.r
+		return R(Inf)
+	end
+	return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBallL0, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  p = []
-  if ndims(x) == 1
-    p = partialsortperm(x, 1:f.r, by=abs, rev=true)
-  else
-    p = partialsortperm(x[:], 1:f.r, by=abs, rev=true)
-  end
-  sort!(p)
-  idx = 1
-  for i = 1:length(p)
-    y[idx:p[i]-1] .= T(0)
-    y[p[i]] = x[p[i]]
-    idx = p[i]+1
-  end
-  y[idx:end] .= T(0)
-  return R(0)
+	p = []
+	if ndims(x) == 1
+		p = partialsortperm(x, 1:f.r, by=abs, rev=true)
+	else
+		p = partialsortperm(x[:], 1:f.r, by=abs, rev=true)
+	end
+	sort!(p)
+	idx = 1
+	for i = 1:length(p)
+		y[idx:p[i]-1] .= T(0)
+		y[p[i]] = x[p[i]]
+		idx = p[i]+1
+	end
+	y[idx:end] .= T(0)
+	return R(0)
 end
 
 fun_name(f::IndBallL0) = "indicator of an L0 pseudo-norm ball"
@@ -59,9 +59,9 @@ fun_expr(f::IndBallL0) = "x ↦ 0 if countnz(x) ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL0) = "r = $(f.r)"
 
 function prox_naive(f::IndBallL0, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  p = sortperm(abs.(x)[:], rev=true)
-  y = similar(x)
-  y[p[1:f.r]] .= x[p[1:f.r]]
-  y[p[f.r+1:end]] .= T(0)
-  return y, R(0)
+	p = sortperm(abs.(x)[:], rev=true)
+	y = similar(x)
+	y[p[1:f.r]] .= x[p[1:f.r]]
+	y[p[f.r+1:end]] .= T(0)
+	return y, R(0)
 end

--- a/src/functions/indBallL0.jl
+++ b/src/functions/indBallL0.jl
@@ -5,7 +5,7 @@ export IndBallL0
 """
 **Indicator of a ``L_0`` pseudo-norm ball**
 
-	IndBallL0(r=1)
+    IndBallL0(r=1)
 
 Returns the indicator function of the set
 ```math
@@ -14,14 +14,14 @@ S = \\{ x : \\mathrm{nnz}(x) \\leq r \\}.
 Parameter `r` must be a positive integer.
 """
 struct IndBallL0{I <: Integer} <: ProximableFunction
-	r::I
-	function IndBallL0{I}(r::I) where {I <: Integer}
-		if r <= 0
-			error("parameter r must be a positive integer")
-		else
-			new(r)
-		end
-	end
+    r::I
+    function IndBallL0{I}(r::I) where {I <: Integer}
+        if r <= 0
+            error("parameter r must be a positive integer")
+        else
+            new(r)
+        end
+    end
 end
 
 is_set(f::IndBallL0) = true
@@ -29,28 +29,28 @@ is_set(f::IndBallL0) = true
 IndBallL0(r::I) where {I <: Integer} = IndBallL0{I}(r)
 
 function (f::IndBallL0)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-	if count(!isequal(0), x) > f.r
-		return R(Inf)
-	end
-	return R(0)
+    if count(!isequal(0), x) > f.r
+        return R(Inf)
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBallL0, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	p = []
-	if ndims(x) == 1
-		p = partialsortperm(x, 1:f.r, by=abs, rev=true)
-	else
-		p = partialsortperm(x[:], 1:f.r, by=abs, rev=true)
-	end
-	sort!(p)
-	idx = 1
-	for i = 1:length(p)
-		y[idx:p[i]-1] .= T(0)
-		y[p[i]] = x[p[i]]
-		idx = p[i]+1
-	end
-	y[idx:end] .= T(0)
-	return R(0)
+    p = []
+    if ndims(x) == 1
+        p = partialsortperm(x, 1:f.r, by=abs, rev=true)
+    else
+        p = partialsortperm(x[:], 1:f.r, by=abs, rev=true)
+    end
+    sort!(p)
+    idx = 1
+    for i = 1:length(p)
+        y[idx:p[i]-1] .= T(0)
+        y[p[i]] = x[p[i]]
+        idx = p[i]+1
+    end
+    y[idx:end] .= T(0)
+    return R(0)
 end
 
 fun_name(f::IndBallL0) = "indicator of an L0 pseudo-norm ball"
@@ -59,9 +59,9 @@ fun_expr(f::IndBallL0) = "x ↦ 0 if countnz(x) ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL0) = "r = $(f.r)"
 
 function prox_naive(f::IndBallL0, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	p = sortperm(abs.(x)[:], rev=true)
-	y = similar(x)
-	y[p[1:f.r]] .= x[p[1:f.r]]
-	y[p[f.r+1:end]] .= T(0)
-	return y, R(0)
+    p = sortperm(abs.(x)[:], rev=true)
+    y = similar(x)
+    y[p[1:f.r]] .= x[p[1:f.r]]
+    y[p[f.r+1:end]] .= T(0)
+    return y, R(0)
 end

--- a/src/functions/indBallL0.jl
+++ b/src/functions/indBallL0.jl
@@ -35,7 +35,7 @@ function (f::IndBallL0)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComple
 	return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndBallL0, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::IndBallL0, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	p = []
 	if ndims(x) == 1
 		p = partialsortperm(x, 1:f.r, by=abs, rev=true)
@@ -58,7 +58,7 @@ fun_dom(f::IndBallL0) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndBallL0) = "x ↦ 0 if countnz(x) ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL0) = "r = $(f.r)"
 
-function prox_naive(f::IndBallL0, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::IndBallL0, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	p = sortperm(abs.(x)[:], rev=true)
 	y = similar(x)
 	y[p[1:f.r]] .= x[p[1:f.r]]

--- a/src/functions/indBallL1.jl
+++ b/src/functions/indBallL1.jl
@@ -5,7 +5,7 @@ export IndBallL1
 """
 **Indicator of a ``L_1`` norm ball**
 
-    IndBallL1(r=1.0)
+	IndBallL1(r=1.0)
 
 Returns the indicator function of the set
 ```math
@@ -14,14 +14,14 @@ S = \\left\\{ x : ∑_i |x_i| \\leq r \\right\\}.
 Parameter `r` must be positive.
 """
 struct IndBallL1{R <: Real} <: ProximableFunction
-    r::R
-    function IndBallL1{R}(r::R) where {R <: Real}
-        if r <= 0
-            error("parameter r must be positive")
-        else
-            new(r)
-        end
-    end
+	r::R
+	function IndBallL1{R}(r::R) where {R <: Real}
+		if r <= 0
+			error("parameter r must be positive")
+		else
+			new(r)
+		end
+	end
 end
 
 is_convex(f::IndBallL1) = true
@@ -31,38 +31,38 @@ is_prox_accurate(f::IndBallL1) = false
 IndBallL1(r::R=1.0) where {R <: Real} = IndBallL1{R}(r)
 
 function (f::IndBallL1)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-    if norm(x, 1) - f.r > f.r*eps(R)
-        return R(Inf)
-    end
-    return R(0)
+	if norm(x, 1) - f.r > f.r*eps(R)
+		return R(Inf)
+	end
+	return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-    # TODO: a faster algorithm
-    if norm(x, 1) - f.r <= f.r*eps(R)
-        y .= x
-        return R(0)
-    else # do a projection of abs(x) onto simplex then recover signs
-        n = length(x)
-        p = abs.(view(x,:))
-        sort!(p, rev=true)
-        s = R(0)
-        @inbounds for i = 1:n-1
-            s = s + p[i]
-            tmax = (s - f.r)/i
-            if tmax >= p[i+1]
-                @inbounds for j in eachindex(x)
-                    y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
-                end
-                return R(0)
-            end
-        end
-        tmax = (s + p[n] - f.r)/n
-        @inbounds for j in eachindex(x)
-            y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
-        end
-        return R(0)
-    end
+	# TODO: a faster algorithm
+	if norm(x, 1) - f.r <= f.r*eps(R)
+		y .= x
+		return R(0)
+	else # do a projection of abs(x) onto simplex then recover signs
+		n = length(x)
+		p = abs.(view(x,:))
+		sort!(p, rev=true)
+		s = R(0)
+		@inbounds for i = 1:n-1
+			s = s + p[i]
+			tmax = (s - f.r)/i
+			if tmax >= p[i+1]
+				@inbounds for j in eachindex(x)
+					y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
+				end
+				return R(0)
+			end
+		end
+		tmax = (s + p[n] - f.r)/n
+		@inbounds for j in eachindex(x)
+			y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
+		end
+		return R(0)
+	end
 end
 
 fun_name(f::IndBallL1) = "indicator of an L1 norm ball"
@@ -71,21 +71,21 @@ fun_expr(f::IndBallL1) = "x ↦ 0 if ‖x‖_1 ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL1) = "r = $(f.r)"
 
 function prox_naive(f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-    # do a simple bisection (aka binary search) on λ
-    L = R(0)
-    U = maximum(abs, x)
-    λ = L
-    v = R(0)
-    maxit = 120
-    for iter in 1:maxit
-        λ = 0.5*(L + U)
-        v = sum(max.(abs.(x) .- λ, R(0)))
-        # modify lower or upper bound
-        (v < f.r) ? U = λ : L = λ
-        # exit condition
-        if abs(L - U) < (1 + abs(U))*eps(R)
-            break
-        end
-    end
-    return sign.(x) .* max.(R(0), abs.(x) .- λ), R(0)
+	# do a simple bisection (aka binary search) on λ
+	L = R(0)
+	U = maximum(abs, x)
+	λ = L
+	v = R(0)
+	maxit = 120
+	for iter in 1:maxit
+		λ = 0.5*(L + U)
+		v = sum(max.(abs.(x) .- λ, R(0)))
+		# modify lower or upper bound
+		(v < f.r) ? U = λ : L = λ
+		# exit condition
+		if abs(L - U) < (1 + abs(U))*eps(R)
+			break
+		end
+	end
+	return sign.(x) .* max.(R(0), abs.(x) .- λ), R(0)
 end

--- a/src/functions/indBallL1.jl
+++ b/src/functions/indBallL1.jl
@@ -69,16 +69,16 @@ fun_dom(f::IndBallL1) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndBallL1) = "x ↦ 0 if ‖x‖_1 ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL1) = "r = $(f.r)"
 
-function prox_naive(f::IndBallL1, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
+function prox_naive(f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
   # do a simple bisection (aka binary search) on λ
-  L = 0.0
+  L = R(0)
   U = maximum(abs, x)
   λ = L
-  v = 0.0
+  v = R(0)
   maxit = 120
   for iter in 1:maxit
     λ = 0.5*(L + U)
-    v = sum(max.(abs.(x) .- λ, 0.0))
+    v = sum(max.(abs.(x) .- λ, R(0)))
     # modify lower or upper bound
     (v < f.r) ? U = λ : L = λ
     # exit condition
@@ -86,5 +86,5 @@ function prox_naive(f::IndBallL1, x::AbstractArray{T}, gamma::Real=1.0) where T 
       break
     end
   end
-  return sign.(x) .* max.(0.0, abs.(x) .- λ), 0.0
+  return sign.(x) .* max.(R(0), abs.(x) .- λ), R(0)
 end

--- a/src/functions/indBallL1.jl
+++ b/src/functions/indBallL1.jl
@@ -14,54 +14,55 @@ S = \\left\\{ x : ∑_i |x_i| \\leq r \\right\\}.
 Parameter `r` must be positive.
 """
 struct IndBallL1{R <: Real} <: ProximableFunction
-  r::R
-  function IndBallL1{R}(r::R) where {R <: Real}
-    if r <= 0
-      error("parameter r must be positive")
-    else
-      new(r)
+    r::R
+    function IndBallL1{R}(r::R) where {R <: Real}
+        if r <= 0
+            error("parameter r must be positive")
+        else
+            new(r)
+        end
     end
-  end
 end
 
 is_convex(f::IndBallL1) = true
 is_set(f::IndBallL1) = true
+is_prox_accurate(f::IndBallL1) = false
 
 IndBallL1(r::R=1.0) where {R <: Real} = IndBallL1{R}(r)
 
 function (f::IndBallL1)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-  if norm(x, 1) - f.r > 1e-12
-    return R(Inf)
-  end
-  return R(0)
+    if norm(x, 1) - f.r > f.r*eps(R)
+        return R(Inf)
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  # TODO: a faster algorithm
-  if norm(x, 1) - f.r < 1e-14
-    y .= x
-    return R(0)
-  else # do a projection of abs(x) onto simplex then recover signs
-    n = length(x)
-    p = abs.(view(x,:))
-    sort!(p, rev=true)
-    s = R(0)
-    @inbounds for i = 1:n-1
-      s = s + p[i]
-      tmax = (s - f.r)/i
-      if tmax >= p[i+1]
+    # TODO: a faster algorithm
+    if norm(x, 1) - f.r <= f.r*eps(R)
+        y .= x
+        return R(0)
+    else # do a projection of abs(x) onto simplex then recover signs
+        n = length(x)
+        p = abs.(view(x,:))
+        sort!(p, rev=true)
+        s = R(0)
+        @inbounds for i = 1:n-1
+            s = s + p[i]
+            tmax = (s - f.r)/i
+            if tmax >= p[i+1]
+                @inbounds for j in eachindex(x)
+                    y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
+                end
+                return R(0)
+            end
+        end
+        tmax = (s + p[n] - f.r)/n
         @inbounds for j in eachindex(x)
-          y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
+            y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
         end
         return R(0)
-      end
     end
-    tmax = (s + p[n] - f.r)/n
-    @inbounds for j in eachindex(x)
-      y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
-    end
-    return R(0)
-  end
 end
 
 fun_name(f::IndBallL1) = "indicator of an L1 norm ball"
@@ -70,21 +71,21 @@ fun_expr(f::IndBallL1) = "x ↦ 0 if ‖x‖_1 ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL1) = "r = $(f.r)"
 
 function prox_naive(f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  # do a simple bisection (aka binary search) on λ
-  L = R(0)
-  U = maximum(abs, x)
-  λ = L
-  v = R(0)
-  maxit = 120
-  for iter in 1:maxit
-    λ = 0.5*(L + U)
-    v = sum(max.(abs.(x) .- λ, R(0)))
-    # modify lower or upper bound
-    (v < f.r) ? U = λ : L = λ
-    # exit condition
-    if abs(L - U) < 1e-15
-      break
+    # do a simple bisection (aka binary search) on λ
+    L = R(0)
+    U = maximum(abs, x)
+    λ = L
+    v = R(0)
+    maxit = 120
+    for iter in 1:maxit
+        λ = 0.5*(L + U)
+        v = sum(max.(abs.(x) .- λ, R(0)))
+        # modify lower or upper bound
+        (v < f.r) ? U = λ : L = λ
+        # exit condition
+        if abs(L - U) < (1 + abs(U))*eps(R)
+            break
+        end
     end
-  end
-  return sign.(x) .* max.(R(0), abs.(x) .- λ), R(0)
+    return sign.(x) .* max.(R(0), abs.(x) .- λ), R(0)
 end

--- a/src/functions/indBallL1.jl
+++ b/src/functions/indBallL1.jl
@@ -37,7 +37,7 @@ function (f::IndBallL1)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComple
 	return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	# TODO: a faster algorithm
 	if norm(x, 1) - f.r <= f.r*eps(R)
 		y .= x
@@ -52,14 +52,14 @@ function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=
 			tmax = (s - f.r)/i
 			if tmax >= p[i+1]
 				@inbounds for j in eachindex(x)
-					y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
+					y[j] = sign(x[j])*max(abs(x[j])-tmax, R(0))
 				end
 				return R(0)
 			end
 		end
 		tmax = (s + p[n] - f.r)/n
 		@inbounds for j in eachindex(x)
-			y[j] = sign(x[j])*max(abs(x[j])-tmax, zero(R))
+			y[j] = sign(x[j])*max(abs(x[j])-tmax, R(0))
 		end
 		return R(0)
 	end
@@ -70,7 +70,7 @@ fun_dom(f::IndBallL1) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndBallL1) = "x ↦ 0 if ‖x‖_1 ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL1) = "r = $(f.r)"
 
-function prox_naive(f::IndBallL1, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::IndBallL1, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	# do a simple bisection (aka binary search) on λ
 	L = R(0)
 	U = maximum(abs, x)

--- a/src/functions/indBallL1.jl
+++ b/src/functions/indBallL1.jl
@@ -5,7 +5,7 @@ export IndBallL1
 """
 **Indicator of a ``L_1`` norm ball**
 
-	IndBallL1(r=1.0)
+    IndBallL1(r=1.0)
 
 Returns the indicator function of the set
 ```math
@@ -14,14 +14,14 @@ S = \\left\\{ x : ∑_i |x_i| \\leq r \\right\\}.
 Parameter `r` must be positive.
 """
 struct IndBallL1{R <: Real} <: ProximableFunction
-	r::R
-	function IndBallL1{R}(r::R) where {R <: Real}
-		if r <= 0
-			error("parameter r must be positive")
-		else
-			new(r)
-		end
-	end
+    r::R
+    function IndBallL1{R}(r::R) where {R <: Real}
+        if r <= 0
+            error("parameter r must be positive")
+        else
+            new(r)
+        end
+    end
 end
 
 is_convex(f::IndBallL1) = true
@@ -31,38 +31,38 @@ is_prox_accurate(f::IndBallL1) = false
 IndBallL1(r::R=1.0) where {R <: Real} = IndBallL1{R}(r)
 
 function (f::IndBallL1)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-	if norm(x, 1) - f.r > f.r*eps(R)
-		return R(Inf)
-	end
-	return R(0)
+    if norm(x, 1) - f.r > f.r*eps(R)
+        return R(Inf)
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	# TODO: a faster algorithm
-	if norm(x, 1) - f.r <= f.r*eps(R)
-		y .= x
-		return R(0)
-	else # do a projection of abs(x) onto simplex then recover signs
-		n = length(x)
-		p = abs.(view(x,:))
-		sort!(p, rev=true)
-		s = R(0)
-		@inbounds for i = 1:n-1
-			s = s + p[i]
-			tmax = (s - f.r)/i
-			if tmax >= p[i+1]
-				@inbounds for j in eachindex(x)
-					y[j] = sign(x[j])*max(abs(x[j])-tmax, R(0))
-				end
-				return R(0)
-			end
-		end
-		tmax = (s + p[n] - f.r)/n
-		@inbounds for j in eachindex(x)
-			y[j] = sign(x[j])*max(abs(x[j])-tmax, R(0))
-		end
-		return R(0)
-	end
+    # TODO: a faster algorithm
+    if norm(x, 1) - f.r <= f.r*eps(R)
+        y .= x
+        return R(0)
+    else # do a projection of abs(x) onto simplex then recover signs
+        n = length(x)
+        p = abs.(view(x,:))
+        sort!(p, rev=true)
+        s = R(0)
+        @inbounds for i = 1:n-1
+            s = s + p[i]
+            tmax = (s - f.r)/i
+            if tmax >= p[i+1]
+                @inbounds for j in eachindex(x)
+                    y[j] = sign(x[j])*max(abs(x[j])-tmax, R(0))
+                end
+                return R(0)
+            end
+        end
+        tmax = (s + p[n] - f.r)/n
+        @inbounds for j in eachindex(x)
+            y[j] = sign(x[j])*max(abs(x[j])-tmax, R(0))
+        end
+        return R(0)
+    end
 end
 
 fun_name(f::IndBallL1) = "indicator of an L1 norm ball"
@@ -71,21 +71,21 @@ fun_expr(f::IndBallL1) = "x ↦ 0 if ‖x‖_1 ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL1) = "r = $(f.r)"
 
 function prox_naive(f::IndBallL1, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	# do a simple bisection (aka binary search) on λ
-	L = R(0)
-	U = maximum(abs, x)
-	λ = L
-	v = R(0)
-	maxit = 120
-	for iter in 1:maxit
-		λ = 0.5*(L + U)
-		v = sum(max.(abs.(x) .- λ, R(0)))
-		# modify lower or upper bound
-		(v < f.r) ? U = λ : L = λ
-		# exit condition
-		if abs(L - U) < (1 + abs(U))*eps(R)
-			break
-		end
-	end
-	return sign.(x) .* max.(R(0), abs.(x) .- λ), R(0)
+    # do a simple bisection (aka binary search) on λ
+    L = R(0)
+    U = maximum(abs, x)
+    λ = L
+    v = R(0)
+    maxit = 120
+    for iter in 1:maxit
+        λ = 0.5*(L + U)
+        v = sum(max.(abs.(x) .- λ, R(0)))
+        # modify lower or upper bound
+        (v < f.r) ? U = λ : L = λ
+        # exit condition
+        if abs(L - U) < (1 + abs(U))*eps(R)
+            break
+        end
+    end
+    return sign.(x) .* max.(R(0), abs.(x) .- λ), R(0)
 end

--- a/src/functions/indBallL2.jl
+++ b/src/functions/indBallL2.jl
@@ -5,7 +5,7 @@ export IndBallL2
 """
 **Indicator of a Euclidean ball**
 
-	IndBallL2(r=1.0)
+    IndBallL2(r=1.0)
 
 Returns the indicator function of the set
 ```math
@@ -14,14 +14,14 @@ S = \\{ x : \\|x\\| \\leq r \\},
 where ``\\|\\cdot\\|`` is the ``L_2`` (Euclidean) norm. Parameter `r` must be positive.
 """
 struct IndBallL2{R <: Real} <: ProximableFunction
-	r::R
-	function IndBallL2{R}(r::R) where {R <: Real}
-		if r <= 0
-			error("parameter r must be positive")
-		else
-			new(r)
-		end
-	end
+    r::R
+    function IndBallL2{R}(r::R) where {R <: Real}
+        if r <= 0
+            error("parameter r must be positive")
+        else
+            new(r)
+        end
+    end
 end
 
 is_convex(f::IndBallL2) = true
@@ -30,22 +30,22 @@ is_set(f::IndBallL2) = true
 IndBallL2(r::R=1.0) where {R <: Real} = IndBallL2{R}(r)
 
 function (f::IndBallL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-	if norm(x) - f.r > f.r*eps(R)
-		return R(Inf)
-	end
-	return R(0)
+    if norm(x) - f.r > f.r*eps(R)
+        return R(Inf)
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBallL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	scal = f.r/norm(x)
-	if scal > 1
-		y .= x
-		return R(0)
-	end
-	for k in eachindex(x)
-		y[k] = scal*x[k]
-	end
-	return R(0)
+    scal = f.r/norm(x)
+    if scal > 1
+        y .= x
+        return R(0)
+    end
+    for k in eachindex(x)
+        y[k] = scal*x[k]
+    end
+    return R(0)
 end
 
 fun_name(f::IndBallL2) = "indicator of an L2 norm ball"
@@ -54,11 +54,11 @@ fun_expr(f::IndBallL2) = "x ↦ 0 if ||x|| ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL2) = "r = $(f.r)"
 
 function prox_naive(f::IndBallL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	normx = norm(x)
-	if normx > f.r
-		y = (f.r/normx)*x
-	else
-		y = x
-	end
-	return y, R(0)
+    normx = norm(x)
+    if normx > f.r
+        y = (f.r/normx)*x
+    else
+        y = x
+    end
+    return y, R(0)
 end

--- a/src/functions/indBallL2.jl
+++ b/src/functions/indBallL2.jl
@@ -5,7 +5,7 @@ export IndBallL2
 """
 **Indicator of a Euclidean ball**
 
-    IndBallL2(r=1.0)
+	IndBallL2(r=1.0)
 
 Returns the indicator function of the set
 ```math
@@ -14,14 +14,14 @@ S = \\{ x : \\|x\\| \\leq r \\},
 where ``\\|\\cdot\\|`` is the ``L_2`` (Euclidean) norm. Parameter `r` must be positive.
 """
 struct IndBallL2{R <: Real} <: ProximableFunction
-    r::R
-    function IndBallL2{R}(r::R) where {R <: Real}
-        if r <= 0
-            error("parameter r must be positive")
-        else
-            new(r)
-        end
-    end
+	r::R
+	function IndBallL2{R}(r::R) where {R <: Real}
+		if r <= 0
+			error("parameter r must be positive")
+		else
+			new(r)
+		end
+	end
 end
 
 is_convex(f::IndBallL2) = true
@@ -30,22 +30,22 @@ is_set(f::IndBallL2) = true
 IndBallL2(r::R=1.0) where {R <: Real} = IndBallL2{R}(r)
 
 function (f::IndBallL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-    if norm(x) - f.r > f.r*eps(R)
-        return R(Inf)
-    end
-    return R(0)
+	if norm(x) - f.r > f.r*eps(R)
+		return R(Inf)
+	end
+	return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBallL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-    scal = f.r/norm(x)
-    if scal > 1
-        y .= x
-        return R(0)
-    end
-    for k in eachindex(x)
-        y[k] = scal*x[k]
-    end
-    return R(0)
+	scal = f.r/norm(x)
+	if scal > 1
+		y .= x
+		return R(0)
+	end
+	for k in eachindex(x)
+		y[k] = scal*x[k]
+	end
+	return R(0)
 end
 
 fun_name(f::IndBallL2) = "indicator of an L2 norm ball"
@@ -54,11 +54,11 @@ fun_expr(f::IndBallL2) = "x ↦ 0 if ||x|| ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL2) = "r = $(f.r)"
 
 function prox_naive(f::IndBallL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-    normx = norm(x)
-    if normx > f.r
-        y = (f.r/normx)*x
-    else
-        y = x
-    end
-    return y, R(0)
+	normx = norm(x)
+	if normx > f.r
+		y = (f.r/normx)*x
+	else
+		y = x
+	end
+	return y, R(0)
 end

--- a/src/functions/indBallL2.jl
+++ b/src/functions/indBallL2.jl
@@ -14,14 +14,14 @@ S = \\{ x : \\|x\\| \\leq r \\},
 where ``\\|\\cdot\\|`` is the ``L_2`` (Euclidean) norm. Parameter `r` must be positive.
 """
 struct IndBallL2{R <: Real} <: ProximableFunction
-  r::R
-  function IndBallL2{R}(r::R) where {R <: Real}
-    if r <= 0
-      error("parameter r must be positive")
-    else
-      new(r)
+    r::R
+    function IndBallL2{R}(r::R) where {R <: Real}
+        if r <= 0
+            error("parameter r must be positive")
+        else
+            new(r)
+        end
     end
-  end
 end
 
 is_convex(f::IndBallL2) = true
@@ -30,22 +30,22 @@ is_set(f::IndBallL2) = true
 IndBallL2(r::R=1.0) where {R <: Real} = IndBallL2{R}(r)
 
 function (f::IndBallL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-  if norm(x) - f.r > 1e-14
-    return R(Inf)
-  end
-  return R(0)
+    if norm(x) - f.r > f.r*eps(R)
+        return R(Inf)
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBallL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  scal = f.r/norm(x)
-  if scal > 1
-    y .= x
+    scal = f.r/norm(x)
+    if scal > 1
+        y .= x
+        return R(0)
+    end
+    for k in eachindex(x)
+        y[k] = scal*x[k]
+    end
     return R(0)
-  end
-  for k in eachindex(x)
-    y[k] = scal*x[k]
-  end
-  return R(0)
 end
 
 fun_name(f::IndBallL2) = "indicator of an L2 norm ball"
@@ -54,11 +54,11 @@ fun_expr(f::IndBallL2) = "x ↦ 0 if ||x|| ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL2) = "r = $(f.r)"
 
 function prox_naive(f::IndBallL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-  normx = norm(x)
-  if normx > f.r
-    y = (f.r/normx)*x
-  else
-    y = x
-  end
-  return y, R(0)
+    normx = norm(x)
+    if normx > f.r
+        y = (f.r/normx)*x
+    else
+        y = x
+    end
+    return y, R(0)
 end

--- a/src/functions/indBallL2.jl
+++ b/src/functions/indBallL2.jl
@@ -29,23 +29,23 @@ is_set(f::IndBallL2) = true
 
 IndBallL2(r::R=1.0) where {R <: Real} = IndBallL2{R}(r)
 
-function (f::IndBallL2)(x::AbstractArray{T}) where T <: RealOrComplex
+function (f::IndBallL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
   if norm(x) - f.r > 1e-14
-    return +Inf
+    return R(Inf)
   end
-  return zero(T)
+  return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndBallL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
+function prox!(y::AbstractArray{T}, f::IndBallL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
   scal = f.r/norm(x)
   if scal > 1
     y .= x
-    return zero(T)
+    return R(0)
   end
   for k in eachindex(x)
     y[k] = scal*x[k]
   end
-  return zero(T)
+  return R(0)
 end
 
 fun_name(f::IndBallL2) = "indicator of an L2 norm ball"
@@ -53,12 +53,12 @@ fun_dom(f::IndBallL2) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndBallL2) = "x ↦ 0 if ||x|| ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL2) = "r = $(f.r)"
 
-function prox_naive(f::IndBallL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
+function prox_naive(f::IndBallL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
   normx = norm(x)
   if normx > f.r
     y = (f.r/normx)*x
   else
     y = x
   end
-  return y, 0.0
+  return y, R(0)
 end

--- a/src/functions/indBallL2.jl
+++ b/src/functions/indBallL2.jl
@@ -36,7 +36,7 @@ function (f::IndBallL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComple
 	return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndBallL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::IndBallL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	scal = f.r/norm(x)
 	if scal > 1
 		y .= x
@@ -53,7 +53,7 @@ fun_dom(f::IndBallL2) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndBallL2) = "x ↦ 0 if ||x|| ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL2) = "r = $(f.r)"
 
-function prox_naive(f::IndBallL2{R}, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::IndBallL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
 	normx = norm(x)
 	if normx > f.r
 		y = (f.r/normx)*x

--- a/src/functions/indBallL2.jl
+++ b/src/functions/indBallL2.jl
@@ -36,7 +36,7 @@ function (f::IndBallL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComple
 	return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndBallL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::IndBallL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	scal = f.r/norm(x)
 	if scal > 1
 		y .= x
@@ -53,7 +53,7 @@ fun_dom(f::IndBallL2) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndBallL2) = "x ↦ 0 if ||x|| ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL2) = "r = $(f.r)"
 
-function prox_naive(f::IndBallL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::IndBallL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	normx = norm(x)
 	if normx > f.r
 		y = (f.r/normx)*x

--- a/src/functions/indBallRank.jl
+++ b/src/functions/indBallRank.jl
@@ -8,7 +8,7 @@ export IndBallRank
 """
 **Indicator of rank ball**
 
-    IndBallRank(r=1)
+	IndBallRank(r=1)
 
 Returns the indicator function of the set of matrices of rank at most `r`:
 ```math
@@ -17,14 +17,14 @@ S = \\{ X : \\mathrm{rank}(X) \\leq r \\},
 Parameter `r` must be a positive integer.
 """
 struct IndBallRank{I <: Integer} <: ProximableFunction
-    r::I
-    function IndBallRank{I}(r::I) where {I <: Integer}
-        if r <= 0
-            error("parameter r must be a positive integer")
-        else
-            new(r)
-        end
-    end
+	r::I
+	function IndBallRank{I}(r::I) where {I <: Integer}
+		if r <= 0
+			error("parameter r must be a positive integer")
+		else
+			new(r)
+		end
+	end
 end
 
 is_set(f::IndBallRank) = true
@@ -33,27 +33,27 @@ is_prox_accurate(f::IndBallRank) = false
 IndBallRank(r::I=1) where {I <: Integer} = IndBallRank{I}(r)
 
 function (f::IndBallRank)(x::AbstractArray{T, 2}) where {R <: Real, T <: RealOrComplex{R}}
-    maxr = minimum(size(x))
-    if maxr <= f.r return zero(R) end
-    U, S, V = tsvd(x, f.r+1)
-    # the tolerance in the following line should be customizable
-    if S[end]/S[1] <= 1e-7
-        return zero(R)
-    end
-    return +Inf
+	maxr = minimum(size(x))
+	if maxr <= f.r return zero(R) end
+	U, S, V = tsvd(x, f.r+1)
+	# the tolerance in the following line should be customizable
+	if S[end]/S[1] <= 1e-7
+		return zero(R)
+	end
+	return +Inf
 end
 
 function prox!(y::AbstractMatrix{T}, f::IndBallRank, x::AbstractMatrix{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-    maxr = minimum(size(x))
-    if maxr <= f.r
-        y .= x
-        return zero(R)
-    end
-    U, S, V = tsvd(x, f.r)
-    # TODO: the order of the following matrix products should depend on the shape of x
-    M = S .* V'
-    mul!(y, U, M)
-    return zero(R)
+	maxr = minimum(size(x))
+	if maxr <= f.r
+		y .= x
+		return zero(R)
+	end
+	U, S, V = tsvd(x, f.r)
+	# TODO: the order of the following matrix products should depend on the shape of x
+	M = S .* V'
+	mul!(y, U, M)
+	return zero(R)
 end
 
 fun_name(f::IndBallRank) = "indicator of the set of rank-r matrices"
@@ -62,12 +62,12 @@ fun_expr(f::IndBallRank) = "x ↦ 0 if rank(x) ⩽ r, +∞ otherwise"
 fun_params(f::IndBallRank) = "r = $(f.r)"
 
 function prox_naive(f::IndBallRank, x::AbstractMatrix{T}, gamma=1.0) where T
-    maxr = minimum(size(x))
-    if maxr <= f.r
-        y = x
-        return y, 0.0
-    end
-    F = svd(x)
-    y = F.U[:,1:f.r]*(Diagonal(F.S[1:f.r])*F.V[:,1:f.r]')
-    return y, 0.0
+	maxr = minimum(size(x))
+	if maxr <= f.r
+		y = x
+		return y, 0.0
+	end
+	F = svd(x)
+	y = F.U[:,1:f.r]*(Diagonal(F.S[1:f.r])*F.V[:,1:f.r]')
+	return y, 0.0
 end

--- a/src/functions/indBallRank.jl
+++ b/src/functions/indBallRank.jl
@@ -8,7 +8,7 @@ export IndBallRank
 """
 **Indicator of rank ball**
 
-	IndBallRank(r=1)
+    IndBallRank(r=1)
 
 Returns the indicator function of the set of matrices of rank at most `r`:
 ```math
@@ -17,14 +17,14 @@ S = \\{ X : \\mathrm{rank}(X) \\leq r \\},
 Parameter `r` must be a positive integer.
 """
 struct IndBallRank{I <: Integer} <: ProximableFunction
-	r::I
-	function IndBallRank{I}(r::I) where {I <: Integer}
-		if r <= 0
-			error("parameter r must be a positive integer")
-		else
-			new(r)
-		end
-	end
+    r::I
+    function IndBallRank{I}(r::I) where {I <: Integer}
+        if r <= 0
+            error("parameter r must be a positive integer")
+        else
+            new(r)
+        end
+    end
 end
 
 is_set(f::IndBallRank) = true
@@ -33,27 +33,27 @@ is_prox_accurate(f::IndBallRank) = false
 IndBallRank(r::I=1) where {I <: Integer} = IndBallRank{I}(r)
 
 function (f::IndBallRank)(x::AbstractArray{T, 2}) where {R <: Real, T <: RealOrComplex{R}}
-	maxr = minimum(size(x))
-	if maxr <= f.r return R(0) end
-	U, S, V = tsvd(x, f.r+1)
-	# the tolerance in the following line should be customizable
-	if S[end]/S[1] <= 1e-7
-		return R(0)
-	end
-	return R(Inf)
+    maxr = minimum(size(x))
+    if maxr <= f.r return R(0) end
+    U, S, V = tsvd(x, f.r+1)
+    # the tolerance in the following line should be customizable
+    if S[end]/S[1] <= 1e-7
+        return R(0)
+    end
+    return R(Inf)
 end
 
 function prox!(y::AbstractMatrix{T}, f::IndBallRank, x::AbstractMatrix{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	maxr = minimum(size(x))
-	if maxr <= f.r
-		y .= x
-		return R(0)
-	end
-	U, S, V = tsvd(x, f.r)
-	# TODO: the order of the following matrix products should depend on the shape of x
-	M = S .* V'
-	mul!(y, U, M)
-	return R(0)
+    maxr = minimum(size(x))
+    if maxr <= f.r
+        y .= x
+        return R(0)
+    end
+    U, S, V = tsvd(x, f.r)
+    # TODO: the order of the following matrix products should depend on the shape of x
+    M = S .* V'
+    mul!(y, U, M)
+    return R(0)
 end
 
 fun_name(f::IndBallRank) = "indicator of the set of rank-r matrices"
@@ -62,12 +62,12 @@ fun_expr(f::IndBallRank) = "x ↦ 0 if rank(x) ⩽ r, +∞ otherwise"
 fun_params(f::IndBallRank) = "r = $(f.r)"
 
 function prox_naive(f::IndBallRank, x::AbstractMatrix{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	maxr = minimum(size(x))
-	if maxr <= f.r
-		y = x
-		return y, R(0)
-	end
-	F = svd(x)
-	y = F.U[:,1:f.r]*(Diagonal(F.S[1:f.r])*F.V[:,1:f.r]')
-	return y, R(0)
+    maxr = minimum(size(x))
+    if maxr <= f.r
+        y = x
+        return y, R(0)
+    end
+    F = svd(x)
+    y = F.U[:,1:f.r]*(Diagonal(F.S[1:f.r])*F.V[:,1:f.r]')
+    return y, R(0)
 end

--- a/src/functions/indBallRank.jl
+++ b/src/functions/indBallRank.jl
@@ -34,26 +34,26 @@ IndBallRank(r::I=1) where {I <: Integer} = IndBallRank{I}(r)
 
 function (f::IndBallRank)(x::AbstractArray{T, 2}) where {R <: Real, T <: RealOrComplex{R}}
 	maxr = minimum(size(x))
-	if maxr <= f.r return zero(R) end
+	if maxr <= f.r return R(0) end
 	U, S, V = tsvd(x, f.r+1)
 	# the tolerance in the following line should be customizable
 	if S[end]/S[1] <= 1e-7
-		return zero(R)
+		return R(0)
 	end
-	return +Inf
+	return R(Inf)
 end
 
-function prox!(y::AbstractMatrix{T}, f::IndBallRank, x::AbstractMatrix{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractMatrix{T}, f::IndBallRank, x::AbstractMatrix{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	maxr = minimum(size(x))
 	if maxr <= f.r
 		y .= x
-		return zero(R)
+		return R(0)
 	end
 	U, S, V = tsvd(x, f.r)
 	# TODO: the order of the following matrix products should depend on the shape of x
 	M = S .* V'
 	mul!(y, U, M)
-	return zero(R)
+	return R(0)
 end
 
 fun_name(f::IndBallRank) = "indicator of the set of rank-r matrices"
@@ -61,13 +61,13 @@ fun_dom(f::IndBallRank) = "AbstractArray{Real,2}, AbstractArray{Complex,2}"
 fun_expr(f::IndBallRank) = "x ↦ 0 if rank(x) ⩽ r, +∞ otherwise"
 fun_params(f::IndBallRank) = "r = $(f.r)"
 
-function prox_naive(f::IndBallRank, x::AbstractMatrix{T}, gamma=1.0) where T
+function prox_naive(f::IndBallRank, x::AbstractMatrix{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	maxr = minimum(size(x))
 	if maxr <= f.r
 		y = x
-		return y, 0.0
+		return y, R(0)
 	end
 	F = svd(x)
 	y = F.U[:,1:f.r]*(Diagonal(F.S[1:f.r])*F.V[:,1:f.r]')
-	return y, 0.0
+	return y, R(0)
 end

--- a/src/functions/indBinary.jl
+++ b/src/functions/indBinary.jl
@@ -5,7 +5,7 @@ export IndBinary
 """
 **Indicator of the product of binary sets**
 
-    IndBinary(low, up)
+	IndBinary(low, up)
 
 Returns the indicator function of the set
 ```math
@@ -14,8 +14,8 @@ S = \\{ x : x_i = low_i\\ \\text{or}\\ x_i = up_i \\},
 Parameters `low` and `up` can be either scalars or arrays of the same dimension as the space.
 """
 struct IndBinary{T <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}} <: ProximableFunction
-  low::T
-  high::S
+	low::T
+	high::S
 end
 
 is_set(f::IndBinary) = true
@@ -28,37 +28,37 @@ IndBinary_high(f::IndBinary{T, S}, i) where {T, S <: Real} = f.high
 IndBinary_high(f::IndBinary{T, S}, i) where {T, S <: AbstractArray} = f.high[i]
 
 function (f::IndBinary)(x::AbstractArray{T}) where T <: Real
-  for k in eachindex(x)
-    if x[k] != IndBinary_low(f, k) && x[k] != IndBinary_high(f, k)
-      return +Inf
-    end
-  end
-  return zero(T)
+	for k in eachindex(x)
+		if x[k] != IndBinary_low(f, k) && x[k] != IndBinary_high(f, k)
+			return +Inf
+		end
+	end
+	return zero(T)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBinary, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-  low = zero(T)
-  high = zero(T)
-  for k in eachindex(x)
-    low = IndBinary_low(f, k)
-    high = IndBinary_high(f, k)
-    if abs(x[k] - low) < abs(x[k] - high)
-      y[k] = low
-    else
-      y[k] = high
-    end
-  end
-  return zero(T)
+	low = zero(T)
+	high = zero(T)
+	for k in eachindex(x)
+		low = IndBinary_low(f, k)
+		high = IndBinary_high(f, k)
+		if abs(x[k] - low) < abs(x[k] - high)
+			y[k] = low
+		else
+			y[k] = high
+		end
+	end
+	return zero(T)
 end
 
 fun_name(f::IndBinary) = "indicator of binary array"
 fun_dom(f::IndBinary) = "AbstractArray{Real}"
 
 function prox_naive(f::IndBinary, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-  distlow = abs.(x .- f.low)
-  disthigh = abs.(x .- f.high)
-  indlow = distlow .< disthigh
-  indhigh = distlow .>= disthigh
-  y = f.low.*indlow + f.high.*indhigh
-  return y, 0.0
+	distlow = abs.(x .- f.low)
+	disthigh = abs.(x .- f.high)
+	indlow = distlow .< disthigh
+	indhigh = distlow .>= disthigh
+	y = f.low.*indlow + f.high.*indhigh
+	return y, 0.0
 end

--- a/src/functions/indBinary.jl
+++ b/src/functions/indBinary.jl
@@ -5,7 +5,7 @@ export IndBinary
 """
 **Indicator of the product of binary sets**
 
-	IndBinary(low, up)
+    IndBinary(low, up)
 
 Returns the indicator function of the set
 ```math
@@ -14,8 +14,8 @@ S = \\{ x : x_i = low_i\\ \\text{or}\\ x_i = up_i \\},
 Parameters `low` and `up` can be either scalars or arrays of the same dimension as the space.
 """
 struct IndBinary{C <: RealOrComplex, T <: Union{C, AbstractArray{C}}, S <: Union{C, AbstractArray{C}}} <: ProximableFunction
-	low::T
-	high::S
+    low::T
+    high::S
 end
 
 is_set(f::IndBinary) = true
@@ -28,35 +28,35 @@ IndBinary_high(f::IndBinary{C, T, C}, i) where {C, T} = f.high
 IndBinary_high(f::IndBinary{C, T, S}, i) where {C, T, S <: AbstractArray} = f.high[i]
 
 function (f::IndBinary)(x::AbstractArray{C}) where {R <: Real, C <: RealOrComplex{R}}
-	for k in eachindex(x)
-		if x[k] != IndBinary_low(f, k) && x[k] != IndBinary_high(f, k)
-			return R(Inf)
-		end
-	end
-	return R(0)
+    for k in eachindex(x)
+        if x[k] != IndBinary_low(f, k) && x[k] != IndBinary_high(f, k)
+            return R(Inf)
+        end
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndBinary, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: Union{R, Complex{R}}}
-	for k in eachindex(x)
-		low = IndBinary_low(f, k)
-		high = IndBinary_high(f, k)
-		if abs(x[k] - low) < abs(x[k] - high)
-			y[k] = low
-		else
-			y[k] = high
-		end
-	end
-	return R(0)
+    for k in eachindex(x)
+        low = IndBinary_low(f, k)
+        high = IndBinary_high(f, k)
+        if abs(x[k] - low) < abs(x[k] - high)
+            y[k] = low
+        else
+            y[k] = high
+        end
+    end
+    return R(0)
 end
 
 fun_name(f::IndBinary) = "indicator of binary array"
 fun_dom(f::IndBinary) = "AbstractArray{Real}"
 
 function prox_naive(f::IndBinary, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: Union{R, Complex{R}}}
-	distlow = abs.(x .- f.low)
-	disthigh = abs.(x .- f.high)
-	indlow = distlow .< disthigh
-	indhigh = distlow .>= disthigh
-	y = f.low.*indlow + f.high.*indhigh
-	return y, R(0)
+    distlow = abs.(x .- f.low)
+    disthigh = abs.(x .- f.high)
+    indlow = distlow .< disthigh
+    indhigh = distlow .>= disthigh
+    y = f.low.*indlow + f.high.*indhigh
+    return y, R(0)
 end

--- a/src/functions/indBinary.jl
+++ b/src/functions/indBinary.jl
@@ -13,32 +13,30 @@ S = \\{ x : x_i = low_i\\ \\text{or}\\ x_i = up_i \\},
 ```
 Parameters `low` and `up` can be either scalars or arrays of the same dimension as the space.
 """
-struct IndBinary{T <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}} <: ProximableFunction
+struct IndBinary{C <: RealOrComplex, T <: Union{C, AbstractArray{C}}, S <: Union{C, AbstractArray{C}}} <: ProximableFunction
 	low::T
 	high::S
 end
 
 is_set(f::IndBinary) = true
 
-IndBinary(low::T=0.0, high::T=1.0) where {T <: Real} = IndBinary{T, T}(low, high)
+IndBinary() = IndBinary(0.0, 1.0)
 
-IndBinary_low(f::IndBinary{T, S}, i) where {T <: Real, S} = f.low
-IndBinary_low(f::IndBinary{T, S}, i) where {T <: AbstractArray, S} = f.low[i]
-IndBinary_high(f::IndBinary{T, S}, i) where {T, S <: Real} = f.high
-IndBinary_high(f::IndBinary{T, S}, i) where {T, S <: AbstractArray} = f.high[i]
+IndBinary_low(f::IndBinary{C, C, S}, i) where {C, S} = f.low
+IndBinary_low(f::IndBinary{C, T, S}, i) where {C, T <: AbstractArray, S} = f.low[i]
+IndBinary_high(f::IndBinary{C, T, C}, i) where {C, T} = f.high
+IndBinary_high(f::IndBinary{C, T, S}, i) where {C, T, S <: AbstractArray} = f.high[i]
 
-function (f::IndBinary)(x::AbstractArray{T}) where T <: Real
+function (f::IndBinary)(x::AbstractArray{C}) where {R <: Real, C <: RealOrComplex{R}}
 	for k in eachindex(x)
 		if x[k] != IndBinary_low(f, k) && x[k] != IndBinary_high(f, k)
-			return +Inf
+			return R(Inf)
 		end
 	end
-	return zero(T)
+	return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndBinary, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-	low = zero(T)
-	high = zero(T)
+function prox!(y::AbstractArray{T}, f::IndBinary, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: Union{R, Complex{R}}}
 	for k in eachindex(x)
 		low = IndBinary_low(f, k)
 		high = IndBinary_high(f, k)
@@ -48,17 +46,17 @@ function prox!(y::AbstractArray{T}, f::IndBinary, x::AbstractArray{T}, gamma::Re
 			y[k] = high
 		end
 	end
-	return zero(T)
+	return R(0)
 end
 
 fun_name(f::IndBinary) = "indicator of binary array"
 fun_dom(f::IndBinary) = "AbstractArray{Real}"
 
-function prox_naive(f::IndBinary, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
+function prox_naive(f::IndBinary, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: Union{R, Complex{R}}}
 	distlow = abs.(x .- f.low)
 	disthigh = abs.(x .- f.high)
 	indlow = distlow .< disthigh
 	indhigh = distlow .>= disthigh
 	y = f.low.*indlow + f.high.*indhigh
-	return y, 0.0
+	return y, R(0)
 end

--- a/src/functions/indBox.jl
+++ b/src/functions/indBox.jl
@@ -52,7 +52,7 @@ function (f::IndBox)(x::AbstractArray{R}) where R <: Real
 	return 0.0
 end
 
-function prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::Real=one(R)) where R <: Real
+function prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::Real=R(1)) where R <: Real
 	for k in eachindex(x)
 		if x[k] < get_kth_elem(f.lb, k)
 			y[k] = get_kth_elem(f.lb, k)
@@ -62,10 +62,10 @@ function prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::Real=
 			y[k] = x[k]
 		end
 	end
-	return zero(R)
+	return R(0)
 end
 
-prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox!(y, f, x, one(R))
+prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox!(y, f, x, R(1))
 
 """
 **Indicator of a ``L_∞`` norm ball**
@@ -87,7 +87,7 @@ fun_params(f::IndBox) =
 	string( "lb = ", typeof(f.lb) <: AbstractArray ? string(typeof(f.lb), " of size ", size(f.lb)) : f.lb, ", ",
 			"ub = ", typeof(f.ub) <: AbstractArray ? string(typeof(f.ub), " of size ", size(f.ub)) : f.ub)
 
-function prox_naive(f::IndBox, x::AbstractArray{R}, gamma=one(R)) where R <: Real
+function prox_naive(f::IndBox, x::AbstractArray{R}, gamma=R(1)) where R <: Real
 	y = min.(f.ub, max.(f.lb, x))
-	return y, zero(R)
+	return y, R(0)
 end

--- a/src/functions/indBox.jl
+++ b/src/functions/indBox.jl
@@ -62,7 +62,7 @@ function prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::Real=
       y[k] = x[k]
     end
   end
-  return 0.0
+  return zero(R)
 end
 
 prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox!(y, f, x, one(R))
@@ -87,9 +87,7 @@ fun_params(f::IndBox) =
   string( "lb = ", typeof(f.lb) <: AbstractArray ? string(typeof(f.lb), " of size ", size(f.lb)) : f.lb, ", ",
           "ub = ", typeof(f.ub) <: AbstractArray ? string(typeof(f.ub), " of size ", size(f.ub)) : f.ub)
 
-function prox_naive(f::IndBox, x::AbstractArray{R}, gamma::Real=1.0) where R <: Real
+function prox_naive(f::IndBox, x::AbstractArray{R}, gamma=one(R)) where R <: Real
   y = min.(f.ub, max.(f.lb, x))
-  return y, 0.0
+  return y, zero(R)
 end
-
-prox_naive(f::IndBox, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox_naive(f, x, 1.0)

--- a/src/functions/indBox.jl
+++ b/src/functions/indBox.jl
@@ -5,7 +5,7 @@ export IndBox, IndBallLinf
 """
 **Indicator of a box**
 
-    IndBox(low, up)
+	IndBox(low, up)
 
 Returns the indicator function of the set
 ```math
@@ -14,18 +14,18 @@ S = \\{ x : low \\leq x \\leq up \\}.
 Parameters `low` and `up` can be either scalars or arrays of the same dimension as the space: they must satisfy `low <= up`, and are allowed to take values `-Inf` and `+Inf` to indicate unbounded coordinates.
 """
 struct IndBox{T <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}} <: ProximableFunction
-  lb::T
-  ub::S
-  function IndBox{T,S}(lb::T, ub::S) where {T <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
-    if !(eltype(lb) <: Real && eltype(ub) <: Real)
-      error("`lb` and `ub` must be real")
-    end
-    if any(lb .> ub)
-      error("`lb` and `ub` must satisfy `lb <= ub`")
-    else
-      new(lb, ub)
-    end
-  end
+	lb::T
+	ub::S
+	function IndBox{T,S}(lb::T, ub::S) where {T <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
+		if !(eltype(lb) <: Real && eltype(ub) <: Real)
+			error("`lb` and `ub` must be real")
+		end
+		if any(lb .> ub)
+			error("`lb` and `ub` must satisfy `lb <= ub`")
+		else
+			new(lb, ub)
+		end
+	end
 end
 
 is_separable(f::IndBox) = true
@@ -40,29 +40,29 @@ IndBox(lb::T, ub::S) where {T <: AbstractArray, S <: Real} = IndBox{T, S}(lb, ub
 IndBox(lb::T, ub::S) where {T <: Real, S <: AbstractArray} = IndBox{T, S}(lb, ub)
 
 IndBox(lb::T, ub::S) where {T <: AbstractArray, S <: AbstractArray} =
-  size(lb) != size(ub) ? error("bounds must have the same dimensions, or at least one of them be scalar") :
-  IndBox{T, S}(lb, ub)
+	size(lb) != size(ub) ? error("bounds must have the same dimensions, or at least one of them be scalar") :
+	IndBox{T, S}(lb, ub)
 
 function (f::IndBox)(x::AbstractArray{R}) where R <: Real
-  for k in eachindex(x)
-    if x[k] < get_kth_elem(f.lb, k) || x[k] > get_kth_elem(f.ub, k)
-      return +Inf
-    end
-  end
-  return 0.0
+	for k in eachindex(x)
+		if x[k] < get_kth_elem(f.lb, k) || x[k] > get_kth_elem(f.ub, k)
+			return +Inf
+		end
+	end
+	return 0.0
 end
 
 function prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::Real=one(R)) where R <: Real
-  for k in eachindex(x)
-    if x[k] < get_kth_elem(f.lb, k)
-      y[k] = get_kth_elem(f.lb, k)
-    elseif x[k] > get_kth_elem(f.ub, k)
-      y[k] = get_kth_elem(f.ub, k)
-    else
-      y[k] = x[k]
-    end
-  end
-  return zero(R)
+	for k in eachindex(x)
+		if x[k] < get_kth_elem(f.lb, k)
+			y[k] = get_kth_elem(f.lb, k)
+		elseif x[k] > get_kth_elem(f.ub, k)
+			y[k] = get_kth_elem(f.ub, k)
+		else
+			y[k] = x[k]
+		end
+	end
+	return zero(R)
 end
 
 prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox!(y, f, x, one(R))
@@ -70,7 +70,7 @@ prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::AbstractArray)
 """
 **Indicator of a ``L_∞`` norm ball**
 
-    IndBallLinf(r=1.0)
+	IndBallLinf(r=1.0)
 
 Returns the indicator function of the set
 ```math
@@ -84,10 +84,10 @@ fun_name(f::IndBox) = "indicator of a box"
 fun_dom(f::IndBox) = "AbstractArray{Real}"
 fun_expr(f::IndBox) = "x ↦ 0 if all(lb ⩽ x ⩽ ub), +∞ otherwise"
 fun_params(f::IndBox) =
-  string( "lb = ", typeof(f.lb) <: AbstractArray ? string(typeof(f.lb), " of size ", size(f.lb)) : f.lb, ", ",
-          "ub = ", typeof(f.ub) <: AbstractArray ? string(typeof(f.ub), " of size ", size(f.ub)) : f.ub)
+	string( "lb = ", typeof(f.lb) <: AbstractArray ? string(typeof(f.lb), " of size ", size(f.lb)) : f.lb, ", ",
+			"ub = ", typeof(f.ub) <: AbstractArray ? string(typeof(f.ub), " of size ", size(f.ub)) : f.ub)
 
 function prox_naive(f::IndBox, x::AbstractArray{R}, gamma=one(R)) where R <: Real
-  y = min.(f.ub, max.(f.lb, x))
-  return y, zero(R)
+	y = min.(f.ub, max.(f.lb, x))
+	return y, zero(R)
 end

--- a/src/functions/indBox.jl
+++ b/src/functions/indBox.jl
@@ -5,7 +5,7 @@ export IndBox, IndBallLinf
 """
 **Indicator of a box**
 
-	IndBox(low, up)
+    IndBox(low, up)
 
 Returns the indicator function of the set
 ```math
@@ -14,18 +14,18 @@ S = \\{ x : low \\leq x \\leq up \\}.
 Parameters `low` and `up` can be either scalars or arrays of the same dimension as the space: they must satisfy `low <= up`, and are allowed to take values `-Inf` and `+Inf` to indicate unbounded coordinates.
 """
 struct IndBox{T <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}} <: ProximableFunction
-	lb::T
-	ub::S
-	function IndBox{T,S}(lb::T, ub::S) where {T <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
-		if !(eltype(lb) <: Real && eltype(ub) <: Real)
-			error("`lb` and `ub` must be real")
-		end
-		if any(lb .> ub)
-			error("`lb` and `ub` must satisfy `lb <= ub`")
-		else
-			new(lb, ub)
-		end
-	end
+    lb::T
+    ub::S
+    function IndBox{T,S}(lb::T, ub::S) where {T <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
+        if !(eltype(lb) <: Real && eltype(ub) <: Real)
+            error("`lb` and `ub` must be real")
+        end
+        if any(lb .> ub)
+            error("`lb` and `ub` must satisfy `lb <= ub`")
+        else
+            new(lb, ub)
+        end
+    end
 end
 
 is_separable(f::IndBox) = true
@@ -40,29 +40,29 @@ IndBox(lb::T, ub::S) where {T <: AbstractArray, S <: Real} = IndBox{T, S}(lb, ub
 IndBox(lb::T, ub::S) where {T <: Real, S <: AbstractArray} = IndBox{T, S}(lb, ub)
 
 IndBox(lb::T, ub::S) where {T <: AbstractArray, S <: AbstractArray} =
-	size(lb) != size(ub) ? error("bounds must have the same dimensions, or at least one of them be scalar") :
-	IndBox{T, S}(lb, ub)
+    size(lb) != size(ub) ? error("bounds must have the same dimensions, or at least one of them be scalar") :
+    IndBox{T, S}(lb, ub)
 
 function (f::IndBox)(x::AbstractArray{R}) where R <: Real
-	for k in eachindex(x)
-		if x[k] < get_kth_elem(f.lb, k) || x[k] > get_kth_elem(f.ub, k)
-			return +Inf
-		end
-	end
-	return 0.0
+    for k in eachindex(x)
+        if x[k] < get_kth_elem(f.lb, k) || x[k] > get_kth_elem(f.ub, k)
+            return +Inf
+        end
+    end
+    return 0.0
 end
 
 function prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::Real=R(1)) where R <: Real
-	for k in eachindex(x)
-		if x[k] < get_kth_elem(f.lb, k)
-			y[k] = get_kth_elem(f.lb, k)
-		elseif x[k] > get_kth_elem(f.ub, k)
-			y[k] = get_kth_elem(f.ub, k)
-		else
-			y[k] = x[k]
-		end
-	end
-	return R(0)
+    for k in eachindex(x)
+        if x[k] < get_kth_elem(f.lb, k)
+            y[k] = get_kth_elem(f.lb, k)
+        elseif x[k] > get_kth_elem(f.ub, k)
+            y[k] = get_kth_elem(f.ub, k)
+        else
+            y[k] = x[k]
+        end
+    end
+    return R(0)
 end
 
 prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox!(y, f, x, R(1))
@@ -70,7 +70,7 @@ prox!(y::AbstractArray{R}, f::IndBox, x::AbstractArray{R}, gamma::AbstractArray)
 """
 **Indicator of a ``L_∞`` norm ball**
 
-	IndBallLinf(r=1.0)
+    IndBallLinf(r=1.0)
 
 Returns the indicator function of the set
 ```math
@@ -84,10 +84,10 @@ fun_name(f::IndBox) = "indicator of a box"
 fun_dom(f::IndBox) = "AbstractArray{Real}"
 fun_expr(f::IndBox) = "x ↦ 0 if all(lb ⩽ x ⩽ ub), +∞ otherwise"
 fun_params(f::IndBox) =
-	string( "lb = ", typeof(f.lb) <: AbstractArray ? string(typeof(f.lb), " of size ", size(f.lb)) : f.lb, ", ",
-			"ub = ", typeof(f.ub) <: AbstractArray ? string(typeof(f.ub), " of size ", size(f.ub)) : f.ub)
+    string( "lb = ", typeof(f.lb) <: AbstractArray ? string(typeof(f.lb), " of size ", size(f.lb)) : f.lb, ", ",
+            "ub = ", typeof(f.ub) <: AbstractArray ? string(typeof(f.ub), " of size ", size(f.ub)) : f.ub)
 
 function prox_naive(f::IndBox, x::AbstractArray{R}, gamma=R(1)) where R <: Real
-	y = min.(f.ub, max.(f.lb, x))
-	return y, R(0)
+    y = min.(f.ub, max.(f.lb, x))
+    return y, R(0)
 end

--- a/src/functions/indExp.jl
+++ b/src/functions/indExp.jl
@@ -6,7 +6,7 @@ export IndExpPrimal, IndExpDual
 """
 **Indicator of the (primal) exponential cone**
 
-    IndExpPrimal()
+	IndExpPrimal()
 
 Returns the indicator function of the primal exponential cone, that is
 ```math
@@ -21,7 +21,7 @@ is_cone(f::IndExpPrimal) = true
 """
 **Indicator of the (dual) exponential cone**
 
-    IndExpDual()
+	IndExpDual()
 
 Returns the indicator function of the dual exponential cone, that is
 ```math
@@ -36,19 +36,19 @@ EXP_PROJ_TOL = 1e-15
 EXP_PROJ_MAXIT = 100
 
 function (f::IndExpPrimal)(x::AbstractArray{R,1}) where R <: Real
-  if (x[2] > 0.0 && x[2]*exp(x[1]/x[2]) <= x[3]+EXP_PRIMAL_CALL_TOL) ||
-     (x[1] <= EXP_PRIMAL_CALL_TOL && abs(x[2]) <= EXP_PRIMAL_CALL_TOL && x[3] >= -EXP_PRIMAL_CALL_TOL)
-    return 0.0
-  end
-  return +Inf
+	if (x[2] > 0.0 && x[2]*exp(x[1]/x[2]) <= x[3]+EXP_PRIMAL_CALL_TOL) ||
+		(x[1] <= EXP_PRIMAL_CALL_TOL && abs(x[2]) <= EXP_PRIMAL_CALL_TOL && x[3] >= -EXP_PRIMAL_CALL_TOL)
+		return 0.0
+	end
+	return +Inf
 end
 
 function (f::Conjugate{IndExpPrimal})(x::AbstractArray{R,1}) where R <: Real
-  if (x[1] > 0.0 && x[1]*exp(x[2]/x[1]) <= -exp(1)*x[3]+EXP_POLAR_CALL_TOL) ||
-     (abs(x[1]) <= EXP_POLAR_CALL_TOL && x[2] <= EXP_POLAR_CALL_TOL && x[3] <= EXP_POLAR_CALL_TOL)
-    return 0.0
-  end
-  return +Inf
+	if (x[1] > 0.0 && x[1]*exp(x[2]/x[1]) <= -exp(1)*x[3]+EXP_POLAR_CALL_TOL) ||
+		(abs(x[1]) <= EXP_POLAR_CALL_TOL && x[2] <= EXP_POLAR_CALL_TOL && x[3] <= EXP_POLAR_CALL_TOL)
+		return 0.0
+	end
+	return +Inf
 end
 
 # Projection onto the cone is performed as in SCS (https://github.com/cvxgrp/scs).
@@ -77,89 +77,89 @@ end
 # SOFTWARE.
 
 function prox!(y::AbstractVector{R}, f::IndExpPrimal, x::AbstractVector{R}, gamma::R=1.0) where R <: Real
-  r = x[1]
-  s = x[2]
-  t = x[3]
-  if (s*exp(r/s) <= t && s > 0) || (r <= 0 && s == 0 && t >= 0)
-    # x in the cone
-    y .= x
-  elseif (-r < 0 && r*exp(s/r) <= -exp(1)*t) || (-r == 0 && -s >= 0 && -t >= 0)
-    # -x in the dual cone (x in the polar cone)
-    y .= zero(R)
-  elseif r < 0 && s < 0
-    # analytical solution
-    y[1] = x[1]
-    y[2] = max(x[2], 0.0)
-    y[3] = max(x[3], 0.0)
-  else
-    v = x
-    ub, lb = getRhoUb(x)
-    for iter = 1:EXP_PROJ_MAXIT
-      rho = (ub + lb)/2
-      g, v = calcGrad(x,rho)
-      if g > 0
-        lb = rho
-      else
-        ub = rho
-      end
-      if ub - lb <= EXP_PROJ_TOL
-        break
-      end
-    end
-    y .= v
-  end
-  return zero(R)
+	r = x[1]
+	s = x[2]
+	t = x[3]
+	if (s*exp(r/s) <= t && s > 0) || (r <= 0 && s == 0 && t >= 0)
+		# x in the cone
+		y .= x
+	elseif (-r < 0 && r*exp(s/r) <= -exp(1)*t) || (-r == 0 && -s >= 0 && -t >= 0)
+		# -x in the dual cone (x in the polar cone)
+		y .= zero(R)
+	elseif r < 0 && s < 0
+		# analytical solution
+		y[1] = x[1]
+		y[2] = max(x[2], 0.0)
+		y[3] = max(x[3], 0.0)
+	else
+		v = x
+		ub, lb = getRhoUb(x)
+		for iter = 1:EXP_PROJ_MAXIT
+			rho = (ub + lb)/2
+			g, v = calcGrad(x,rho)
+			if g > 0
+				lb = rho
+			else
+				ub = rho
+			end
+			if ub - lb <= EXP_PROJ_TOL
+				break
+			end
+		end
+		y .= v
+	end
+	return zero(R)
 end
 
 function getRhoUb(v)
-  lb = 0
-  rho = 2.0^(-3)
-  g, z = calcGrad(v, rho)
-  while g > 0
-    lb = rho
-    rho = rho*2
-    g, z = calcGrad(v, rho)
-  end
-  ub = rho
-  return ub, lb
+	lb = 0
+	rho = 2.0^(-3)
+	g, z = calcGrad(v, rho)
+	while g > 0
+		lb = rho
+		rho = rho*2
+		g, z = calcGrad(v, rho)
+	end
+	ub = rho
+	return ub, lb
 end
 
 function calcGrad(v, rho)
-  x = solve_with_rho(v, rho)
-  if x[2] == 0.0
-    g = x[1]
-  else
-    g = x[1] + x[2]*log(x[2]/x[3])
-  end
-  return g, x
+	x = solve_with_rho(v, rho)
+	if x[2] == 0.0
+		g = x[1]
+	else
+		g = x[1] + x[2]*log(x[2]/x[3])
+	end
+	return g, x
 end
 
 function solve_with_rho(v, rho)
-  x = zeros(3)
-  x[3] = newton_exp_onz(rho, v[2], v[3])
-  x[2] = (1/rho)*(x[3] - v[3])*x[3]
-  x[1] = v[1] - rho
-  return x
+	x = zeros(3)
+	x[3] = newton_exp_onz(rho, v[2], v[3])
+	x[2] = (1/rho)*(x[3] - v[3])*x[3]
+	x[1] = v[1] - rho
+	return x
 end
 
 function newton_exp_onz(rho, y_hat, z_hat)
-  t = max(-z_hat,EXP_PROJ_TOL)
-  for iter=1:EXP_PROJ_MAXIT
-    f = (1.0/rho^2)*t*(t + z_hat) - y_hat/rho + log(t/rho) + 1.0
-    fp = (1.0/rho^2)*(2.0*t + z_hat) + 1.0/t
-    t = t - f/fp
-    if t <= -z_hat
-      t = -z_hat
-      break
-    elseif t <= 0
-      t = 0
-      break
-    elseif abs(f) <= EXP_PROJ_TOL
-      break
-    end
-  end
-  z = t + z_hat
-  return z
+	t = max(-z_hat,EXP_PROJ_TOL)
+	for iter=1:EXP_PROJ_MAXIT
+		f = (1.0/rho^2)*t*(t + z_hat) - y_hat/rho + log(t/rho) + 1.0
+		fp = (1.0/rho^2)*(2.0*t + z_hat) + 1.0/t
+		t = t - f/fp
+		if t <= -z_hat
+			t = -z_hat
+			break
+		elseif t <= 0
+			t = 0
+			break
+		elseif abs(f) <= EXP_PROJ_TOL
+			break
+		end
+	end
+	z = t + z_hat
+	return z
 end
 
 fun_name(f::IndExpPrimal) = "indicator exponential cone (primal)"
@@ -172,7 +172,7 @@ fun_expr(f::PrecomposeDiagonal{Conjugate{IndExpPrimal}, R}) where {R <: Real} = 
 fun_params(f::PrecomposeDiagonal{Conjugate{IndExpPrimal}, R}) where {R <: Real} = "none"
 
 prox_naive(f::IndExpPrimal, x::AbstractArray{R}, gamma::Real=1.0) where {R <: Real} =
-  prox(f, x, gamma) # we don't have a much simpler way to do this yet
+	prox(f, x, gamma) # we don't have a much simpler way to do this yet
 
 prox_naive(f::PrecomposeDiagonal{Conjugate{IndExpPrimal}}, x::AbstractArray{R}, gamma::Real=1.0) where {R <: Real} =
-  prox(f, x, gamma) # we don't have a much simpler way to do this yet
+	prox(f, x, gamma) # we don't have a much simpler way to do this yet

--- a/src/functions/indExp.jl
+++ b/src/functions/indExp.jl
@@ -85,7 +85,7 @@ function prox!(y::AbstractVector{R}, f::IndExpPrimal, x::AbstractVector{R}, gamm
 		y .= x
 	elseif (-r < 0 && r*exp(s/r) <= -exp(1)*t) || (-r == 0 && -s >= 0 && -t >= 0)
 		# -x in the dual cone (x in the polar cone)
-		y .= zero(R)
+		y .= R(0)
 	elseif r < 0 && s < 0
 		# analytical solution
 		y[1] = x[1]
@@ -108,7 +108,7 @@ function prox!(y::AbstractVector{R}, f::IndExpPrimal, x::AbstractVector{R}, gamm
 		end
 		y .= v
 	end
-	return zero(R)
+	return R(0)
 end
 
 function getRhoUb(v)

--- a/src/functions/indExp.jl
+++ b/src/functions/indExp.jl
@@ -6,7 +6,7 @@ export IndExpPrimal, IndExpDual
 """
 **Indicator of the (primal) exponential cone**
 
-	IndExpPrimal()
+    IndExpPrimal()
 
 Returns the indicator function of the primal exponential cone, that is
 ```math
@@ -21,7 +21,7 @@ is_cone(f::IndExpPrimal) = true
 """
 **Indicator of the (dual) exponential cone**
 
-	IndExpDual()
+    IndExpDual()
 
 Returns the indicator function of the dual exponential cone, that is
 ```math
@@ -36,19 +36,19 @@ EXP_PROJ_TOL = 1e-15
 EXP_PROJ_MAXIT = 100
 
 function (f::IndExpPrimal)(x::AbstractArray{R,1}) where R <: Real
-	if (x[2] > 0.0 && x[2]*exp(x[1]/x[2]) <= x[3]+EXP_PRIMAL_CALL_TOL) ||
-		(x[1] <= EXP_PRIMAL_CALL_TOL && abs(x[2]) <= EXP_PRIMAL_CALL_TOL && x[3] >= -EXP_PRIMAL_CALL_TOL)
-		return 0.0
-	end
-	return +Inf
+    if (x[2] > 0.0 && x[2]*exp(x[1]/x[2]) <= x[3]+EXP_PRIMAL_CALL_TOL) ||
+        (x[1] <= EXP_PRIMAL_CALL_TOL && abs(x[2]) <= EXP_PRIMAL_CALL_TOL && x[3] >= -EXP_PRIMAL_CALL_TOL)
+        return 0.0
+    end
+    return +Inf
 end
 
 function (f::Conjugate{IndExpPrimal})(x::AbstractArray{R,1}) where R <: Real
-	if (x[1] > 0.0 && x[1]*exp(x[2]/x[1]) <= -exp(1)*x[3]+EXP_POLAR_CALL_TOL) ||
-		(abs(x[1]) <= EXP_POLAR_CALL_TOL && x[2] <= EXP_POLAR_CALL_TOL && x[3] <= EXP_POLAR_CALL_TOL)
-		return 0.0
-	end
-	return +Inf
+    if (x[1] > 0.0 && x[1]*exp(x[2]/x[1]) <= -exp(1)*x[3]+EXP_POLAR_CALL_TOL) ||
+        (abs(x[1]) <= EXP_POLAR_CALL_TOL && x[2] <= EXP_POLAR_CALL_TOL && x[3] <= EXP_POLAR_CALL_TOL)
+        return 0.0
+    end
+    return +Inf
 end
 
 # Projection onto the cone is performed as in SCS (https://github.com/cvxgrp/scs).
@@ -77,89 +77,89 @@ end
 # SOFTWARE.
 
 function prox!(y::AbstractVector{R}, f::IndExpPrimal, x::AbstractVector{R}, gamma::R=1.0) where R <: Real
-	r = x[1]
-	s = x[2]
-	t = x[3]
-	if (s*exp(r/s) <= t && s > 0) || (r <= 0 && s == 0 && t >= 0)
-		# x in the cone
-		y .= x
-	elseif (-r < 0 && r*exp(s/r) <= -exp(1)*t) || (-r == 0 && -s >= 0 && -t >= 0)
-		# -x in the dual cone (x in the polar cone)
-		y .= R(0)
-	elseif r < 0 && s < 0
-		# analytical solution
-		y[1] = x[1]
-		y[2] = max(x[2], 0.0)
-		y[3] = max(x[3], 0.0)
-	else
-		v = x
-		ub, lb = getRhoUb(x)
-		for iter = 1:EXP_PROJ_MAXIT
-			rho = (ub + lb)/2
-			g, v = calcGrad(x,rho)
-			if g > 0
-				lb = rho
-			else
-				ub = rho
-			end
-			if ub - lb <= EXP_PROJ_TOL
-				break
-			end
-		end
-		y .= v
-	end
-	return R(0)
+    r = x[1]
+    s = x[2]
+    t = x[3]
+    if (s*exp(r/s) <= t && s > 0) || (r <= 0 && s == 0 && t >= 0)
+        # x in the cone
+        y .= x
+    elseif (-r < 0 && r*exp(s/r) <= -exp(1)*t) || (-r == 0 && -s >= 0 && -t >= 0)
+        # -x in the dual cone (x in the polar cone)
+        y .= R(0)
+    elseif r < 0 && s < 0
+        # analytical solution
+        y[1] = x[1]
+        y[2] = max(x[2], 0.0)
+        y[3] = max(x[3], 0.0)
+    else
+        v = x
+        ub, lb = getRhoUb(x)
+        for iter = 1:EXP_PROJ_MAXIT
+            rho = (ub + lb)/2
+            g, v = calcGrad(x,rho)
+            if g > 0
+                lb = rho
+            else
+                ub = rho
+            end
+            if ub - lb <= EXP_PROJ_TOL
+                break
+            end
+        end
+        y .= v
+    end
+    return R(0)
 end
 
 function getRhoUb(v)
-	lb = 0
-	rho = 2.0^(-3)
-	g, z = calcGrad(v, rho)
-	while g > 0
-		lb = rho
-		rho = rho*2
-		g, z = calcGrad(v, rho)
-	end
-	ub = rho
-	return ub, lb
+    lb = 0
+    rho = 2.0^(-3)
+    g, z = calcGrad(v, rho)
+    while g > 0
+        lb = rho
+        rho = rho*2
+        g, z = calcGrad(v, rho)
+    end
+    ub = rho
+    return ub, lb
 end
 
 function calcGrad(v, rho)
-	x = solve_with_rho(v, rho)
-	if x[2] == 0.0
-		g = x[1]
-	else
-		g = x[1] + x[2]*log(x[2]/x[3])
-	end
-	return g, x
+    x = solve_with_rho(v, rho)
+    if x[2] == 0.0
+        g = x[1]
+    else
+        g = x[1] + x[2]*log(x[2]/x[3])
+    end
+    return g, x
 end
 
 function solve_with_rho(v, rho)
-	x = zeros(3)
-	x[3] = newton_exp_onz(rho, v[2], v[3])
-	x[2] = (1/rho)*(x[3] - v[3])*x[3]
-	x[1] = v[1] - rho
-	return x
+    x = zeros(3)
+    x[3] = newton_exp_onz(rho, v[2], v[3])
+    x[2] = (1/rho)*(x[3] - v[3])*x[3]
+    x[1] = v[1] - rho
+    return x
 end
 
 function newton_exp_onz(rho, y_hat, z_hat)
-	t = max(-z_hat,EXP_PROJ_TOL)
-	for iter=1:EXP_PROJ_MAXIT
-		f = (1.0/rho^2)*t*(t + z_hat) - y_hat/rho + log(t/rho) + 1.0
-		fp = (1.0/rho^2)*(2.0*t + z_hat) + 1.0/t
-		t = t - f/fp
-		if t <= -z_hat
-			t = -z_hat
-			break
-		elseif t <= 0
-			t = 0
-			break
-		elseif abs(f) <= EXP_PROJ_TOL
-			break
-		end
-	end
-	z = t + z_hat
-	return z
+    t = max(-z_hat,EXP_PROJ_TOL)
+    for iter=1:EXP_PROJ_MAXIT
+        f = (1.0/rho^2)*t*(t + z_hat) - y_hat/rho + log(t/rho) + 1.0
+        fp = (1.0/rho^2)*(2.0*t + z_hat) + 1.0/t
+        t = t - f/fp
+        if t <= -z_hat
+            t = -z_hat
+            break
+        elseif t <= 0
+            t = 0
+            break
+        elseif abs(f) <= EXP_PROJ_TOL
+            break
+        end
+    end
+    z = t + z_hat
+    return z
 end
 
 fun_name(f::IndExpPrimal) = "indicator exponential cone (primal)"
@@ -172,7 +172,7 @@ fun_expr(f::PrecomposeDiagonal{Conjugate{IndExpPrimal}, R}) where {R <: Real} = 
 fun_params(f::PrecomposeDiagonal{Conjugate{IndExpPrimal}, R}) where {R <: Real} = "none"
 
 prox_naive(f::IndExpPrimal, x::AbstractArray{R}, gamma::Real=1.0) where {R <: Real} =
-	prox(f, x, gamma) # we don't have a much simpler way to do this yet
+    prox(f, x, gamma) # we don't have a much simpler way to do this yet
 
 prox_naive(f::PrecomposeDiagonal{Conjugate{IndExpPrimal}}, x::AbstractArray{R}, gamma::Real=1.0) where {R <: Real} =
-	prox(f, x, gamma) # we don't have a much simpler way to do this yet
+    prox(f, x, gamma) # we don't have a much simpler way to do this yet

--- a/src/functions/indFree.jl
+++ b/src/functions/indFree.jl
@@ -5,7 +5,7 @@ export IndFree
 """
 **Indicator of the free cone**
 
-	IndFree()
+    IndFree()
 
 Returns the indicator function of the whole space, or "free cone", *i.e.*,
 a function which is identically zero.
@@ -22,19 +22,19 @@ is_quadratic(f::IndFree) = true
 const Zero = IndFree
 
 function (f::IndFree)(x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-	return R(0)
+    return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}, gamma::R=R(1)) where {R, T <: RealOrComplex{R}}
-	y .= x
-	return R(0)
+    y .= x
+    return R(0)
 end
 
 prox!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}, gamma::AbstractArray{T}) where {R, T <: RealOrComplex{R}} = prox!(y, f, x)
 
 function gradient!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-	y .= T(0)
-	return R(0)
+    y .= T(0)
+    return R(0)
 end
 
 fun_name(f::IndFree) = "indicator of the free cone"
@@ -43,5 +43,5 @@ fun_expr(f::IndFree) = "x ↦ 0"
 fun_params(f::IndFree) = "none"
 
 function prox_naive(f::IndFree, x::AbstractArray{R}, gamma=R(1)) where {R, T <: RealOrComplex{R}}
-	return x, R(0)
+    return x, R(0)
 end

--- a/src/functions/indFree.jl
+++ b/src/functions/indFree.jl
@@ -22,19 +22,19 @@ is_quadratic(f::IndFree) = true
 const Zero = IndFree
 
 function (f::IndFree)(x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-	return zero(R)
+	return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}, gamma::R=one(R)) where {R, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}, gamma::R=R(1)) where {R, T <: RealOrComplex{R}}
 	y .= x
-	return zero(R)
+	return R(0)
 end
 
 prox!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}, gamma::AbstractArray{T}) where {R, T <: RealOrComplex{R}} = prox!(y, f, x)
 
 function gradient!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-	y .= zero(T)
-	return zero(R)
+	y .= T(0)
+	return R(0)
 end
 
 fun_name(f::IndFree) = "indicator of the free cone"
@@ -42,6 +42,6 @@ fun_dom(f::IndFree) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndFree) = "x ↦ 0"
 fun_params(f::IndFree) = "none"
 
-function prox_naive(f::IndFree, x::AbstractArray, gamma=1.0)
-	return x, 0.0
+function prox_naive(f::IndFree, x::AbstractArray{R}, gamma=R(1)) where {R, T <: RealOrComplex{R}}
+	return x, R(0)
 end

--- a/src/functions/indFree.jl
+++ b/src/functions/indFree.jl
@@ -5,7 +5,7 @@ export IndFree
 """
 **Indicator of the free cone**
 
-    IndFree()
+	IndFree()
 
 Returns the indicator function of the whole space, or "free cone", *i.e.*,
 a function which is identically zero.
@@ -22,19 +22,19 @@ is_quadratic(f::IndFree) = true
 const Zero = IndFree
 
 function (f::IndFree)(x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-  return zero(R)
+	return zero(R)
 end
 
 function prox!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}, gamma::R=one(R)) where {R, T <: RealOrComplex{R}}
-  y .= x
-  return zero(R)
+	y .= x
+	return zero(R)
 end
 
 prox!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}, gamma::AbstractArray{T}) where {R, T <: RealOrComplex{R}} = prox!(y, f, x)
 
 function gradient!(y::AbstractArray{T}, f::IndFree, x::AbstractArray{T}) where {R, T <: RealOrComplex{R}}
-  y .= zero(T)
-  return zero(R)
+	y .= zero(T)
+	return zero(R)
 end
 
 fun_name(f::IndFree) = "indicator of the free cone"
@@ -43,5 +43,5 @@ fun_expr(f::IndFree) = "x ↦ 0"
 fun_params(f::IndFree) = "none"
 
 function prox_naive(f::IndFree, x::AbstractArray, gamma=1.0)
-  return x, 0.0
+	return x, 0.0
 end

--- a/src/functions/indHalfspace.jl
+++ b/src/functions/indHalfspace.jl
@@ -33,19 +33,19 @@ is_cone(f::IndHalfspace) = f.b == 0 || f.b == Inf
 
 function (f::IndHalfspace{R})(x::AbstractArray{R}) where R
 	if dot(f.a, x) - f.b <= eps(R)*f.norm_a*(1 + abs(f.b))
-		return zero(R)
+		return R(0)
 	end
 	return R(Inf)
 end
 
-function prox!(y::AbstractArray{R}, f::IndHalfspace{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
+function prox!(y::AbstractArray{R}, f::IndHalfspace{R}, x::AbstractArray{R}, gamma::R=R(1)) where R
 	s = dot(f.a, x)
 	if s > f.b
 		y .= x .- ((s - f.b)/f.norm_a^2) .* f.a
 	else
 		copyto!(y, x)
 	end
-	return zero(R)
+	return R(0)
 end
 
 fun_name(f::IndHalfspace) = "indicator of a halfspace"
@@ -55,7 +55,7 @@ fun_params(f::IndHalfspace) =
 	string( "a = ", typeof(f.a), " of size ", size(f.a), ", ",
 			"b = $(f.b)")
 
-function prox_naive(f::IndHalfspace{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
+function prox_naive(f::IndHalfspace{R}, x::AbstractArray{R}, gamma::R=R(1)) where R
 	s = dot(f.a, x) - f.b
 	if s <= 0
 		return x, 0.0

--- a/src/functions/indHalfspace.jl
+++ b/src/functions/indHalfspace.jl
@@ -5,7 +5,7 @@ export IndHalfspace
 """
 **Indicator of a halfspace**
 
-    IndHalfspace(a, b)
+	IndHalfspace(a, b)
 
 For an array `a` and a scalar `b`, returns the indicator of set
 ```math
@@ -13,16 +13,16 @@ S = \\{x : \\langle a,x \\rangle \\leq b \\}.
 ```
 """
 struct IndHalfspace{R <: Real, T <: AbstractArray{R}} <: ProximableFunction
-  a::T
-  b::R
-  norm_a::R
-  function IndHalfspace{R, T}(a::T, b::R) where {R <: Real, T <: AbstractArray{R}}
-    norm_a = norm(a)
-    if norm_a == 0 && b < 0
-        error("function is improper")
-    end
-    new(a, b, norm_a)
-  end
+	a::T
+	b::R
+	norm_a::R
+	function IndHalfspace{R, T}(a::T, b::R) where {R <: Real, T <: AbstractArray{R}}
+		norm_a = norm(a)
+		if norm_a == 0 && b < 0
+			error("function is improper")
+		end
+		new(a, b, norm_a)
+	end
 end
 
 IndHalfspace(a::T, b::R) where {R <: Real, T <: AbstractArray{R}} = IndHalfspace{R, T}(a, b)
@@ -32,33 +32,33 @@ is_set(f::IndHalfspace) = true
 is_cone(f::IndHalfspace) = f.b == 0 || f.b == Inf
 
 function (f::IndHalfspace{R})(x::AbstractArray{R}) where R
-  if dot(f.a, x) - f.b <= eps(R)*f.norm_a*(1 + abs(f.b))
-    return zero(R)
-  end
-  return R(Inf)
+	if dot(f.a, x) - f.b <= eps(R)*f.norm_a*(1 + abs(f.b))
+		return zero(R)
+	end
+	return R(Inf)
 end
 
 function prox!(y::AbstractArray{R}, f::IndHalfspace{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
-  s = dot(f.a, x)
-  if s > f.b
-    y .= x .- ((s - f.b)/f.norm_a^2) .* f.a
-  else
-    copyto!(y, x)
-  end
-  return zero(R)
+	s = dot(f.a, x)
+	if s > f.b
+		y .= x .- ((s - f.b)/f.norm_a^2) .* f.a
+	else
+		copyto!(y, x)
+	end
+	return zero(R)
 end
 
 fun_name(f::IndHalfspace) = "indicator of a halfspace"
 fun_dom(f::IndHalfspace) = "AbstractArray{Real}"
 fun_expr(f::IndHalfspace) = "x ↦ 0 if <a,x> ⩽ b, +∞ otherwise"
 fun_params(f::IndHalfspace) =
-  string( "a = ", typeof(f.a), " of size ", size(f.a), ", ",
-          "b = $(f.b)")
+	string( "a = ", typeof(f.a), " of size ", size(f.a), ", ",
+			"b = $(f.b)")
 
 function prox_naive(f::IndHalfspace{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
-  s = dot(f.a, x) - f.b
-  if s <= 0
-    return x, 0.0
-  end
-  return x - (s/norm(f.a)^2)*f.a, 0.0
+	s = dot(f.a, x) - f.b
+	if s <= 0
+		return x, 0.0
+	end
+	return x - (s/norm(f.a)^2)*f.a, 0.0
 end

--- a/src/functions/indHalfspace.jl
+++ b/src/functions/indHalfspace.jl
@@ -5,7 +5,7 @@ export IndHalfspace
 """
 **Indicator of a halfspace**
 
-	IndHalfspace(a, b)
+    IndHalfspace(a, b)
 
 For an array `a` and a scalar `b`, returns the indicator of set
 ```math
@@ -13,16 +13,16 @@ S = \\{x : \\langle a,x \\rangle \\leq b \\}.
 ```
 """
 struct IndHalfspace{R <: Real, T <: AbstractArray{R}} <: ProximableFunction
-	a::T
-	b::R
-	norm_a::R
-	function IndHalfspace{R, T}(a::T, b::R) where {R <: Real, T <: AbstractArray{R}}
-		norm_a = norm(a)
-		if norm_a == 0 && b < 0
-			error("function is improper")
-		end
-		new(a, b, norm_a)
-	end
+    a::T
+    b::R
+    norm_a::R
+    function IndHalfspace{R, T}(a::T, b::R) where {R <: Real, T <: AbstractArray{R}}
+        norm_a = norm(a)
+        if norm_a == 0 && b < 0
+            error("function is improper")
+        end
+        new(a, b, norm_a)
+    end
 end
 
 IndHalfspace(a::T, b::R) where {R <: Real, T <: AbstractArray{R}} = IndHalfspace{R, T}(a, b)
@@ -32,33 +32,33 @@ is_set(f::IndHalfspace) = true
 is_cone(f::IndHalfspace) = f.b == 0 || f.b == Inf
 
 function (f::IndHalfspace{R})(x::AbstractArray{R}) where R
-	if dot(f.a, x) - f.b <= eps(R)*f.norm_a*(1 + abs(f.b))
-		return R(0)
-	end
-	return R(Inf)
+    if dot(f.a, x) - f.b <= eps(R)*f.norm_a*(1 + abs(f.b))
+        return R(0)
+    end
+    return R(Inf)
 end
 
 function prox!(y::AbstractArray{R}, f::IndHalfspace{R}, x::AbstractArray{R}, gamma::R=R(1)) where R
-	s = dot(f.a, x)
-	if s > f.b
-		y .= x .- ((s - f.b)/f.norm_a^2) .* f.a
-	else
-		copyto!(y, x)
-	end
-	return R(0)
+    s = dot(f.a, x)
+    if s > f.b
+        y .= x .- ((s - f.b)/f.norm_a^2) .* f.a
+    else
+        copyto!(y, x)
+    end
+    return R(0)
 end
 
 fun_name(f::IndHalfspace) = "indicator of a halfspace"
 fun_dom(f::IndHalfspace) = "AbstractArray{Real}"
 fun_expr(f::IndHalfspace) = "x ↦ 0 if <a,x> ⩽ b, +∞ otherwise"
 fun_params(f::IndHalfspace) =
-	string( "a = ", typeof(f.a), " of size ", size(f.a), ", ",
-			"b = $(f.b)")
+    string( "a = ", typeof(f.a), " of size ", size(f.a), ", ",
+            "b = $(f.b)")
 
 function prox_naive(f::IndHalfspace{R}, x::AbstractArray{R}, gamma::R=R(1)) where R
-	s = dot(f.a, x) - f.b
-	if s <= 0
-		return x, 0.0
-	end
-	return x - (s/norm(f.a)^2)*f.a, 0.0
+    s = dot(f.a, x) - f.b
+    if s <= 0
+        return x, 0.0
+    end
+    return x - (s/norm(f.a)^2)*f.a, 0.0
 end

--- a/src/functions/indHyperslab.jl
+++ b/src/functions/indHyperslab.jl
@@ -5,7 +5,7 @@ export IndHyperslab
 """
 **Indicator of a hyperslab**
 
-	IndHyperslab(low, a, upp)
+    IndHyperslab(low, a, upp)
 
 For an array `a` and scalars `low` and `upp`, returns the indicator of set
 ```math
@@ -13,17 +13,17 @@ S = \\{x : low \\leq \\langle a,x \\rangle \\leq upp \\}.
 ```
 """
 struct IndHyperslab{R <: Real, T <: AbstractArray{R}} <: ProximableFunction
-	low::R
-	a::T
-	upp::R
-	norm_a::R
-	function IndHyperslab{R, T}(low::R, a::T, upp::R) where {R <: Real, T <: AbstractArray{R}}
-		norm_a = norm(a)
-		if (norm_a == 0 && (upp < 0 || low > 0)) || upp < low
-			error("function is improper")
-		end
-		new(low, a, upp, norm_a)
-	end
+    low::R
+    a::T
+    upp::R
+    norm_a::R
+    function IndHyperslab{R, T}(low::R, a::T, upp::R) where {R <: Real, T <: AbstractArray{R}}
+        norm_a = norm(a)
+        if (norm_a == 0 && (upp < 0 || low > 0)) || upp < low
+            error("function is improper")
+        end
+        new(low, a, upp, norm_a)
+    end
 end
 
 IndHyperslab(low::R, a::T, upp::R) where {R <: Real, T <: AbstractArray{R}} = IndHyperslab{R, T}(low, a, upp)
@@ -31,40 +31,40 @@ IndHyperslab(low::R, a::T, upp::R) where {R <: Real, T <: AbstractArray{R}} = In
 is_convex(f::IndHyperslab) = true
 is_set(f::IndHyperslab) = true
 is_cone(f::IndHyperslab{R}) where R =
-	(f.low == f.upp == 0) ||
-	(f.low == 0 && f.upp == Inf) ||
-	(f.low == -Inf && f.upp == 0) ||
-	(f.low == -Inf && f.upp == Inf)
+    (f.low == f.upp == 0) ||
+    (f.low == 0 && f.upp == Inf) ||
+    (f.low == -Inf && f.upp == 0) ||
+    (f.low == -Inf && f.upp == Inf)
 
 function (f::IndHyperslab{R})(x::AbstractArray{R}) where R
-	s = dot(f.a, x)
-	# if f.low <= s <= f.upp
-	# tol = (R(1) + abs(s))*eps(R)
-	if f.low - s <= eps(R)*f.norm_a*(1 + abs(f.low)) && s - f.upp <= eps(R)*f.norm_a*(1 + abs(f.upp))
-		return R(0)
-	end
-	return R(Inf)
+    s = dot(f.a, x)
+    # if f.low <= s <= f.upp
+    # tol = (R(1) + abs(s))*eps(R)
+    if f.low - s <= eps(R)*f.norm_a*(1 + abs(f.low)) && s - f.upp <= eps(R)*f.norm_a*(1 + abs(f.upp))
+        return R(0)
+    end
+    return R(Inf)
 end
 
 function prox!(y::AbstractArray{R}, f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=R(1)) where R
-	s = dot(f.a, x)
-	if s < f.low && f.norm_a > 0
-		y .= x .- ((s - f.low)/f.norm_a^2) .* f.a
-	elseif s > f.upp && f.norm_a > 0
-		y .= x .- ((s - f.upp)/f.norm_a^2) .* f.a
-	else
-		copyto!(y, x)
-	end
-	return R(0)
+    s = dot(f.a, x)
+    if s < f.low && f.norm_a > 0
+        y .= x .- ((s - f.low)/f.norm_a^2) .* f.a
+    elseif s > f.upp && f.norm_a > 0
+        y .= x .- ((s - f.upp)/f.norm_a^2) .* f.a
+    else
+        copyto!(y, x)
+    end
+    return R(0)
 end
 
 function prox_naive(f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=R(1)) where R
-	s = dot(f.a, x)
-	if s < f.low && f.norm_a > 0
-		return x - ((s - f.low)/norm(f.a)^2) * f.a, R(0)
-	elseif s > f.upp && f.norm_a > 0
-		return x - ((s - f.upp)/norm(f.a)^2) * f.a, R(0)
-	else
-		return x, R(0)
-	end
+    s = dot(f.a, x)
+    if s < f.low && f.norm_a > 0
+        return x - ((s - f.low)/norm(f.a)^2) * f.a, R(0)
+    elseif s > f.upp && f.norm_a > 0
+        return x - ((s - f.upp)/norm(f.a)^2) * f.a, R(0)
+    else
+        return x, R(0)
+    end
 end

--- a/src/functions/indHyperslab.jl
+++ b/src/functions/indHyperslab.jl
@@ -41,12 +41,12 @@ function (f::IndHyperslab{R})(x::AbstractArray{R}) where R
 	# if f.low <= s <= f.upp
 	# tol = (R(1) + abs(s))*eps(R)
 	if f.low - s <= eps(R)*f.norm_a*(1 + abs(f.low)) && s - f.upp <= eps(R)*f.norm_a*(1 + abs(f.upp))
-		return zero(R)
+		return R(0)
 	end
 	return R(Inf)
 end
 
-function prox!(y::AbstractArray{R}, f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
+function prox!(y::AbstractArray{R}, f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=R(1)) where R
 	s = dot(f.a, x)
 	if s < f.low && f.norm_a > 0
 		y .= x .- ((s - f.low)/f.norm_a^2) .* f.a
@@ -55,10 +55,10 @@ function prox!(y::AbstractArray{R}, f::IndHyperslab{R}, x::AbstractArray{R}, gam
 	else
 		copyto!(y, x)
 	end
-	return zero(R)
+	return R(0)
 end
 
-function prox_naive(f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
+function prox_naive(f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=R(1)) where R
 	s = dot(f.a, x)
 	if s < f.low && f.norm_a > 0
 		return x - ((s - f.low)/norm(f.a)^2) * f.a, R(0)

--- a/src/functions/indHyperslab.jl
+++ b/src/functions/indHyperslab.jl
@@ -5,7 +5,7 @@ export IndHyperslab
 """
 **Indicator of a hyperslab**
 
-    IndHyperslab(low, a, upp)
+	IndHyperslab(low, a, upp)
 
 For an array `a` and scalars `low` and `upp`, returns the indicator of set
 ```math
@@ -13,17 +13,17 @@ S = \\{x : low \\leq \\langle a,x \\rangle \\leq upp \\}.
 ```
 """
 struct IndHyperslab{R <: Real, T <: AbstractArray{R}} <: ProximableFunction
-  low::R
-  a::T
-  upp::R
-  norm_a::R
-  function IndHyperslab{R, T}(low::R, a::T, upp::R) where {R <: Real, T <: AbstractArray{R}}
-    norm_a = norm(a)
-    if (norm_a == 0 && (upp < 0 || low > 0)) || upp < low
-        error("function is improper")
-    end
-    new(low, a, upp, norm_a)
-  end
+	low::R
+	a::T
+	upp::R
+	norm_a::R
+	function IndHyperslab{R, T}(low::R, a::T, upp::R) where {R <: Real, T <: AbstractArray{R}}
+		norm_a = norm(a)
+		if (norm_a == 0 && (upp < 0 || low > 0)) || upp < low
+			error("function is improper")
+		end
+		new(low, a, upp, norm_a)
+	end
 end
 
 IndHyperslab(low::R, a::T, upp::R) where {R <: Real, T <: AbstractArray{R}} = IndHyperslab{R, T}(low, a, upp)
@@ -31,40 +31,40 @@ IndHyperslab(low::R, a::T, upp::R) where {R <: Real, T <: AbstractArray{R}} = In
 is_convex(f::IndHyperslab) = true
 is_set(f::IndHyperslab) = true
 is_cone(f::IndHyperslab{R}) where R =
-    (f.low == f.upp == 0) ||
-    (f.low == 0 && f.upp == Inf) ||
-    (f.low == -Inf && f.upp == 0) ||
-    (f.low == -Inf && f.upp == Inf)
+	(f.low == f.upp == 0) ||
+	(f.low == 0 && f.upp == Inf) ||
+	(f.low == -Inf && f.upp == 0) ||
+	(f.low == -Inf && f.upp == Inf)
 
 function (f::IndHyperslab{R})(x::AbstractArray{R}) where R
-  s = dot(f.a, x)
-  # if f.low <= s <= f.upp
-  # tol = (R(1) + abs(s))*eps(R)
-  if f.low - s <= eps(R)*f.norm_a*(1 + abs(f.low)) && s - f.upp <= eps(R)*f.norm_a*(1 + abs(f.upp))
-    return zero(R)
-  end
-  return R(Inf)
+	s = dot(f.a, x)
+	# if f.low <= s <= f.upp
+	# tol = (R(1) + abs(s))*eps(R)
+	if f.low - s <= eps(R)*f.norm_a*(1 + abs(f.low)) && s - f.upp <= eps(R)*f.norm_a*(1 + abs(f.upp))
+		return zero(R)
+	end
+	return R(Inf)
 end
 
 function prox!(y::AbstractArray{R}, f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
-  s = dot(f.a, x)
-  if s < f.low && f.norm_a > 0
-    y .= x .- ((s - f.low)/f.norm_a^2) .* f.a
-  elseif s > f.upp && f.norm_a > 0
-    y .= x .- ((s - f.upp)/f.norm_a^2) .* f.a
-  else
-    copyto!(y, x)
-  end
-  return zero(R)
+	s = dot(f.a, x)
+	if s < f.low && f.norm_a > 0
+		y .= x .- ((s - f.low)/f.norm_a^2) .* f.a
+	elseif s > f.upp && f.norm_a > 0
+		y .= x .- ((s - f.upp)/f.norm_a^2) .* f.a
+	else
+		copyto!(y, x)
+	end
+	return zero(R)
 end
 
 function prox_naive(f::IndHyperslab{R}, x::AbstractArray{R}, gamma::R=one(R)) where R
-  s = dot(f.a, x)
-  if s < f.low && f.norm_a > 0
-    return x - ((s - f.low)/norm(f.a)^2) * f.a, R(0)
-  elseif s > f.upp && f.norm_a > 0
-    return x - ((s - f.upp)/norm(f.a)^2) * f.a, R(0)
-  else
-    return x, R(0)
-  end
+	s = dot(f.a, x)
+	if s < f.low && f.norm_a > 0
+		return x - ((s - f.low)/norm(f.a)^2) * f.a, R(0)
+	elseif s > f.upp && f.norm_a > 0
+		return x - ((s - f.upp)/norm(f.a)^2) * f.a, R(0)
+	else
+		return x, R(0)
+	end
 end

--- a/src/functions/indNonnegative.jl
+++ b/src/functions/indNonnegative.jl
@@ -24,18 +24,18 @@ function (f::IndNonnegative)(x::AbstractArray{R}) where R <: Real
 			return R(Inf)
 		end
 	end
-	return zero(R)
+	return R(0)
 end
 
-function prox!(y::AbstractArray{R}, f::IndNonnegative, x::AbstractArray{R}, gamma=one(R)) where R <: Real
+function prox!(y::AbstractArray{R}, f::IndNonnegative, x::AbstractArray{R}, gamma=R(1)) where R <: Real
 	for k in eachindex(x)
 		if x[k] < 0
-			y[k] = zero(R)
+			y[k] = R(0)
 		else
 			y[k] = x[k]
 		end
 	end
-	return zero(R)
+	return R(0)
 end
 
 fun_name(f::IndNonnegative) = "indicator of the Nonnegative cone"
@@ -43,7 +43,7 @@ fun_dom(f::IndNonnegative) = "AbstractArray{Real}"
 fun_expr(f::IndNonnegative) = "x ↦ 0 if all(0 ⩽ x), +∞ otherwise"
 fun_params(f::IndNonnegative) = "none"
 
-function prox_naive(f::IndNonnegative, x::AbstractArray{R}, gamma=one(R)) where R <: Real
-	y = max.(zero(R), x)
-	return y, zero(R)
+function prox_naive(f::IndNonnegative, x::AbstractArray{R}, gamma=R(1)) where R <: Real
+	y = max.(R(0), x)
+	return y, R(0)
 end

--- a/src/functions/indNonnegative.jl
+++ b/src/functions/indNonnegative.jl
@@ -19,35 +19,31 @@ is_convex(f::IndNonnegative) = true
 is_cone(f::IndNonnegative) = true
 
 function (f::IndNonnegative)(x::AbstractArray{R}) where R <: Real
-  for k in eachindex(x)
-    if x[k] < 0
-      return +Inf
+    for k in eachindex(x)
+        if x[k] < 0
+            return R(Inf)
+        end
     end
-  end
-  return zero(R)
+    return zero(R)
 end
 
-function prox!(y::AbstractArray{R}, f::IndNonnegative, x::AbstractArray{R}, gamma::Real=1.0) where R <: Real
-  for k in eachindex(x)
-    if x[k] < 0
-      y[k] = zero(R)
-    else
-      y[k] = x[k]
+function prox!(y::AbstractArray{R}, f::IndNonnegative, x::AbstractArray{R}, gamma=one(R)) where R <: Real
+    for k in eachindex(x)
+        if x[k] < 0
+            y[k] = zero(R)
+        else
+            y[k] = x[k]
+        end
     end
-  end
-  return zero(R)
+    return zero(R)
 end
-
-prox!(y::AbstractArray{R}, f::IndNonnegative, x::AbstractArray{R}, gamma::AbstractArray{R}) where {R <: Real} = prox!(y, f, x, 1.0)
 
 fun_name(f::IndNonnegative) = "indicator of the Nonnegative cone"
 fun_dom(f::IndNonnegative) = "AbstractArray{Real}"
 fun_expr(f::IndNonnegative) = "x ↦ 0 if all(0 ⩽ x), +∞ otherwise"
 fun_params(f::IndNonnegative) = "none"
 
-function prox_naive(f::IndNonnegative, x::AbstractArray{R}, gamma::Real=1.0) where R <: Real
-  y = max.(zero(R), x)
-  return y, 0.0
+function prox_naive(f::IndNonnegative, x::AbstractArray{R}, gamma=one(R)) where R <: Real
+    y = max.(zero(R), x)
+    return y, zero(R)
 end
-
-prox_naive(f::IndNonnegative, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox_naive(f, x, 1.0)

--- a/src/functions/indNonnegative.jl
+++ b/src/functions/indNonnegative.jl
@@ -5,7 +5,7 @@ export IndNonnegative
 """
 **Indicator of the nonnegative orthant**
 
-	IndNonnegative()
+    IndNonnegative()
 
 Returns the indicator of the set
 ```math
@@ -19,23 +19,23 @@ is_convex(f::IndNonnegative) = true
 is_cone(f::IndNonnegative) = true
 
 function (f::IndNonnegative)(x::AbstractArray{R}) where R <: Real
-	for k in eachindex(x)
-		if x[k] < 0
-			return R(Inf)
-		end
-	end
-	return R(0)
+    for k in eachindex(x)
+        if x[k] < 0
+            return R(Inf)
+        end
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{R}, f::IndNonnegative, x::AbstractArray{R}, gamma=R(1)) where R <: Real
-	for k in eachindex(x)
-		if x[k] < 0
-			y[k] = R(0)
-		else
-			y[k] = x[k]
-		end
-	end
-	return R(0)
+    for k in eachindex(x)
+        if x[k] < 0
+            y[k] = R(0)
+        else
+            y[k] = x[k]
+        end
+    end
+    return R(0)
 end
 
 fun_name(f::IndNonnegative) = "indicator of the Nonnegative cone"
@@ -44,6 +44,6 @@ fun_expr(f::IndNonnegative) = "x ↦ 0 if all(0 ⩽ x), +∞ otherwise"
 fun_params(f::IndNonnegative) = "none"
 
 function prox_naive(f::IndNonnegative, x::AbstractArray{R}, gamma=R(1)) where R <: Real
-	y = max.(R(0), x)
-	return y, R(0)
+    y = max.(R(0), x)
+    return y, R(0)
 end

--- a/src/functions/indNonnegative.jl
+++ b/src/functions/indNonnegative.jl
@@ -5,7 +5,7 @@ export IndNonnegative
 """
 **Indicator of the nonnegative orthant**
 
-    IndNonnegative()
+	IndNonnegative()
 
 Returns the indicator of the set
 ```math
@@ -19,23 +19,23 @@ is_convex(f::IndNonnegative) = true
 is_cone(f::IndNonnegative) = true
 
 function (f::IndNonnegative)(x::AbstractArray{R}) where R <: Real
-    for k in eachindex(x)
-        if x[k] < 0
-            return R(Inf)
-        end
-    end
-    return zero(R)
+	for k in eachindex(x)
+		if x[k] < 0
+			return R(Inf)
+		end
+	end
+	return zero(R)
 end
 
 function prox!(y::AbstractArray{R}, f::IndNonnegative, x::AbstractArray{R}, gamma=one(R)) where R <: Real
-    for k in eachindex(x)
-        if x[k] < 0
-            y[k] = zero(R)
-        else
-            y[k] = x[k]
-        end
-    end
-    return zero(R)
+	for k in eachindex(x)
+		if x[k] < 0
+			y[k] = zero(R)
+		else
+			y[k] = x[k]
+		end
+	end
+	return zero(R)
 end
 
 fun_name(f::IndNonnegative) = "indicator of the Nonnegative cone"
@@ -44,6 +44,6 @@ fun_expr(f::IndNonnegative) = "x ↦ 0 if all(0 ⩽ x), +∞ otherwise"
 fun_params(f::IndNonnegative) = "none"
 
 function prox_naive(f::IndNonnegative, x::AbstractArray{R}, gamma=one(R)) where R <: Real
-    y = max.(zero(R), x)
-    return y, zero(R)
+	y = max.(zero(R), x)
+	return y, zero(R)
 end

--- a/src/functions/indNonpositive.jl
+++ b/src/functions/indNonpositive.jl
@@ -5,7 +5,7 @@ export IndNonpositive
 """
 **Indicator of the nonpositive orthant**
 
-    IndNonpositive()
+	IndNonpositive()
 
 Returns the indicator of the set
 ```math
@@ -19,23 +19,23 @@ is_convex(f::IndNonpositive) = true
 is_cone(f::IndNonpositive) = true
 
 function (f::IndNonpositive)(x::AbstractArray{R}) where R <: Real
-    for k in eachindex(x)
-        if x[k] > 0
-            return R(Inf)
-        end
-    end
-    return zero(R)
+	for k in eachindex(x)
+		if x[k] > 0
+			return R(Inf)
+		end
+	end
+	return zero(R)
 end
 
 function prox!(y::AbstractArray{R}, f::IndNonpositive, x::AbstractArray{R}, gamma=one(R)) where R <: Real
-    for k in eachindex(x)
-        if x[k] > 0
-            y[k] = zero(R)
-        else
-            y[k] = x[k]
-        end
-    end
-    return zero(R)
+	for k in eachindex(x)
+		if x[k] > 0
+			y[k] = zero(R)
+		else
+			y[k] = x[k]
+		end
+	end
+	return zero(R)
 end
 
 fun_name(f::IndNonpositive) = "indicator of the Nonpositive cone"
@@ -44,6 +44,6 @@ fun_expr(f::IndNonpositive) = "x ↦ 0 if all(0 ⩾ x), +∞ otherwise"
 fun_params(f::IndNonpositive) = "none"
 
 function prox_naive(f::IndNonpositive, x::AbstractArray{R}, gamma=one(R)) where R <: Real
-    y = min.(zero(R), x)
-    return y, zero(R)
+	y = min.(zero(R), x)
+	return y, zero(R)
 end

--- a/src/functions/indNonpositive.jl
+++ b/src/functions/indNonpositive.jl
@@ -24,18 +24,18 @@ function (f::IndNonpositive)(x::AbstractArray{R}) where R <: Real
 			return R(Inf)
 		end
 	end
-	return zero(R)
+	return R(0)
 end
 
-function prox!(y::AbstractArray{R}, f::IndNonpositive, x::AbstractArray{R}, gamma=one(R)) where R <: Real
+function prox!(y::AbstractArray{R}, f::IndNonpositive, x::AbstractArray{R}, gamma=R(1)) where R <: Real
 	for k in eachindex(x)
 		if x[k] > 0
-			y[k] = zero(R)
+			y[k] = R(0)
 		else
 			y[k] = x[k]
 		end
 	end
-	return zero(R)
+	return R(0)
 end
 
 fun_name(f::IndNonpositive) = "indicator of the Nonpositive cone"
@@ -43,7 +43,7 @@ fun_dom(f::IndNonpositive) = "AbstractArray{Real}"
 fun_expr(f::IndNonpositive) = "x ↦ 0 if all(0 ⩾ x), +∞ otherwise"
 fun_params(f::IndNonpositive) = "none"
 
-function prox_naive(f::IndNonpositive, x::AbstractArray{R}, gamma=one(R)) where R <: Real
-	y = min.(zero(R), x)
-	return y, zero(R)
+function prox_naive(f::IndNonpositive, x::AbstractArray{R}, gamma=R(1)) where R <: Real
+	y = min.(R(0), x)
+	return y, R(0)
 end

--- a/src/functions/indNonpositive.jl
+++ b/src/functions/indNonpositive.jl
@@ -5,7 +5,7 @@ export IndNonpositive
 """
 **Indicator of the nonpositive orthant**
 
-	IndNonpositive()
+    IndNonpositive()
 
 Returns the indicator of the set
 ```math
@@ -19,23 +19,23 @@ is_convex(f::IndNonpositive) = true
 is_cone(f::IndNonpositive) = true
 
 function (f::IndNonpositive)(x::AbstractArray{R}) where R <: Real
-	for k in eachindex(x)
-		if x[k] > 0
-			return R(Inf)
-		end
-	end
-	return R(0)
+    for k in eachindex(x)
+        if x[k] > 0
+            return R(Inf)
+        end
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{R}, f::IndNonpositive, x::AbstractArray{R}, gamma=R(1)) where R <: Real
-	for k in eachindex(x)
-		if x[k] > 0
-			y[k] = R(0)
-		else
-			y[k] = x[k]
-		end
-	end
-	return R(0)
+    for k in eachindex(x)
+        if x[k] > 0
+            y[k] = R(0)
+        else
+            y[k] = x[k]
+        end
+    end
+    return R(0)
 end
 
 fun_name(f::IndNonpositive) = "indicator of the Nonpositive cone"
@@ -44,6 +44,6 @@ fun_expr(f::IndNonpositive) = "x ↦ 0 if all(0 ⩾ x), +∞ otherwise"
 fun_params(f::IndNonpositive) = "none"
 
 function prox_naive(f::IndNonpositive, x::AbstractArray{R}, gamma=R(1)) where R <: Real
-	y = min.(R(0), x)
-	return y, R(0)
+    y = min.(R(0), x)
+    return y, R(0)
 end

--- a/src/functions/indNonpositive.jl
+++ b/src/functions/indNonpositive.jl
@@ -19,35 +19,31 @@ is_convex(f::IndNonpositive) = true
 is_cone(f::IndNonpositive) = true
 
 function (f::IndNonpositive)(x::AbstractArray{R}) where R <: Real
-  for k in eachindex(x)
-    if x[k] > 0
-      return +Inf
+    for k in eachindex(x)
+        if x[k] > 0
+            return R(Inf)
+        end
     end
-  end
-  return zero(R)
+    return zero(R)
 end
 
-function prox!(y::AbstractArray{R}, f::IndNonpositive, x::AbstractArray{R}, gamma::Real=1.0) where R <: Real
-  for k in eachindex(x)
-    if x[k] > 0
-      y[k] = zero(R)
-    else
-      y[k] = x[k]
+function prox!(y::AbstractArray{R}, f::IndNonpositive, x::AbstractArray{R}, gamma=one(R)) where R <: Real
+    for k in eachindex(x)
+        if x[k] > 0
+            y[k] = zero(R)
+        else
+            y[k] = x[k]
+        end
     end
-  end
-  return zero(R)
+    return zero(R)
 end
-
-prox!(y::AbstractArray{R}, f::IndNonpositive, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox!(y, f, x, 1.0)
 
 fun_name(f::IndNonpositive) = "indicator of the Nonpositive cone"
 fun_dom(f::IndNonpositive) = "AbstractArray{Real}"
 fun_expr(f::IndNonpositive) = "x ↦ 0 if all(0 ⩾ x), +∞ otherwise"
 fun_params(f::IndNonpositive) = "none"
 
-function prox_naive(f::IndNonpositive, x::AbstractArray{R}, gamma::Real=1.0) where R <: Real
-  y = min.(zero(R), x)
-  return y, 0.0
+function prox_naive(f::IndNonpositive, x::AbstractArray{R}, gamma=one(R)) where R <: Real
+    y = min.(zero(R), x)
+    return y, zero(R)
 end
-
-prox_naive(f::IndNonpositive, x::AbstractArray{R}, gamma::AbstractArray) where {R <: Real} = prox_naive(f, x, 1.0)

--- a/src/functions/indPSD.jl
+++ b/src/functions/indPSD.jl
@@ -5,7 +5,7 @@ export IndPSD
 """
 **Indicator of the set of positive semi-definite cone**
 
-	IndPSD(;scaling=false)
+    IndPSD(;scaling=false)
 
 Returns the indicator of the set
 ```math
@@ -28,40 +28,40 @@ I.e. when when `scaling=true`, let `X,Y` be matrices and
 then `prox!(Y, f, X)` is equivalent to `prox!(y, f, x)`.
 """
 struct IndPSD <: ProximableFunction
-	scaling::Bool
+    scaling::Bool
 end
 
 IndPSD(;scaling=false) = IndPSD(scaling)
 
 function (f::IndPSD)(X::HermOrSym{T}) where T <: RealOrComplex
-	F = eigen(X)
-	for i in eachindex(F.values)
-		#Do we allow for some tolerance here?
-		if F.values[i] <= -1e-14
-			return +Inf
-		end
-	end
-	return 0.0
+    F = eigen(X)
+    for i in eachindex(F.values)
+        #Do we allow for some tolerance here?
+        if F.values[i] <= -1e-14
+            return +Inf
+        end
+    end
+    return 0.0
 end
 
 is_convex(f::IndPSD) = true
 is_cone(f::IndPSD) = true
 
 function prox!(Y::HermOrSym{T}, f::IndPSD, X::HermOrSym{T}, gamma::Real=1.0) where T <: RealOrComplex
-	n = size(X, 1)
-	F = eigen(X)
-	for i in eachindex(F.values)
-		F.values[i] = max.(0.0, F.values[i])
-	end
-	for i = 1:n
-		for j = 1:n
-			Y.data[i,j] = 0.0
-			for k = 1:n
-				Y.data[i,j] += F.vectors[i,k]*F.values[k]*F.vectors[j,k]
-			end
-		end
-	end
-	return 0.0
+    n = size(X, 1)
+    F = eigen(X)
+    for i in eachindex(F.values)
+        F.values[i] = max.(0.0, F.values[i])
+    end
+    for i = 1:n
+        for j = 1:n
+            Y.data[i,j] = 0.0
+            for k = 1:n
+                Y.data[i,j] += F.vectors[i,k]*F.values[k]*F.vectors[j,k]
+            end
+        end
+    end
+    return 0.0
 end
 
 fun_name(f::IndPSD) = "indicator of positive semidefinite cone"
@@ -70,8 +70,8 @@ fun_expr(f::IndPSD) = "x ↦ 0 if A ⪰ 0, +∞ otherwise"
 fun_params(f::IndPSD) = "none"
 
 function prox_naive(f::IndPSD, X::HermOrSym{T}, gamma::Real=1.0) where T <: RealOrComplex
-	F = eigen(X)
-	return F.vectors * Diagonal(max.(0.0, F.values)) * F.vectors', 0.0
+    F = eigen(X)
+    return F.vectors * Diagonal(max.(0.0, F.values)) * F.vectors', 0.0
 end
 
 """
@@ -79,83 +79,83 @@ Scales the diagonal of `x` with `val`, where `x` is the lower triangualar part
 of a matrix, stored column by column.
 """
 function scale_diagonal!(x, val)
-	n = Int(sqrt(1/4+2*length(x))-1/2)
-	k = -n
-	for i = 1:n
-		k += n - i + 2		#Calculate indices of diagonal elements recursively (paralell faster?)
-		x[k] *= val			#Scale diagonal
-	end
+    n = Int(sqrt(1/4+2*length(x))-1/2)
+    k = -n
+    for i = 1:n
+        k += n - i + 2        #Calculate indices of diagonal elements recursively (paralell faster?)
+        x[k] *= val            #Scale diagonal
+    end
 end
 
 ### Below: with AbstractVector argument
 
 function (f::IndPSD)(x::AbstractVector{T}) where T <: Float64
-	y = copy(x)
-	f.scaling && scale_diagonal!(y, sqrt(2)) #If scaling, scale diagonal (eigenvalues scaled by sqrt(2))
+    y = copy(x)
+    f.scaling && scale_diagonal!(y, sqrt(2)) #If scaling, scale diagonal (eigenvalues scaled by sqrt(2))
 
-	Z = dspev!(:N, :L, y)
-	for i in 1:length(Z)
-		#Do we allow for some tolerance here?
-		if Z[i] <= -1e-14
-			return +Inf
-		end
-	end
-	return 0.0
+    Z = dspev!(:N, :L, y)
+    for i in 1:length(Z)
+        #Do we allow for some tolerance here?
+        if Z[i] <= -1e-14
+            return +Inf
+        end
+    end
+    return 0.0
 end
 
 function prox!(y::AbstractVector{Float64}, f::IndPSD, x::AbstractVector{Float64}, gamma::Real=1.0)
-	y .= x							# Copy x since dspev! corrupts input
+    y .= x                            # Copy x since dspev! corrupts input
 
-	f.scaling && scale_diagonal!(y, sqrt(2)) #If scaling, scale diagonal
+    f.scaling && scale_diagonal!(y, sqrt(2)) #If scaling, scale diagonal
 
-	(W, Z) = dspevV!(:L, y)
-	W = max.(W, 0.0)				 # NonNeg eigenvalues
-	M = Z.*W'						 # Equivalent to Z*diagm(W) without constructing W matrix
-	M = M*Z'							# Now let M = Z*diagm(W)*Z'
-	n = length(W)
-	k = 1
-	for j in 1:n, i in j:n	# Store lower diagonal of M in y
-		y[k] = M[i,j]
-		k = k+1
-	end
+    (W, Z) = dspevV!(:L, y)
+    W = max.(W, 0.0)                 # NonNeg eigenvalues
+    M = Z.*W'                         # Equivalent to Z*diagm(W) without constructing W matrix
+    M = M*Z'                            # Now let M = Z*diagm(W)*Z'
+    n = length(W)
+    k = 1
+    for j in 1:n, i in j:n    # Store lower diagonal of M in y
+        y[k] = M[i,j]
+        k = k+1
+    end
 
-	f.scaling && scale_diagonal!(y, 1/sqrt(2))	#If scaling, un-scale diagonal
+    f.scaling && scale_diagonal!(y, 1/sqrt(2))    #If scaling, un-scale diagonal
 
-	return 0.0
+    return 0.0
 end
 
 function prox_naive(f::IndPSD, x::AbstractVector{T}, gamma::Real=1.0) where T<:Float64
-	n = Int(sqrt(1/4+2*length(x))-1/2)	# Formula for size of matrix
-	X = Array{T,2}(undef, n, n)
-	k = 1
-	for j = 1:n, i = j:n								# Store y in M
-		X[i,j] = x[k]									 # Lower half
-		if i != j
-			X[j,i] = x[k]							 # Strictly upper half
-		end
-		k = k+1
-	end
-	# Scale diagonal elements by sqrt(2)
-	# See Vandenberghe 2010 http://www.seas.ucla.edu/~vandenbe/publications/coneprog.pdf
-	# It's equivalent to scaling off-diagonal by 1/sqrt(2) and working with sqrt(2)*X
-	if f.scaling
-		for i = 1:n
-			X[i,i] *= sqrt(2)
-		end
-	end
-	X, v = prox_naive(f, Symmetric(X), gamma)
+    n = Int(sqrt(1/4+2*length(x))-1/2)    # Formula for size of matrix
+    X = Array{T,2}(undef, n, n)
+    k = 1
+    for j = 1:n, i = j:n                                # Store y in M
+        X[i,j] = x[k]                                     # Lower half
+        if i != j
+            X[j,i] = x[k]                             # Strictly upper half
+        end
+        k = k+1
+    end
+    # Scale diagonal elements by sqrt(2)
+    # See Vandenberghe 2010 http://www.seas.ucla.edu/~vandenbe/publications/coneprog.pdf
+    # It's equivalent to scaling off-diagonal by 1/sqrt(2) and working with sqrt(2)*X
+    if f.scaling
+        for i = 1:n
+            X[i,i] *= sqrt(2)
+        end
+    end
+    X, v = prox_naive(f, Symmetric(X), gamma)
 
-	if f.scaling	#Scale diagonal elements back
-		for i = 1:n
-			X[i,i] /= sqrt(2)
-		end
-	end
+    if f.scaling    #Scale diagonal elements back
+        for i = 1:n
+            X[i,i] /= sqrt(2)
+        end
+    end
 
-	y = similar(x)
-	k = 1
-	for j = 1:n, i = j:n								# Store Lower half of X in y
-		y[k] = X[i,j]
-		k = k+1
-	end
-	return y, 0.0
+    y = similar(x)
+    k = 1
+    for j = 1:n, i = j:n                                # Store Lower half of X in y
+        y[k] = X[i,j]
+        k = k+1
+    end
+    return y, 0.0
 end

--- a/src/functions/indPSD.jl
+++ b/src/functions/indPSD.jl
@@ -5,7 +5,7 @@ export IndPSD
 """
 **Indicator of the set of positive semi-definite cone**
 
-    IndPSD(;scaling=false)
+	IndPSD(;scaling=false)
 
 Returns the indicator of the set
 ```math
@@ -28,40 +28,40 @@ I.e. when when `scaling=true`, let `X,Y` be matrices and
 then `prox!(Y, f, X)` is equivalent to `prox!(y, f, x)`.
 """
 struct IndPSD <: ProximableFunction
-    scaling::Bool
+	scaling::Bool
 end
 
 IndPSD(;scaling=false) = IndPSD(scaling)
 
 function (f::IndPSD)(X::HermOrSym{T}) where T <: RealOrComplex
-  F = eigen(X)
-  for i in eachindex(F.values)
-    #Do we allow for some tolerance here?
-    if F.values[i] <= -1e-14
-      return +Inf
-    end
-  end
-  return 0.0
+	F = eigen(X)
+	for i in eachindex(F.values)
+		#Do we allow for some tolerance here?
+		if F.values[i] <= -1e-14
+			return +Inf
+		end
+	end
+	return 0.0
 end
 
 is_convex(f::IndPSD) = true
 is_cone(f::IndPSD) = true
 
 function prox!(Y::HermOrSym{T}, f::IndPSD, X::HermOrSym{T}, gamma::Real=1.0) where T <: RealOrComplex
-  n = size(X, 1)
-  F = eigen(X)
-  for i in eachindex(F.values)
-    F.values[i] = max.(0.0, F.values[i])
-  end
-  for i = 1:n
-    for j = 1:n
-      Y.data[i,j] = 0.0
-      for k = 1:n
-        Y.data[i,j] += F.vectors[i,k]*F.values[k]*F.vectors[j,k]
-      end
-    end
-  end
-  return 0.0
+	n = size(X, 1)
+	F = eigen(X)
+	for i in eachindex(F.values)
+		F.values[i] = max.(0.0, F.values[i])
+	end
+	for i = 1:n
+		for j = 1:n
+			Y.data[i,j] = 0.0
+			for k = 1:n
+				Y.data[i,j] += F.vectors[i,k]*F.values[k]*F.vectors[j,k]
+			end
+		end
+	end
+	return 0.0
 end
 
 fun_name(f::IndPSD) = "indicator of positive semidefinite cone"
@@ -70,8 +70,8 @@ fun_expr(f::IndPSD) = "x ↦ 0 if A ⪰ 0, +∞ otherwise"
 fun_params(f::IndPSD) = "none"
 
 function prox_naive(f::IndPSD, X::HermOrSym{T}, gamma::Real=1.0) where T <: RealOrComplex
-  F = eigen(X)
-  return F.vectors * Diagonal(max.(0.0, F.values)) * F.vectors', 0.0
+	F = eigen(X)
+	return F.vectors * Diagonal(max.(0.0, F.values)) * F.vectors', 0.0
 end
 
 """
@@ -79,83 +79,83 @@ Scales the diagonal of `x` with `val`, where `x` is the lower triangualar part
 of a matrix, stored column by column.
 """
 function scale_diagonal!(x, val)
-    n = Int(sqrt(1/4+2*length(x))-1/2)
-    k = -n
-    for i = 1:n
-         k += n - i + 2    #Calculate indices of diagonal elements recursively (paralell faster?)
-         x[k] *= val      #Scale diagonal
-    end
+	n = Int(sqrt(1/4+2*length(x))-1/2)
+	k = -n
+	for i = 1:n
+		k += n - i + 2		#Calculate indices of diagonal elements recursively (paralell faster?)
+		x[k] *= val			#Scale diagonal
+	end
 end
 
 ### Below: with AbstractVector argument
 
 function (f::IndPSD)(x::AbstractVector{T}) where T <: Float64
-  y = copy(x)
-  f.scaling && scale_diagonal!(y, sqrt(2)) #If scaling, scale diagonal (eigenvalues scaled by sqrt(2))
+	y = copy(x)
+	f.scaling && scale_diagonal!(y, sqrt(2)) #If scaling, scale diagonal (eigenvalues scaled by sqrt(2))
 
-  Z = dspev!(:N, :L, y)
-  for i in 1:length(Z)
-    #Do we allow for some tolerance here?
-    if Z[i] <= -1e-14
-      return +Inf
-    end
-  end
-  return 0.0
+	Z = dspev!(:N, :L, y)
+	for i in 1:length(Z)
+		#Do we allow for some tolerance here?
+		if Z[i] <= -1e-14
+			return +Inf
+		end
+	end
+	return 0.0
 end
 
 function prox!(y::AbstractVector{Float64}, f::IndPSD, x::AbstractVector{Float64}, gamma::Real=1.0)
-  y .= x              # Copy x since dspev! corrupts input
+	y .= x							# Copy x since dspev! corrupts input
 
-  f.scaling && scale_diagonal!(y, sqrt(2)) #If scaling, scale diagonal
+	f.scaling && scale_diagonal!(y, sqrt(2)) #If scaling, scale diagonal
 
-  (W, Z) = dspevV!(:L, y)
-  W = max.(W, 0.0)         # NonNeg eigenvalues
-  M = Z.*W'             # Equivalent to Z*diagm(W) without constructing W matrix
-  M = M*Z'              # Now let M = Z*diagm(W)*Z'
-  n = length(W)
-  k = 1
-  for j in 1:n, i in j:n  # Store lower diagonal of M in y
-    y[k] = M[i,j]
-    k = k+1
-  end
+	(W, Z) = dspevV!(:L, y)
+	W = max.(W, 0.0)				 # NonNeg eigenvalues
+	M = Z.*W'						 # Equivalent to Z*diagm(W) without constructing W matrix
+	M = M*Z'							# Now let M = Z*diagm(W)*Z'
+	n = length(W)
+	k = 1
+	for j in 1:n, i in j:n	# Store lower diagonal of M in y
+		y[k] = M[i,j]
+		k = k+1
+	end
 
-  f.scaling && scale_diagonal!(y, 1/sqrt(2))  #If scaling, un-scale diagonal
+	f.scaling && scale_diagonal!(y, 1/sqrt(2))	#If scaling, un-scale diagonal
 
-  return 0.0
+	return 0.0
 end
 
 function prox_naive(f::IndPSD, x::AbstractVector{T}, gamma::Real=1.0) where T<:Float64
-  n = Int(sqrt(1/4+2*length(x))-1/2)  # Formula for size of matrix
-  X = Array{T,2}(undef, n, n)
-  k = 1
-  for j = 1:n, i = j:n                # Store y in M
-    X[i,j] = x[k]                   # Lower half
-    if i != j
-      X[j,i] = x[k]               # Strictly upper half
-    end
-    k = k+1
-  end
-  # Scale diagonal elements by sqrt(2)
-  # See Vandenberghe 2010 http://www.seas.ucla.edu/~vandenbe/publications/coneprog.pdf
-  # It's equivalent to scaling off-diagonal by 1/sqrt(2) and working with sqrt(2)*X
-  if f.scaling
-    for i = 1:n
-      X[i,i] *= sqrt(2)
-    end
-  end
-  X, v = prox_naive(f, Symmetric(X), gamma)
+	n = Int(sqrt(1/4+2*length(x))-1/2)	# Formula for size of matrix
+	X = Array{T,2}(undef, n, n)
+	k = 1
+	for j = 1:n, i = j:n								# Store y in M
+		X[i,j] = x[k]									 # Lower half
+		if i != j
+			X[j,i] = x[k]							 # Strictly upper half
+		end
+		k = k+1
+	end
+	# Scale diagonal elements by sqrt(2)
+	# See Vandenberghe 2010 http://www.seas.ucla.edu/~vandenbe/publications/coneprog.pdf
+	# It's equivalent to scaling off-diagonal by 1/sqrt(2) and working with sqrt(2)*X
+	if f.scaling
+		for i = 1:n
+			X[i,i] *= sqrt(2)
+		end
+	end
+	X, v = prox_naive(f, Symmetric(X), gamma)
 
-  if f.scaling  #Scale diagonal elements back
-    for i = 1:n
-      X[i,i] /= sqrt(2)
-    end
-  end
+	if f.scaling	#Scale diagonal elements back
+		for i = 1:n
+			X[i,i] /= sqrt(2)
+		end
+	end
 
-  y = similar(x)
-  k = 1
-  for j = 1:n, i = j:n                # Store Lower half of X in y
-    y[k] = X[i,j]
-    k = k+1
-  end
-  return y, 0.0
+	y = similar(x)
+	k = 1
+	for j = 1:n, i = j:n								# Store Lower half of X in y
+		y[k] = X[i,j]
+		k = k+1
+	end
+	return y, 0.0
 end

--- a/src/functions/indPoint.jl
+++ b/src/functions/indPoint.jl
@@ -5,7 +5,7 @@ export IndPoint
 """
 **Indicator of a singleton**
 
-	IndPoint(p=0.0)
+    IndPoint(p=0.0)
 
 Returns the indicator of the set
 ```math
@@ -14,10 +14,10 @@ C = \\{p \\}.
 Parameter `p` can be a scalar, in which case the unique element of `S` has uniform coefficients.
 """
 struct IndPoint{R <: Real, C <: Union{R, Complex{R}}, T <: Union{C, AbstractArray{C}}} <: ProximableFunction
-	p::T
-	function IndPoint{R, C, T}(p::T) where {R, C, T}
-		new(p)
-	end
+    p::T
+    function IndPoint{R, C, T}(p::T) where {R, C, T}
+        new(p)
+    end
 end
 
 is_separable(f::IndPoint) = true
@@ -29,25 +29,25 @@ is_affine(f::IndPoint) = true
 IndPoint(p::T=0.0) where {R <: Real, C <: Union{R, Complex{R}}, T <: Union{C, AbstractArray{C}}} = IndPoint{R, C, T}(p)
 
 function (f::IndPoint{R, C})(x::AbstractArray{C}) where {R, C}
-	if all(x .≈ f.p)
-		return R(0)
-	end
-	return R(Inf)
+    if all(x .≈ f.p)
+        return R(0)
+    end
+    return R(Inf)
 end
 
 function prox!(y::AbstractArray{C}, f::IndPoint{R, C}, x::AbstractArray{C}, gamma=R(1)) where {R, C}
-	y .= f.p
-	return R(0)
+    y .= f.p
+    return R(0)
 end
 
 fun_name(f::IndPoint) = "indicator of a point"
 fun_dom(f::IndPoint) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndPoint) = "x ↦ 0 if x = p, +∞ otherwise"
 fun_params(f::IndPoint) =
-	string( "p = ", typeof(f.p) <: AbstractArray ? string(typeof(f.p), " of size ", size(f.p)) : f.p, ", ")
+    string( "p = ", typeof(f.p) <: AbstractArray ? string(typeof(f.p), " of size ", size(f.p)) : f.p, ", ")
 
 function prox_naive(f::IndPoint{R, C}, x::AbstractArray{C}, gamma=R(1)) where {R, C}
-	y = similar(x)
-	y .= f.p
-	return y, R(0)
+    y = similar(x)
+    y .= f.p
+    return y, R(0)
 end

--- a/src/functions/indPoint.jl
+++ b/src/functions/indPoint.jl
@@ -13,11 +13,11 @@ C = \\{p \\}.
 ```
 Parameter `p` can be a scalar, in which case the unique element of `S` has uniform coefficients.
 """
-struct IndPoint{T <: Union{Real, Complex, AbstractArray{<:RealOrComplex}}} <: ProximableFunction
-  p::T
-  function IndPoint{T}(p::T) where {T <: Union{Real, Complex, AbstractArray{<:RealOrComplex}}}
-    new(p)
-  end
+struct IndPoint{R <: Real, C <: Union{R, Complex{R}}, T <: Union{C, AbstractArray{C}}} <: ProximableFunction
+    p::T
+    function IndPoint{R, C, T}(p::T) where {R, C, T}
+        new(p)
+    end
 end
 
 is_separable(f::IndPoint) = true
@@ -26,50 +26,28 @@ is_singleton(f::IndPoint) = true
 is_cone(f::IndPoint) = norm(f.p) == 0
 is_affine(f::IndPoint) = true
 
-IndPoint(p::T=0.0) where {T <: Union{Real, Complex, AbstractArray{<:RealOrComplex}}} = IndPoint{T}(p)
+IndPoint(p::T=0.0) where {R <: Real, C <: Union{R, Complex{R}}, T <: Union{C, AbstractArray{C}}} = IndPoint{R, C, T}(p)
 
-function (f::IndPoint{R})(x::AbstractArray{T}) where {R <: RealOrComplex, T <: RealOrComplex}
-  for k in eachindex(x)
-    if abs(x[k] - f.p) > 1e-14
-      return +Inf
+function (f::IndPoint{R, C})(x::AbstractArray{C}) where {R, C}
+    if all(x .≈ f.p)
+        return R(0)
     end
-  end
-  return zero(T)
+    return R(Inf)
 end
 
-function (f::IndPoint{A})(x::AbstractArray{T}) where {A <: AbstractArray, T <: RealOrComplex}
-  for k in eachindex(x)
-    if abs(x[k] - f.p[k]) > 1e-14
-      return +Inf
-    end
-  end
-  return zero(T)
+function prox!(y::AbstractArray{C}, f::IndPoint{R, C}, x::AbstractArray{C}, gamma=one(R)) where {R, C}
+    y .= f.p
+    return R(0)
 end
-
-function prox!(y::AbstractArray{T}, f::IndPoint{R}, x::AbstractArray{T}, gamma::Real=1.0) where {R <: RealOrComplex, T <: RealOrComplex}
-  for k in eachindex(x)
-    y[k] = f.p
-  end
-  return zero(T)
-end
-
-function prox!(y::AbstractArray{T}, f::IndPoint{A}, x::AbstractArray{T}, gamma::Real=1.0) where {A <: AbstractArray, T <: RealOrComplex}
-  for k in eachindex(x)
-    y[k] = f.p[k]
-  end
-  return zero(T)
-end
-
-prox!(y::AbstractArray{T}, f::IndPoint, x::AbstractArray{T}, gamma::AbstractArray) where {T <: RealOrComplex} = prox!(y, f, x, 1.0)
 
 fun_name(f::IndPoint) = "indicator of a point"
 fun_dom(f::IndPoint) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndPoint) = "x ↦ 0 if x = p, +∞ otherwise"
 fun_params(f::IndPoint) =
-  string( "p = ", typeof(f.p) <: AbstractArray ? string(typeof(f.p), " of size ", size(f.p)) : f.p, ", ")
+    string( "p = ", typeof(f.p) <: AbstractArray ? string(typeof(f.p), " of size ", size(f.p)) : f.p, ", ")
 
-function prox_naive(f::IndPoint, x::AbstractArray{T}, gamma=1.0) where T <: RealOrComplex
+function prox_naive(f::IndPoint{R, C}, x::AbstractArray{C}, gamma=one(R)) where {R, C}
     y = similar(x)
     y .= f.p
-    return y, 0.0
+    return y, R(0)
 end

--- a/src/functions/indPoint.jl
+++ b/src/functions/indPoint.jl
@@ -5,7 +5,7 @@ export IndPoint
 """
 **Indicator of a singleton**
 
-    IndPoint(p=0.0)
+	IndPoint(p=0.0)
 
 Returns the indicator of the set
 ```math
@@ -14,10 +14,10 @@ C = \\{p \\}.
 Parameter `p` can be a scalar, in which case the unique element of `S` has uniform coefficients.
 """
 struct IndPoint{R <: Real, C <: Union{R, Complex{R}}, T <: Union{C, AbstractArray{C}}} <: ProximableFunction
-    p::T
-    function IndPoint{R, C, T}(p::T) where {R, C, T}
-        new(p)
-    end
+	p::T
+	function IndPoint{R, C, T}(p::T) where {R, C, T}
+		new(p)
+	end
 end
 
 is_separable(f::IndPoint) = true
@@ -29,25 +29,25 @@ is_affine(f::IndPoint) = true
 IndPoint(p::T=0.0) where {R <: Real, C <: Union{R, Complex{R}}, T <: Union{C, AbstractArray{C}}} = IndPoint{R, C, T}(p)
 
 function (f::IndPoint{R, C})(x::AbstractArray{C}) where {R, C}
-    if all(x .≈ f.p)
-        return R(0)
-    end
-    return R(Inf)
+	if all(x .≈ f.p)
+		return R(0)
+	end
+	return R(Inf)
 end
 
 function prox!(y::AbstractArray{C}, f::IndPoint{R, C}, x::AbstractArray{C}, gamma=one(R)) where {R, C}
-    y .= f.p
-    return R(0)
+	y .= f.p
+	return R(0)
 end
 
 fun_name(f::IndPoint) = "indicator of a point"
 fun_dom(f::IndPoint) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndPoint) = "x ↦ 0 if x = p, +∞ otherwise"
 fun_params(f::IndPoint) =
-    string( "p = ", typeof(f.p) <: AbstractArray ? string(typeof(f.p), " of size ", size(f.p)) : f.p, ", ")
+	string( "p = ", typeof(f.p) <: AbstractArray ? string(typeof(f.p), " of size ", size(f.p)) : f.p, ", ")
 
 function prox_naive(f::IndPoint{R, C}, x::AbstractArray{C}, gamma=one(R)) where {R, C}
-    y = similar(x)
-    y .= f.p
-    return y, R(0)
+	y = similar(x)
+	y .= f.p
+	return y, R(0)
 end

--- a/src/functions/indPoint.jl
+++ b/src/functions/indPoint.jl
@@ -35,7 +35,7 @@ function (f::IndPoint{R, C})(x::AbstractArray{C}) where {R, C}
 	return R(Inf)
 end
 
-function prox!(y::AbstractArray{C}, f::IndPoint{R, C}, x::AbstractArray{C}, gamma=one(R)) where {R, C}
+function prox!(y::AbstractArray{C}, f::IndPoint{R, C}, x::AbstractArray{C}, gamma=R(1)) where {R, C}
 	y .= f.p
 	return R(0)
 end
@@ -46,7 +46,7 @@ fun_expr(f::IndPoint) = "x ↦ 0 if x = p, +∞ otherwise"
 fun_params(f::IndPoint) =
 	string( "p = ", typeof(f.p) <: AbstractArray ? string(typeof(f.p), " of size ", size(f.p)) : f.p, ", ")
 
-function prox_naive(f::IndPoint{R, C}, x::AbstractArray{C}, gamma=one(R)) where {R, C}
+function prox_naive(f::IndPoint{R, C}, x::AbstractArray{C}, gamma=R(1)) where {R, C}
 	y = similar(x)
 	y .= f.p
 	return y, R(0)

--- a/src/functions/indPolyhedral.jl
+++ b/src/functions/indPolyhedral.jl
@@ -8,7 +8,7 @@ is_set(::IndPolyhedral) = true
 """
 **Indicator of a polyhedral set**
 
-    IndPolyhedral([l,] A, [u, xmin, xmax])
+	IndPolyhedral([l,] A, [u, xmin, xmax])
 
 Returns the indicator function of the polyhedral set:
 ```math
@@ -18,11 +18,11 @@ Matrix `A` is a mandatory argument; when any of the bounds is not provided,
 it is assumed to be (plus or minus) infinity.
 """
 function IndPolyhedral(args...; solver=:osqp)
-    if solver == :osqp
-        IndPolyhedralOSQP(args...)
-    else
-        error("unknown solver")
-    end
+	if solver == :osqp
+		IndPolyhedralOSQP(args...)
+	else
+		error("unknown solver")
+	end
 end
 
 # including concrete types

--- a/src/functions/indPolyhedral.jl
+++ b/src/functions/indPolyhedral.jl
@@ -8,7 +8,7 @@ is_set(::IndPolyhedral) = true
 """
 **Indicator of a polyhedral set**
 
-	IndPolyhedral([l,] A, [u, xmin, xmax])
+    IndPolyhedral([l,] A, [u, xmin, xmax])
 
 Returns the indicator function of the polyhedral set:
 ```math
@@ -18,11 +18,11 @@ Matrix `A` is a mandatory argument; when any of the bounds is not provided,
 it is assumed to be (plus or minus) infinity.
 """
 function IndPolyhedral(args...; solver=:osqp)
-	if solver == :osqp
-		IndPolyhedralOSQP(args...)
-	else
-		error("unknown solver")
-	end
+    if solver == :osqp
+        IndPolyhedralOSQP(args...)
+    else
+        error("unknown solver")
+    end
 end
 
 # including concrete types

--- a/src/functions/indPolyhedralOSQP.jl
+++ b/src/functions/indPolyhedralOSQP.jl
@@ -3,23 +3,23 @@
 using OSQP
 
 struct IndPolyhedralOSQP{R} <: IndPolyhedral
-    l::AbstractVector{R}
-    A::AbstractMatrix{R}
-    u::AbstractVector{R}
-    mod::OSQP.Model
-    function IndPolyhedralOSQP{R}(
-        l::AbstractVector{R}, A::AbstractMatrix{R}, u::AbstractVector{R}
-    ) where R
-        m, n = size(A)
-        mod = OSQP.Model()
-        if !all(l .<= u)
-            error("function is improper (are some bounds inverted?)")
-        end
-        OSQP.setup!(mod; P=SparseMatrixCSC{R}(I, n, n), l=l, A=sparse(A), u=u, verbose=false,
-            eps_abs=eps(R), eps_rel=eps(R),
-            eps_prim_inf=eps(R), eps_dual_inf=eps(R))
-        new(l, A, u, mod)
-    end
+	l::AbstractVector{R}
+	A::AbstractMatrix{R}
+	u::AbstractVector{R}
+	mod::OSQP.Model
+	function IndPolyhedralOSQP{R}(
+		l::AbstractVector{R}, A::AbstractMatrix{R}, u::AbstractVector{R}
+	) where R
+		m, n = size(A)
+		mod = OSQP.Model()
+		if !all(l .<= u)
+			error("function is improper (are some bounds inverted?)")
+		end
+		OSQP.setup!(mod; P=SparseMatrixCSC{R}(I, n, n), l=l, A=sparse(A), u=u, verbose=false,
+			eps_abs=eps(R), eps_rel=eps(R),
+			eps_prim_inf=eps(R), eps_dual_inf=eps(R))
+		new(l, A, u, mod)
+	end
 end
 
 # properties
@@ -29,44 +29,44 @@ is_prox_accurate(::IndPolyhedralOSQP) = false
 # constructors
 
 IndPolyhedralOSQP(
-    l::AbstractVector{R}, A::AbstractMatrix{R}, u::AbstractVector{R}
+	l::AbstractVector{R}, A::AbstractMatrix{R}, u::AbstractVector{R}
 ) where R =
-    IndPolyhedralOSQP{R}(l, A, u)
+	IndPolyhedralOSQP{R}(l, A, u)
 
 IndPolyhedralOSQP(
-    l::AbstractVector{R}, A::AbstractMatrix{R}, u::AbstractVector{R},
-    xmin::AbstractVector{R}, xmax::AbstractVector{R}
+	l::AbstractVector{R}, A::AbstractMatrix{R}, u::AbstractVector{R},
+	xmin::AbstractVector{R}, xmax::AbstractVector{R}
 ) where R =
-    IndPolyhedralOSQP([l; xmin], [A; I], [u; xmax])
+	IndPolyhedralOSQP([l; xmin], [A; I], [u; xmax])
 
 IndPolyhedralOSQP(
-    l::AbstractVector{R}, A::AbstractMatrix{R}, args...
+	l::AbstractVector{R}, A::AbstractMatrix{R}, args...
 ) where R =
-    IndPolyhedralOSQP(
-        l, SparseMatrixCSC(A), R(Inf).*ones(R, size(A, 1)), args...
-    )
+	IndPolyhedralOSQP(
+		l, SparseMatrixCSC(A), R(Inf).*ones(R, size(A, 1)), args...
+	)
 
 IndPolyhedralOSQP(
-    A::AbstractMatrix{R}, u::AbstractVector{R}, args...
+	A::AbstractMatrix{R}, u::AbstractVector{R}, args...
 ) where R =
-    IndPolyhedralOSQP(
-        R(-Inf).*ones(R, size(A, 1)), SparseMatrixCSC(A), u, args...
-    )
+	IndPolyhedralOSQP(
+		R(-Inf).*ones(R, size(A, 1)), SparseMatrixCSC(A), u, args...
+	)
 
 # function evaluation
 
 function (f::IndPolyhedralOSQP{R})(x::AbstractVector{R}) where R
-    Ax = f.A * x
-    return all(f.l .<= Ax .<= f.u) ? zero(R) : Inf
+	Ax = f.A * x
+	return all(f.l .<= Ax .<= f.u) ? zero(R) : Inf
 end
 
 # prox
 
 function prox!(y::AbstractVector{R}, f::IndPolyhedralOSQP{R}, x::AbstractVector{R}, gamma::R=one(R)) where R
-    OSQP.update!(f.mod; q=-x)
-    results = OSQP.solve!(f.mod)
-    y .= results.x
-    return zero(R)
+	OSQP.update!(f.mod; q=-x)
+	results = OSQP.solve!(f.mod)
+	y .= results.x
+	return zero(R)
 end
 
 # naive prox
@@ -80,19 +80,19 @@ end
 # can solve with (fast) dual proximal gradient method
 
 function prox_naive(f::IndPolyhedralOSQP{R}, x::AbstractVector{R}, gamma::R=one(R)) where R
-    y = zeros(R, size(f.A, 1)) # dual vector
-    y1 = y
-    g = IndBox(f.l, f.u)
-    gstar = Conjugate(g)
-    gstar_y = zero(R)
-    stepsize = one(R)/opnorm(Matrix(f.A*f.A'))
-    for it = 1:1e6
-        w = y + (it-1)/(it+2)*(y - y1)
-        y1 = y
-        z = w - stepsize * (f.A * (f.A'*w - x))
-        y, = prox(gstar, z, stepsize)
-        if norm(y-w)/(1+norm(w)) <= 1e-12 break end
-    end
-    p = -f.A'*y + x
-    return p, zero(R)
+	y = zeros(R, size(f.A, 1)) # dual vector
+	y1 = y
+	g = IndBox(f.l, f.u)
+	gstar = Conjugate(g)
+	gstar_y = zero(R)
+	stepsize = one(R)/opnorm(Matrix(f.A*f.A'))
+	for it = 1:1e6
+		w = y + (it-1)/(it+2)*(y - y1)
+		y1 = y
+		z = w - stepsize * (f.A * (f.A'*w - x))
+		y, = prox(gstar, z, stepsize)
+		if norm(y-w)/(1+norm(w)) <= 1e-12 break end
+	end
+	p = -f.A'*y + x
+	return p, zero(R)
 end

--- a/src/functions/indPolyhedralOSQP.jl
+++ b/src/functions/indPolyhedralOSQP.jl
@@ -57,16 +57,16 @@ IndPolyhedralOSQP(
 
 function (f::IndPolyhedralOSQP{R})(x::AbstractVector{R}) where R
 	Ax = f.A * x
-	return all(f.l .<= Ax .<= f.u) ? zero(R) : Inf
+	return all(f.l .<= Ax .<= f.u) ? R(0) : Inf
 end
 
 # prox
 
-function prox!(y::AbstractVector{R}, f::IndPolyhedralOSQP{R}, x::AbstractVector{R}, gamma::R=one(R)) where R
+function prox!(y::AbstractVector{R}, f::IndPolyhedralOSQP{R}, x::AbstractVector{R}, gamma::R=R(1)) where R
 	OSQP.update!(f.mod; q=-x)
 	results = OSQP.solve!(f.mod)
 	y .= results.x
-	return zero(R)
+	return R(0)
 end
 
 # naive prox
@@ -79,13 +79,13 @@ end
 # dual problem is: minimize_y (1/2)||-A'y||^2 - x'A'y + g*(y)
 # can solve with (fast) dual proximal gradient method
 
-function prox_naive(f::IndPolyhedralOSQP{R}, x::AbstractVector{R}, gamma::R=one(R)) where R
+function prox_naive(f::IndPolyhedralOSQP{R}, x::AbstractVector{R}, gamma::R=R(1)) where R
 	y = zeros(R, size(f.A, 1)) # dual vector
 	y1 = y
 	g = IndBox(f.l, f.u)
 	gstar = Conjugate(g)
-	gstar_y = zero(R)
-	stepsize = one(R)/opnorm(Matrix(f.A*f.A'))
+	gstar_y = R(0)
+	stepsize = R(1)/opnorm(Matrix(f.A*f.A'))
 	for it = 1:1e6
 		w = y + (it-1)/(it+2)*(y - y1)
 		y1 = y
@@ -94,5 +94,5 @@ function prox_naive(f::IndPolyhedralOSQP{R}, x::AbstractVector{R}, gamma::R=one(
 		if norm(y-w)/(1+norm(w)) <= 1e-12 break end
 	end
 	p = -f.A'*y + x
-	return p, zero(R)
+	return p, R(0)
 end

--- a/src/functions/indSOC.jl
+++ b/src/functions/indSOC.jl
@@ -5,7 +5,7 @@ export IndSOC, IndRotatedSOC
 """
 **Indicator of the second-order cone**
 
-    IndSOC()
+	IndSOC()
 
 Returns the indicator of the second-order cone (also known as ice-cream cone or Lorentz cone), that is
 ```math
@@ -15,29 +15,29 @@ C = \\left\\{ (t, x) : \\|x\\| \\leq t \\right\\}.
 struct IndSOC <: ProximableFunction end
 
 function (f::IndSOC)(x::AbstractVector{T}) where T <: Real
-  # the tolerance in the following line should be customizable
-  if norm(x[2:end]) - x[1] <= 1e-14
-    return zero(T)
-  end
-  return +Inf
+	# the tolerance in the following line should be customizable
+	if norm(x[2:end]) - x[1] <= 1e-14
+		return zero(T)
+	end
+	return +Inf
 end
 
 is_convex(f::IndSOC) = true
 is_set(f::IndSOC) = true
 
 function prox!(y::AbstractVector{T}, f::IndSOC, x::AbstractVector{T}, gamma::T=one(T)) where T <: Real
-  @views nx = norm(x[2:end])
-  t = x[1]
-  if t <= -nx
-    y .= zero(T)
-  elseif t >= nx
-    y .= x
-  else
-    r = T(0.5) * (one(T) + t / nx)
-    y[1] = r * nx
-    @views y[2:end] .= r .* x[2:end]
-  end
-  return zero(T)
+	@views nx = norm(x[2:end])
+	t = x[1]
+	if t <= -nx
+		y .= zero(T)
+	elseif t >= nx
+		y .= x
+	else
+		r = T(0.5) * (one(T) + t / nx)
+		y[1] = r * nx
+		@views y[2:end] .= r .* x[2:end]
+	end
+	return zero(T)
 end
 
 fun_name(f::IndSOC) = "indicator of the second-order cone"
@@ -46,19 +46,19 @@ fun_expr(f::IndSOC) = "x ↦ 0 if x[1] >= ||x[2:end]||, +∞ otherwise"
 fun_params(f::IndSOC) = "none"
 
 function prox_naive(f::IndSOC, x::AbstractVector{T}, gamma=1.0) where T <: Real
-  nx = norm(x[2:end])
-  t = x[1]
-  if t <= -nx
-    y = zero(x)
-  elseif t >= nx
-    y = x
-  else
-    y = zero(x)
-    r = 0.5 * (1 + t / nx)
-    y[1] = r * nx
-    y[2:end] .= r .* x[2:end]
-  end
-  return y, 0.0
+	nx = norm(x[2:end])
+	t = x[1]
+	if t <= -nx
+		y = zero(x)
+	elseif t >= nx
+		y = x
+	else
+		y = zero(x)
+		r = 0.5 * (1 + t / nx)
+		y[1] = r * nx
+		y[2:end] .= r .* x[2:end]
+	end
+	return y, 0.0
 end
 
 # ########################
@@ -68,7 +68,7 @@ end
 """
 **Indicator of the rotated second-order cone**
 
-    IndRotatedSOC()
+		IndRotatedSOC()
 
 Returns the indicator of the *rotated* second-order cone (also known as ice-cream cone or Lorentz cone), that is
 ```math
@@ -78,41 +78,41 @@ C = \\left\\{ (p, q, x) : \\|x\\|^2 \\leq 2\\cdot pq, p \\geq 0, q \\geq 0 \\rig
 struct IndRotatedSOC <: ProximableFunction end
 
 function (f::IndRotatedSOC)(x::AbstractVector{T}) where T <: Real
-  if x[1] >= -1e-14 && x[2] >= -1e-14 && norm(x[3:end])^2 - 2*x[1]*x[2] <= 1e-14
-    return zero(T)
-  end
-  return +Inf
+	if x[1] >= -1e-14 && x[2] >= -1e-14 && norm(x[3:end])^2 - 2*x[1]*x[2] <= 1e-14
+		return zero(T)
+	end
+	return +Inf
 end
 
 is_convex(f::IndRotatedSOC) = true
 is_set(f::IndRotatedSOC) = true
 
 function prox!(y::AbstractVector{T}, f::IndRotatedSOC, x::AbstractVector{T}, gamma::T=one(T)) where T <: Real
-  # sin(pi/4) = cos(pi/4) = 0.7071067811865475
-  # rotate x ccw by pi/4
-  x1 = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
-  x2 = 0.7071067811865475*x[1] - 0.7071067811865475*x[2]
-  # project rotated x onto SOC
-  @views nx = sqrt(x2^2+norm(x[3:end])^2)
-  t = x1
-  if t <= -nx
-    y .= zero(T)
-  elseif t >= nx
-    y[1] = x1
-    y[2] = x2
-    @views y[3:end] .= x[3:end]
-  else
-    r = T(0.5) * (one(T) + t / nx)
-    y[1] = r * nx
-    y[2] = r * x2
-    @views y[3:end] = r .* x[3:end]
-  end
-  # rotate back y cw by pi/4
-  y1 = 0.7071067811865475*y[1] + 0.7071067811865475*y[2]
-  y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
-  y[1] = y1
-  y[2] = y2
-  return zero(T)
+	# sin(pi/4) = cos(pi/4) = 0.7071067811865475
+	# rotate x ccw by pi/4
+	x1 = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
+	x2 = 0.7071067811865475*x[1] - 0.7071067811865475*x[2]
+	# project rotated x onto SOC
+	@views nx = sqrt(x2^2+norm(x[3:end])^2)
+	t = x1
+	if t <= -nx
+		y .= zero(T)
+	elseif t >= nx
+		y[1] = x1
+		y[2] = x2
+		@views y[3:end] .= x[3:end]
+	else
+		r = T(0.5) * (one(T) + t / nx)
+		y[1] = r * nx
+		y[2] = r * x2
+		@views y[3:end] = r .* x[3:end]
+	end
+	# rotate back y cw by pi/4
+	y1 = 0.7071067811865475*y[1] + 0.7071067811865475*y[2]
+	y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
+	y[1] = y1
+	y[2] = y2
+	return zero(T)
 end
 
 fun_name(f::IndRotatedSOC) = "indicator of the rotated second-order cone"
@@ -121,14 +121,14 @@ fun_expr(f::IndRotatedSOC) = "x ↦ 0 if x[1] ⩾ 0, x[2] ⩾ 0, norm(x[3:end])�
 fun_params(f::IndRotatedSOC) = "none"
 
 function prox_naive(f::IndRotatedSOC, x::AbstractVector{T}, gamma=1.0) where T <: Real
-  g = IndSOC()
-  z = copy(x)
-  z[1] = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
-  z[2] = 0.7071067811865475*x[1] - 0.7071067811865475*x[2]
-  y, = prox_naive(g, z, gamma)
-  y1 = 0.7071067811865475*y[1] + 0.7071067811865475*y[2]
-  y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
-  y[1] = y1
-  y[2] = y2
-  return y, 0.0
+	g = IndSOC()
+	z = copy(x)
+	z[1] = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
+	z[2] = 0.7071067811865475*x[1] - 0.7071067811865475*x[2]
+	y, = prox_naive(g, z, gamma)
+	y1 = 0.7071067811865475*y[1] + 0.7071067811865475*y[2]
+	y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
+	y[1] = y1
+	y[2] = y2
+	return y, 0.0
 end

--- a/src/functions/indSOC.jl
+++ b/src/functions/indSOC.jl
@@ -5,7 +5,7 @@ export IndSOC, IndRotatedSOC
 """
 **Indicator of the second-order cone**
 
-	IndSOC()
+    IndSOC()
 
 Returns the indicator of the second-order cone (also known as ice-cream cone or Lorentz cone), that is
 ```math
@@ -15,29 +15,29 @@ C = \\left\\{ (t, x) : \\|x\\| \\leq t \\right\\}.
 struct IndSOC <: ProximableFunction end
 
 function (f::IndSOC)(x::AbstractVector{T}) where T <: Real
-	# the tolerance in the following line should be customizable
-	if norm(x[2:end]) - x[1] <= 1e-14
-		return T(0)
-	end
-	return +Inf
+    # the tolerance in the following line should be customizable
+    if norm(x[2:end]) - x[1] <= 1e-14
+        return T(0)
+    end
+    return +Inf
 end
 
 is_convex(f::IndSOC) = true
 is_set(f::IndSOC) = true
 
 function prox!(y::AbstractVector{T}, f::IndSOC, x::AbstractVector{T}, gamma::T=T(1)) where T <: Real
-	@views nx = norm(x[2:end])
-	t = x[1]
-	if t <= -nx
-		y .= T(0)
-	elseif t >= nx
-		y .= x
-	else
-		r = T(0.5) * (T(1) + t / nx)
-		y[1] = r * nx
-		@views y[2:end] .= r .* x[2:end]
-	end
-	return T(0)
+    @views nx = norm(x[2:end])
+    t = x[1]
+    if t <= -nx
+        y .= T(0)
+    elseif t >= nx
+        y .= x
+    else
+        r = T(0.5) * (T(1) + t / nx)
+        y[1] = r * nx
+        @views y[2:end] .= r .* x[2:end]
+    end
+    return T(0)
 end
 
 fun_name(f::IndSOC) = "indicator of the second-order cone"
@@ -46,19 +46,19 @@ fun_expr(f::IndSOC) = "x ↦ 0 if x[1] >= ||x[2:end]||, +∞ otherwise"
 fun_params(f::IndSOC) = "none"
 
 function prox_naive(f::IndSOC, x::AbstractVector{T}, gamma=T(1)) where T <: Real
-	nx = norm(x[2:end])
-	t = x[1]
-	if t <= -nx
-		y = zero(x)
-	elseif t >= nx
-		y = x
-	else
-		y = zero(x)
-		r = T(0.5) * (T(1) + t / nx)
-		y[1] = r * nx
-		y[2:end] .= r .* x[2:end]
-	end
-	return y, T(0)
+    nx = norm(x[2:end])
+    t = x[1]
+    if t <= -nx
+        y = zero(x)
+    elseif t >= nx
+        y = x
+    else
+        y = zero(x)
+        r = T(0.5) * (T(1) + t / nx)
+        y[1] = r * nx
+        y[2:end] .= r .* x[2:end]
+    end
+    return y, T(0)
 end
 
 # ########################
@@ -68,7 +68,7 @@ end
 """
 **Indicator of the rotated second-order cone**
 
-		IndRotatedSOC()
+        IndRotatedSOC()
 
 Returns the indicator of the *rotated* second-order cone (also known as ice-cream cone or Lorentz cone), that is
 ```math
@@ -78,41 +78,41 @@ C = \\left\\{ (p, q, x) : \\|x\\|^2 \\leq 2\\cdot pq, p \\geq 0, q \\geq 0 \\rig
 struct IndRotatedSOC <: ProximableFunction end
 
 function (f::IndRotatedSOC)(x::AbstractVector{T}) where T <: Real
-	if x[1] >= -1e-14 && x[2] >= -1e-14 && norm(x[3:end])^2 - 2*x[1]*x[2] <= 1e-14
-		return T(0)
-	end
-	return T(Inf)
+    if x[1] >= -1e-14 && x[2] >= -1e-14 && norm(x[3:end])^2 - 2*x[1]*x[2] <= 1e-14
+        return T(0)
+    end
+    return T(Inf)
 end
 
 is_convex(f::IndRotatedSOC) = true
 is_set(f::IndRotatedSOC) = true
 
 function prox!(y::AbstractVector{T}, f::IndRotatedSOC, x::AbstractVector{T}, gamma::T=T(1)) where T <: Real
-	# sin(pi/4) = cos(pi/4) = 0.7071067811865475
-	# rotate x ccw by pi/4
-	x1 = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
-	x2 = 0.7071067811865475*x[1] - 0.7071067811865475*x[2]
-	# project rotated x onto SOC
-	@views nx = sqrt(x2^2+norm(x[3:end])^2)
-	t = x1
-	if t <= -nx
-		y .= T(0)
-	elseif t >= nx
-		y[1] = x1
-		y[2] = x2
-		@views y[3:end] .= x[3:end]
-	else
-		r = T(0.5) * (T(1) + t / nx)
-		y[1] = r * nx
-		y[2] = r * x2
-		@views y[3:end] = r .* x[3:end]
-	end
-	# rotate back y cw by pi/4
-	y1 = 0.7071067811865475*y[1] + 0.7071067811865475*y[2]
-	y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
-	y[1] = y1
-	y[2] = y2
-	return T(0)
+    # sin(pi/4) = cos(pi/4) = 0.7071067811865475
+    # rotate x ccw by pi/4
+    x1 = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
+    x2 = 0.7071067811865475*x[1] - 0.7071067811865475*x[2]
+    # project rotated x onto SOC
+    @views nx = sqrt(x2^2+norm(x[3:end])^2)
+    t = x1
+    if t <= -nx
+        y .= T(0)
+    elseif t >= nx
+        y[1] = x1
+        y[2] = x2
+        @views y[3:end] .= x[3:end]
+    else
+        r = T(0.5) * (T(1) + t / nx)
+        y[1] = r * nx
+        y[2] = r * x2
+        @views y[3:end] = r .* x[3:end]
+    end
+    # rotate back y cw by pi/4
+    y1 = 0.7071067811865475*y[1] + 0.7071067811865475*y[2]
+    y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
+    y[1] = y1
+    y[2] = y2
+    return T(0)
 end
 
 fun_name(f::IndRotatedSOC) = "indicator of the rotated second-order cone"
@@ -121,14 +121,14 @@ fun_expr(f::IndRotatedSOC) = "x ↦ 0 if x[1] ⩾ 0, x[2] ⩾ 0, norm(x[3:end])�
 fun_params(f::IndRotatedSOC) = "none"
 
 function prox_naive(f::IndRotatedSOC, x::AbstractVector{T}, gamma=T(1)) where T <: Real
-	g = IndSOC()
-	z = copy(x)
-	z[1] = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
-	z[2] = 0.7071067811865475*x[1] - 0.7071067811865475*x[2]
-	y, = prox_naive(g, z, gamma)
-	y1 = 0.7071067811865475*y[1] + 0.7071067811865475*y[2]
-	y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
-	y[1] = y1
-	y[2] = y2
-	return y, T(0)
+    g = IndSOC()
+    z = copy(x)
+    z[1] = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
+    z[2] = 0.7071067811865475*x[1] - 0.7071067811865475*x[2]
+    y, = prox_naive(g, z, gamma)
+    y1 = 0.7071067811865475*y[1] + 0.7071067811865475*y[2]
+    y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
+    y[1] = y1
+    y[2] = y2
+    return y, T(0)
 end

--- a/src/functions/indSOC.jl
+++ b/src/functions/indSOC.jl
@@ -17,7 +17,7 @@ struct IndSOC <: ProximableFunction end
 function (f::IndSOC)(x::AbstractVector{T}) where T <: Real
 	# the tolerance in the following line should be customizable
 	if norm(x[2:end]) - x[1] <= 1e-14
-		return zero(T)
+		return T(0)
 	end
 	return +Inf
 end
@@ -25,19 +25,19 @@ end
 is_convex(f::IndSOC) = true
 is_set(f::IndSOC) = true
 
-function prox!(y::AbstractVector{T}, f::IndSOC, x::AbstractVector{T}, gamma::T=one(T)) where T <: Real
+function prox!(y::AbstractVector{T}, f::IndSOC, x::AbstractVector{T}, gamma::T=T(1)) where T <: Real
 	@views nx = norm(x[2:end])
 	t = x[1]
 	if t <= -nx
-		y .= zero(T)
+		y .= T(0)
 	elseif t >= nx
 		y .= x
 	else
-		r = T(0.5) * (one(T) + t / nx)
+		r = T(0.5) * (T(1) + t / nx)
 		y[1] = r * nx
 		@views y[2:end] .= r .* x[2:end]
 	end
-	return zero(T)
+	return T(0)
 end
 
 fun_name(f::IndSOC) = "indicator of the second-order cone"
@@ -45,7 +45,7 @@ fun_dom(f::IndSOC) = "AbstractArray{Real,1}"
 fun_expr(f::IndSOC) = "x ↦ 0 if x[1] >= ||x[2:end]||, +∞ otherwise"
 fun_params(f::IndSOC) = "none"
 
-function prox_naive(f::IndSOC, x::AbstractVector{T}, gamma=1.0) where T <: Real
+function prox_naive(f::IndSOC, x::AbstractVector{T}, gamma=T(1)) where T <: Real
 	nx = norm(x[2:end])
 	t = x[1]
 	if t <= -nx
@@ -54,11 +54,11 @@ function prox_naive(f::IndSOC, x::AbstractVector{T}, gamma=1.0) where T <: Real
 		y = x
 	else
 		y = zero(x)
-		r = 0.5 * (1 + t / nx)
+		r = T(0.5) * (T(1) + t / nx)
 		y[1] = r * nx
 		y[2:end] .= r .* x[2:end]
 	end
-	return y, 0.0
+	return y, T(0)
 end
 
 # ########################
@@ -79,15 +79,15 @@ struct IndRotatedSOC <: ProximableFunction end
 
 function (f::IndRotatedSOC)(x::AbstractVector{T}) where T <: Real
 	if x[1] >= -1e-14 && x[2] >= -1e-14 && norm(x[3:end])^2 - 2*x[1]*x[2] <= 1e-14
-		return zero(T)
+		return T(0)
 	end
-	return +Inf
+	return T(Inf)
 end
 
 is_convex(f::IndRotatedSOC) = true
 is_set(f::IndRotatedSOC) = true
 
-function prox!(y::AbstractVector{T}, f::IndRotatedSOC, x::AbstractVector{T}, gamma::T=one(T)) where T <: Real
+function prox!(y::AbstractVector{T}, f::IndRotatedSOC, x::AbstractVector{T}, gamma::T=T(1)) where T <: Real
 	# sin(pi/4) = cos(pi/4) = 0.7071067811865475
 	# rotate x ccw by pi/4
 	x1 = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
@@ -96,13 +96,13 @@ function prox!(y::AbstractVector{T}, f::IndRotatedSOC, x::AbstractVector{T}, gam
 	@views nx = sqrt(x2^2+norm(x[3:end])^2)
 	t = x1
 	if t <= -nx
-		y .= zero(T)
+		y .= T(0)
 	elseif t >= nx
 		y[1] = x1
 		y[2] = x2
 		@views y[3:end] .= x[3:end]
 	else
-		r = T(0.5) * (one(T) + t / nx)
+		r = T(0.5) * (T(1) + t / nx)
 		y[1] = r * nx
 		y[2] = r * x2
 		@views y[3:end] = r .* x[3:end]
@@ -112,7 +112,7 @@ function prox!(y::AbstractVector{T}, f::IndRotatedSOC, x::AbstractVector{T}, gam
 	y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
 	y[1] = y1
 	y[2] = y2
-	return zero(T)
+	return T(0)
 end
 
 fun_name(f::IndRotatedSOC) = "indicator of the rotated second-order cone"
@@ -120,7 +120,7 @@ fun_dom(f::IndRotatedSOC) = "AbstractArray{Real,1}"
 fun_expr(f::IndRotatedSOC) = "x ↦ 0 if x[1] ⩾ 0, x[2] ⩾ 0, norm(x[3:end])² ⩽ 2*x[1]*x[2], +∞ otherwise"
 fun_params(f::IndRotatedSOC) = "none"
 
-function prox_naive(f::IndRotatedSOC, x::AbstractVector{T}, gamma=1.0) where T <: Real
+function prox_naive(f::IndRotatedSOC, x::AbstractVector{T}, gamma=T(1)) where T <: Real
 	g = IndSOC()
 	z = copy(x)
 	z[1] = 0.7071067811865475*x[1] + 0.7071067811865475*x[2]
@@ -130,5 +130,5 @@ function prox_naive(f::IndRotatedSOC, x::AbstractVector{T}, gamma=1.0) where T <
 	y2 = 0.7071067811865475*y[1] - 0.7071067811865475*y[2]
 	y[1] = y1
 	y[2] = y2
-	return y, 0.0
+	return y, T(0)
 end

--- a/src/functions/indSimplex.jl
+++ b/src/functions/indSimplex.jl
@@ -29,14 +29,14 @@ is_set(f::IndSimplex) = true
 
 IndSimplex(a::R=1.0) where {R <: Real} = IndSimplex{R}(a)
 
-function (f::IndSimplex{T})(x::AbstractArray{R}) where {T, R <: Real}
+function (f::IndSimplex)(x::AbstractArray{R}) where R <: Real
 	if all(x .>= 0) && sum(x) ≈ f.a
-		return zero(R)
+		return R(0)
 	end
 	return R(Inf)
 end
 
-function prox!(y::AbstractArray{R}, f::IndSimplex{T}, x::AbstractArray{R}, gamma::R=one(R)) where {T, R <: Real}
+function prox!(y::AbstractArray{R}, f::IndSimplex, x::AbstractArray{R}, gamma::R=R(1)) where R <: Real
 # Implements Algorithm 1 in Condat, "Fast projection onto the simplex and the l1 ball", Mathematical Programming, 158:575–585, 2016.
 # We should consider implementing the other algorithms reviewed there, and the one proposed in the paper.
 	n = length(x)
@@ -52,16 +52,16 @@ function prox!(y::AbstractArray{R}, f::IndSimplex{T}, x::AbstractArray{R}, gamma
 		tmax = (s - f.a)/i
 		if tmax >= p[i+1]
 			@inbounds for j in eachindex(y)
-				y[j] = x[j] < tmax ? zero(R) : x[j] - tmax
+				y[j] = x[j] < tmax ? R(0) : x[j] - tmax
 			end
-			return zero(R)
+			return R(0)
 		end
 	end
 	tmax = (s + p[n] - f.a)/n
 	@inbounds for j in eachindex(y)
-		y[j] = x[j] < tmax ? zero(R) : x[j] - tmax
+		y[j] = x[j] < tmax ? R(0) : x[j] - tmax
 	end
-	return zero(R)
+	return R(0)
 end
 
 fun_name(f::IndSimplex) = "indicator of the probability simplex"
@@ -69,7 +69,7 @@ fun_dom(f::IndSimplex) = "AbstractArray{Real}"
 fun_expr(f::IndSimplex) = "x ↦ 0 if x ⩾ 0 and sum(x) = a, +∞ otherwise"
 fun_params(f::IndSimplex) = "a = $(f.a)"
 
-function prox_naive(f::IndSimplex{T}, x::AbstractArray{R}, gamma::R=one(R)) where {T, R <: Real}
+function prox_naive(f::IndSimplex, x::AbstractArray{R}, gamma::R=R(1)) where R <: Real
 	low = minimum(x)
 	upp = maximum(x)
 	v = x
@@ -79,7 +79,7 @@ function prox_naive(f::IndSimplex{T}, x::AbstractArray{R}, gamma::R=one(R)) wher
 			break
 		end
 		alpha = (low+upp)/2
-		v = max.(x .- alpha, zero(R))
+		v = max.(x .- alpha, R(0))
 		s = sum(v) - f.a
 		if s <= 0
 			upp = alpha
@@ -87,5 +87,5 @@ function prox_naive(f::IndSimplex{T}, x::AbstractArray{R}, gamma::R=one(R)) wher
 			low = alpha
 		end
 	end
-	return v, zero(R)
+	return v, R(0)
 end

--- a/src/functions/indSimplex.jl
+++ b/src/functions/indSimplex.jl
@@ -5,7 +5,7 @@ export IndSimplex
 """
 **Indicator of a simplex**
 
-    IndSimplex(a=1.0)
+	IndSimplex(a=1.0)
 
 Returns the indicator of the set
 ```math
@@ -14,14 +14,14 @@ S = \\left\\{ x : x \\geq 0, ∑_i x_i = a \\right\\}.
 By default `a=1.0`, therefore ``S`` is the probability simplex.
 """
 struct IndSimplex{R <: Real} <: ProximableFunction
-    a::R
-    function IndSimplex{R}(a::R) where {R <: Real}
-        if a <= 0
-            error("parameter a must be positive")
-        else
-            new(a)
-        end
-    end
+	a::R
+	function IndSimplex{R}(a::R) where {R <: Real}
+		if a <= 0
+			error("parameter a must be positive")
+		else
+			new(a)
+		end
+	end
 end
 
 is_convex(f::IndSimplex) = true
@@ -30,38 +30,38 @@ is_set(f::IndSimplex) = true
 IndSimplex(a::R=1.0) where {R <: Real} = IndSimplex{R}(a)
 
 function (f::IndSimplex{T})(x::AbstractArray{R}) where {T, R <: Real}
-    if all(x .>= 0) && sum(x) ≈ f.a
-        return zero(R)
-    end
-    return R(Inf)
+	if all(x .>= 0) && sum(x) ≈ f.a
+		return zero(R)
+	end
+	return R(Inf)
 end
 
 function prox!(y::AbstractArray{R}, f::IndSimplex{T}, x::AbstractArray{R}, gamma::R=one(R)) where {T, R <: Real}
 # Implements Algorithm 1 in Condat, "Fast projection onto the simplex and the l1 ball", Mathematical Programming, 158:575–585, 2016.
 # We should consider implementing the other algorithms reviewed there, and the one proposed in the paper.
-    n = length(x)
-    p = []
-    if ndims(x) == 1
-        p = sort(x, rev=true)
-    else
-        p = sort(x[:], rev=true)
-    end
-    s = 0
-    for i = 1:n-1
-        s = s + p[i]
-        tmax = (s - f.a)/i
-        if tmax >= p[i+1]
-            @inbounds for j in eachindex(y)
-                y[j] = x[j] < tmax ? zero(R) : x[j] - tmax
-            end
-            return zero(R)
-        end
-    end
-    tmax = (s + p[n] - f.a)/n
-    @inbounds for j in eachindex(y)
-        y[j] = x[j] < tmax ? zero(R) : x[j] - tmax
-    end
-    return zero(R)
+	n = length(x)
+	p = []
+	if ndims(x) == 1
+		p = sort(x, rev=true)
+	else
+		p = sort(x[:], rev=true)
+	end
+	s = 0
+	for i = 1:n-1
+		s = s + p[i]
+		tmax = (s - f.a)/i
+		if tmax >= p[i+1]
+			@inbounds for j in eachindex(y)
+				y[j] = x[j] < tmax ? zero(R) : x[j] - tmax
+			end
+			return zero(R)
+		end
+	end
+	tmax = (s + p[n] - f.a)/n
+	@inbounds for j in eachindex(y)
+		y[j] = x[j] < tmax ? zero(R) : x[j] - tmax
+	end
+	return zero(R)
 end
 
 fun_name(f::IndSimplex) = "indicator of the probability simplex"
@@ -70,22 +70,22 @@ fun_expr(f::IndSimplex) = "x ↦ 0 if x ⩾ 0 and sum(x) = a, +∞ otherwise"
 fun_params(f::IndSimplex) = "a = $(f.a)"
 
 function prox_naive(f::IndSimplex{T}, x::AbstractArray{R}, gamma::R=one(R)) where {T, R <: Real}
-    low = minimum(x)
-    upp = maximum(x)
-    v = x
-    s = Inf
-    for i = 1:100
-        if abs(s)/f.a ≈ 0
-            break
-        end
-        alpha = (low+upp)/2
-        v = max.(x .- alpha, zero(R))
-        s = sum(v) - f.a
-        if s <= 0
-            upp = alpha
-        else
-            low = alpha
-        end
-    end
-    return v, zero(R)
+	low = minimum(x)
+	upp = maximum(x)
+	v = x
+	s = Inf
+	for i = 1:100
+		if abs(s)/f.a ≈ 0
+			break
+		end
+		alpha = (low+upp)/2
+		v = max.(x .- alpha, zero(R))
+		s = sum(v) - f.a
+		if s <= 0
+			upp = alpha
+		else
+			low = alpha
+		end
+	end
+	return v, zero(R)
 end

--- a/src/functions/indSimplex.jl
+++ b/src/functions/indSimplex.jl
@@ -5,7 +5,7 @@ export IndSimplex
 """
 **Indicator of a simplex**
 
-	IndSimplex(a=1.0)
+    IndSimplex(a=1.0)
 
 Returns the indicator of the set
 ```math
@@ -14,14 +14,14 @@ S = \\left\\{ x : x \\geq 0, ∑_i x_i = a \\right\\}.
 By default `a=1.0`, therefore ``S`` is the probability simplex.
 """
 struct IndSimplex{R <: Real} <: ProximableFunction
-	a::R
-	function IndSimplex{R}(a::R) where {R <: Real}
-		if a <= 0
-			error("parameter a must be positive")
-		else
-			new(a)
-		end
-	end
+    a::R
+    function IndSimplex{R}(a::R) where {R <: Real}
+        if a <= 0
+            error("parameter a must be positive")
+        else
+            new(a)
+        end
+    end
 end
 
 is_convex(f::IndSimplex) = true
@@ -30,38 +30,38 @@ is_set(f::IndSimplex) = true
 IndSimplex(a::R=1.0) where {R <: Real} = IndSimplex{R}(a)
 
 function (f::IndSimplex)(x::AbstractArray{R}) where R <: Real
-	if all(x .>= 0) && sum(x) ≈ f.a
-		return R(0)
-	end
-	return R(Inf)
+    if all(x .>= 0) && sum(x) ≈ f.a
+        return R(0)
+    end
+    return R(Inf)
 end
 
 function prox!(y::AbstractArray{R}, f::IndSimplex, x::AbstractArray{R}, gamma::R=R(1)) where R <: Real
 # Implements Algorithm 1 in Condat, "Fast projection onto the simplex and the l1 ball", Mathematical Programming, 158:575–585, 2016.
 # We should consider implementing the other algorithms reviewed there, and the one proposed in the paper.
-	n = length(x)
-	p = []
-	if ndims(x) == 1
-		p = sort(x, rev=true)
-	else
-		p = sort(x[:], rev=true)
-	end
-	s = 0
-	for i = 1:n-1
-		s = s + p[i]
-		tmax = (s - f.a)/i
-		if tmax >= p[i+1]
-			@inbounds for j in eachindex(y)
-				y[j] = x[j] < tmax ? R(0) : x[j] - tmax
-			end
-			return R(0)
-		end
-	end
-	tmax = (s + p[n] - f.a)/n
-	@inbounds for j in eachindex(y)
-		y[j] = x[j] < tmax ? R(0) : x[j] - tmax
-	end
-	return R(0)
+    n = length(x)
+    p = []
+    if ndims(x) == 1
+        p = sort(x, rev=true)
+    else
+        p = sort(x[:], rev=true)
+    end
+    s = 0
+    for i = 1:n-1
+        s = s + p[i]
+        tmax = (s - f.a)/i
+        if tmax >= p[i+1]
+            @inbounds for j in eachindex(y)
+                y[j] = x[j] < tmax ? R(0) : x[j] - tmax
+            end
+            return R(0)
+        end
+    end
+    tmax = (s + p[n] - f.a)/n
+    @inbounds for j in eachindex(y)
+        y[j] = x[j] < tmax ? R(0) : x[j] - tmax
+    end
+    return R(0)
 end
 
 fun_name(f::IndSimplex) = "indicator of the probability simplex"
@@ -70,22 +70,22 @@ fun_expr(f::IndSimplex) = "x ↦ 0 if x ⩾ 0 and sum(x) = a, +∞ otherwise"
 fun_params(f::IndSimplex) = "a = $(f.a)"
 
 function prox_naive(f::IndSimplex, x::AbstractArray{R}, gamma::R=R(1)) where R <: Real
-	low = minimum(x)
-	upp = maximum(x)
-	v = x
-	s = Inf
-	for i = 1:100
-		if abs(s)/f.a ≈ 0
-			break
-		end
-		alpha = (low+upp)/2
-		v = max.(x .- alpha, R(0))
-		s = sum(v) - f.a
-		if s <= 0
-			upp = alpha
-		else
-			low = alpha
-		end
-	end
-	return v, R(0)
+    low = minimum(x)
+    upp = maximum(x)
+    v = x
+    s = Inf
+    for i = 1:100
+        if abs(s)/f.a ≈ 0
+            break
+        end
+        alpha = (low+upp)/2
+        v = max.(x .- alpha, R(0))
+        s = sum(v) - f.a
+        if s <= 0
+            upp = alpha
+        else
+            low = alpha
+        end
+    end
+    return v, R(0)
 end

--- a/src/functions/indSimplex.jl
+++ b/src/functions/indSimplex.jl
@@ -13,55 +13,55 @@ S = \\left\\{ x : x \\geq 0, ∑_i x_i = a \\right\\}.
 ```
 By default `a=1.0`, therefore ``S`` is the probability simplex.
 """
-struct IndSimplex{T <: Union{Real, Integer}} <: ProximableFunction
-  a::T
-  function IndSimplex{T}(a::T) where {T <: Union{Real, Integer}}
-    if a <= 0
-      error("parameter a must be positive")
-    else
-      new(a)
+struct IndSimplex{R <: Real} <: ProximableFunction
+    a::R
+    function IndSimplex{R}(a::R) where {R <: Real}
+        if a <= 0
+            error("parameter a must be positive")
+        else
+            new(a)
+        end
     end
-  end
 end
 
 is_convex(f::IndSimplex) = true
 is_set(f::IndSimplex) = true
 
-IndSimplex(a::T=1.0) where {T <: Union{Real, Integer}} = IndSimplex{T}(a)
+IndSimplex(a::R=1.0) where {R <: Real} = IndSimplex{R}(a)
 
-function (f::IndSimplex)(x::AbstractArray{T}) where T <: Real
-  if all(x .>= 0) && abs(sum(x)-f.a) <= 1e-14
-    return zero(T)
-  end
-  return +Inf
+function (f::IndSimplex{T})(x::AbstractArray{R}) where {T, R <: Real}
+    if all(x .>= 0) && sum(x) ≈ f.a
+        return zero(R)
+    end
+    return R(Inf)
 end
 
-function prox!(y::AbstractArray{T}, f::IndSimplex, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
+function prox!(y::AbstractArray{R}, f::IndSimplex{T}, x::AbstractArray{R}, gamma::R=one(R)) where {T, R <: Real}
 # Implements Algorithm 1 in Condat, "Fast projection onto the simplex and the l1 ball", Mathematical Programming, 158:575–585, 2016.
 # We should consider implementing the other algorithms reviewed there, and the one proposed in the paper.
-  n = length(x)
-  p = []
-  if ndims(x) == 1
-    p = sort(x, rev=true)
-  else
-    p = sort(x[:], rev=true)
-  end
-  s = 0
-  for i = 1:n-1
-    s = s + p[i]
-    tmax = (s - f.a)/i
-    if tmax >= p[i+1]
-      @inbounds for j in eachindex(y)
-        y[j] = x[j] < tmax ? 0.0 : x[j] - tmax
-      end
-      return zero(T)
+    n = length(x)
+    p = []
+    if ndims(x) == 1
+        p = sort(x, rev=true)
+    else
+        p = sort(x[:], rev=true)
     end
-  end
-  tmax = (s + p[n] - f.a)/n
-  @inbounds for j in eachindex(y)
-    y[j] = x[j] < tmax ? 0.0 : x[j] - tmax
-  end
-  return zero(T)
+    s = 0
+    for i = 1:n-1
+        s = s + p[i]
+        tmax = (s - f.a)/i
+        if tmax >= p[i+1]
+            @inbounds for j in eachindex(y)
+                y[j] = x[j] < tmax ? zero(R) : x[j] - tmax
+            end
+            return zero(R)
+        end
+    end
+    tmax = (s + p[n] - f.a)/n
+    @inbounds for j in eachindex(y)
+        y[j] = x[j] < tmax ? zero(R) : x[j] - tmax
+    end
+    return zero(R)
 end
 
 fun_name(f::IndSimplex) = "indicator of the probability simplex"
@@ -69,23 +69,23 @@ fun_dom(f::IndSimplex) = "AbstractArray{Real}"
 fun_expr(f::IndSimplex) = "x ↦ 0 if x ⩾ 0 and sum(x) = a, +∞ otherwise"
 fun_params(f::IndSimplex) = "a = $(f.a)"
 
-function prox_naive(f::IndSimplex, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-  low = minimum(x)
-  upp = maximum(x)
-  v = x
-  s = Inf
-  for i = 1:100
-    if abs(s)/f.a <= 1e-15
-      break
+function prox_naive(f::IndSimplex{T}, x::AbstractArray{R}, gamma::R=one(R)) where {T, R <: Real}
+    low = minimum(x)
+    upp = maximum(x)
+    v = x
+    s = Inf
+    for i = 1:100
+        if abs(s)/f.a ≈ 0
+            break
+        end
+        alpha = (low+upp)/2
+        v = max.(x .- alpha, zero(R))
+        s = sum(v) - f.a
+        if s <= 0
+            upp = alpha
+        else
+            low = alpha
+        end
     end
-    alpha = (low+upp)/2
-    v = max.(x .- alpha, 0.0)
-    s = sum(v) - f.a
-    if s <= 0
-      upp = alpha
-    else
-      low = alpha
-    end
-  end
-  return v, 0.0
+    return v, zero(R)
 end

--- a/src/functions/indSphereL2.jl
+++ b/src/functions/indSphereL2.jl
@@ -14,44 +14,44 @@ S = \\{ x : \\|x\\| = r \\},
 where ``\\|\\cdot\\|`` is the ``L_2`` (Euclidean) norm. Parameter `r` must be positive.
 """
 struct IndSphereL2{R <: Real} <: ProximableFunction
-  r::R
-  function IndSphereL2{R}(r::R) where {R <: Real}
-    if r <= 0
-      error("parameter r must be positive")
-    else
-      new(r)
+    r::R
+    function IndSphereL2{R}(r::R) where {R <: Real}
+        if r <= 0
+            error("parameter r must be positive")
+        else
+            new(r)
+        end
     end
-  end
 end
 
 is_set(f::IndSphereL2) = true
 
 IndSphereL2(r::R=1.0) where {R <: Real} = IndSphereL2{R}(r)
 
-function (f::IndSphereL2)(x::AbstractArray{T}) where T <: RealOrComplex
-  if abs(norm(x) - f.r)/f.r > 1e-14
-    return +Inf
-  end
-  return zero(T)
+function (f::IndSphereL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
+    if abs(norm(x) - f.r) > f.r*eps(R)
+        return R(Inf)
+    end
+    return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndSphereL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-  normx = norm(x)
-  if normx > 0 # zero-zero?
-    scal = f.r/normx
-    for k in eachindex(x)
-      y[k] = scal*x[k]
+function prox!(y::AbstractArray{T}, f::IndSphereL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+    normx = norm(x)
+    if normx > 0 # zero-zero?
+        scal = f.r/normx
+        for k in eachindex(x)
+            y[k] = scal*x[k]
+        end
+    else
+        normy = R(0)
+        for k in eachindex(x)
+            y[k] = randn()
+            normy += y[k]*y[k]
+        end
+        normy = sqrt(normy)
+        y .*= f.r/normy
     end
-  else
-    normy = zero(T)
-    for k in eachindex(x)
-      y[k] = randn()
-      normy += y[k]*y[k]
-    end
-    normy = sqrt(normy)
-    y .*= f.r/normy
-  end
-  return zero(T)
+    return R(0)
 end
 
 fun_name(f::IndSphereL2) = "indicator of an L2 norm sphere"
@@ -59,13 +59,13 @@ fun_dom(f::IndSphereL2) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndSphereL2) = "x ↦ 0 if ||x|| = r, +∞ otherwise"
 fun_params(f::IndSphereL2) = "r = $(f.r)"
 
-function prox_naive(f::IndSphereL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-  normx = norm(x)
-  if normx > 0
-    y = x*f.r/normx
-  else
-    y = randn(size(x))
-    y *= f.r/norm(y)
-  end
-  return y, 0.0
+function prox_naive(f::IndSphereL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+    normx = norm(x)
+    if normx > 0
+        y = x*f.r/normx
+    else
+        y = randn(size(x))
+        y *= f.r/norm(y)
+    end
+    return y, R(0)
 end

--- a/src/functions/indSphereL2.jl
+++ b/src/functions/indSphereL2.jl
@@ -5,7 +5,7 @@ export IndSphereL2
 """
 **Indicator of a Euclidean sphere**
 
-    IndSphereL2(r=1.0)
+	IndSphereL2(r=1.0)
 
 Returns the indicator function of the set
 ```math
@@ -14,14 +14,14 @@ S = \\{ x : \\|x\\| = r \\},
 where ``\\|\\cdot\\|`` is the ``L_2`` (Euclidean) norm. Parameter `r` must be positive.
 """
 struct IndSphereL2{R <: Real} <: ProximableFunction
-    r::R
-    function IndSphereL2{R}(r::R) where {R <: Real}
-        if r <= 0
-            error("parameter r must be positive")
-        else
-            new(r)
-        end
-    end
+	r::R
+	function IndSphereL2{R}(r::R) where {R <: Real}
+		if r <= 0
+			error("parameter r must be positive")
+		else
+			new(r)
+		end
+	end
 end
 
 is_set(f::IndSphereL2) = true
@@ -29,29 +29,29 @@ is_set(f::IndSphereL2) = true
 IndSphereL2(r::R=1.0) where {R <: Real} = IndSphereL2{R}(r)
 
 function (f::IndSphereL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-    if abs(norm(x) - f.r) > f.r*eps(R)
-        return R(Inf)
-    end
-    return R(0)
+	if abs(norm(x) - f.r) > f.r*eps(R)
+		return R(Inf)
+	end
+	return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndSphereL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-    normx = norm(x)
-    if normx > 0 # zero-zero?
-        scal = f.r/normx
-        for k in eachindex(x)
-            y[k] = scal*x[k]
-        end
-    else
-        normy = R(0)
-        for k in eachindex(x)
-            y[k] = randn()
-            normy += y[k]*y[k]
-        end
-        normy = sqrt(normy)
-        y .*= f.r/normy
-    end
-    return R(0)
+	normx = norm(x)
+	if normx > 0 # zero-zero?
+		scal = f.r/normx
+		for k in eachindex(x)
+			y[k] = scal*x[k]
+		end
+	else
+		normy = R(0)
+		for k in eachindex(x)
+			y[k] = randn()
+			normy += y[k]*y[k]
+		end
+		normy = sqrt(normy)
+		y .*= f.r/normy
+	end
+	return R(0)
 end
 
 fun_name(f::IndSphereL2) = "indicator of an L2 norm sphere"
@@ -60,12 +60,12 @@ fun_expr(f::IndSphereL2) = "x ↦ 0 if ||x|| = r, +∞ otherwise"
 fun_params(f::IndSphereL2) = "r = $(f.r)"
 
 function prox_naive(f::IndSphereL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
-    normx = norm(x)
-    if normx > 0
-        y = x*f.r/normx
-    else
-        y = randn(size(x))
-        y *= f.r/norm(y)
-    end
-    return y, R(0)
+	normx = norm(x)
+	if normx > 0
+		y = x*f.r/normx
+	else
+		y = randn(size(x))
+		y *= f.r/norm(y)
+	end
+	return y, R(0)
 end

--- a/src/functions/indSphereL2.jl
+++ b/src/functions/indSphereL2.jl
@@ -35,7 +35,7 @@ function (f::IndSphereL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComp
 	return R(0)
 end
 
-function prox!(y::AbstractArray{T}, f::IndSphereL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox!(y::AbstractArray{T}, f::IndSphereL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	normx = norm(x)
 	if normx > 0 # zero-zero?
 		scal = f.r/normx
@@ -59,7 +59,7 @@ fun_dom(f::IndSphereL2) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndSphereL2) = "x ↦ 0 if ||x|| = r, +∞ otherwise"
 fun_params(f::IndSphereL2) = "r = $(f.r)"
 
-function prox_naive(f::IndSphereL2, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: RealOrComplex{R}}
+function prox_naive(f::IndSphereL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
 	normx = norm(x)
 	if normx > 0
 		y = x*f.r/normx

--- a/src/functions/indSphereL2.jl
+++ b/src/functions/indSphereL2.jl
@@ -5,7 +5,7 @@ export IndSphereL2
 """
 **Indicator of a Euclidean sphere**
 
-	IndSphereL2(r=1.0)
+    IndSphereL2(r=1.0)
 
 Returns the indicator function of the set
 ```math
@@ -14,14 +14,14 @@ S = \\{ x : \\|x\\| = r \\},
 where ``\\|\\cdot\\|`` is the ``L_2`` (Euclidean) norm. Parameter `r` must be positive.
 """
 struct IndSphereL2{R <: Real} <: ProximableFunction
-	r::R
-	function IndSphereL2{R}(r::R) where {R <: Real}
-		if r <= 0
-			error("parameter r must be positive")
-		else
-			new(r)
-		end
-	end
+    r::R
+    function IndSphereL2{R}(r::R) where {R <: Real}
+        if r <= 0
+            error("parameter r must be positive")
+        else
+            new(r)
+        end
+    end
 end
 
 is_set(f::IndSphereL2) = true
@@ -29,29 +29,29 @@ is_set(f::IndSphereL2) = true
 IndSphereL2(r::R=1.0) where {R <: Real} = IndSphereL2{R}(r)
 
 function (f::IndSphereL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-	if abs(norm(x) - f.r) > f.r*eps(R)
-		return R(Inf)
-	end
-	return R(0)
+    if abs(norm(x) - f.r) > f.r*eps(R)
+        return R(Inf)
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{T}, f::IndSphereL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	normx = norm(x)
-	if normx > 0 # zero-zero?
-		scal = f.r/normx
-		for k in eachindex(x)
-			y[k] = scal*x[k]
-		end
-	else
-		normy = R(0)
-		for k in eachindex(x)
-			y[k] = randn()
-			normy += y[k]*y[k]
-		end
-		normy = sqrt(normy)
-		y .*= f.r/normy
-	end
-	return R(0)
+    normx = norm(x)
+    if normx > 0 # zero-zero?
+        scal = f.r/normx
+        for k in eachindex(x)
+            y[k] = scal*x[k]
+        end
+    else
+        normy = R(0)
+        for k in eachindex(x)
+            y[k] = randn()
+            normy += y[k]*y[k]
+        end
+        normy = sqrt(normy)
+        y .*= f.r/normy
+    end
+    return R(0)
 end
 
 fun_name(f::IndSphereL2) = "indicator of an L2 norm sphere"
@@ -60,12 +60,12 @@ fun_expr(f::IndSphereL2) = "x ↦ 0 if ||x|| = r, +∞ otherwise"
 fun_params(f::IndSphereL2) = "r = $(f.r)"
 
 function prox_naive(f::IndSphereL2, x::AbstractArray{T}, gamma::R=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	normx = norm(x)
-	if normx > 0
-		y = x*f.r/normx
-	else
-		y = randn(size(x))
-		y *= f.r/norm(y)
-	end
-	return y, R(0)
+    normx = norm(x)
+    if normx > 0
+        y = x*f.r/normx
+    else
+        y = randn(size(x))
+        y *= f.r/norm(y)
+    end
+    return y, R(0)
 end

--- a/src/functions/indZero.jl
+++ b/src/functions/indZero.jl
@@ -17,31 +17,27 @@ is_singleton(f::IndZero) = true
 is_cone(f::IndZero) = true
 is_affine(f::IndZero) = true
 
-function (f::IndZero)(x::AbstractArray{T}) where T <: RealOrComplex
-  for k in eachindex(x)
-    if x[k] != zero(T)
-      return Inf
+function (f::IndZero)(x::AbstractArray{C}) where {R <: Real, C <: Union{R, Complex{R}}}
+    for k in eachindex(x)
+        if x[k] != zero(C)
+            return R(Inf)
+        end
     end
-  end
-  return 0.0
+    return zero(R)
 end
 
-function prox!(y::AbstractArray{T}, f::IndZero, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-  for k in eachindex(x)
-    y[k] = zero(T)
-  end
-  return 0.0
+function prox!(y::AbstractArray{C}, f::IndZero, x::AbstractArray{C}, gamma=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
+    for k in eachindex(x)
+        y[k] = zero(C)
+    end
+    return zero(R)
 end
-
-prox!(y::AbstractArray{T}, f::IndZero, x::AbstractArray{T}, gamma::AbstractArray) where {T <: RealOrComplex} = prox!(y, f, x, 1.0)
 
 fun_name(f::IndZero) = "indicator of the zero cone"
 fun_dom(f::IndZero) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndZero) = "x ↦ 0 if all(x = 0), +∞ otherwise"
 fun_params(f::IndZero) = "none"
 
-function prox_naive(f::IndZero, x::AbstractArray, gamma::Real=1.0)
-  return zero(x), 0.0
+function prox_naive(f::IndZero, x::AbstractArray{C}, gamma=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
+  return zero(x), zero(R)
 end
-
-prox_naive(f::IndZero, x::AbstractArray, gamma::AbstractArray) = prox_naive(f, x, 1.0)

--- a/src/functions/indZero.jl
+++ b/src/functions/indZero.jl
@@ -5,7 +5,7 @@ export IndZero
 """
 **Indicator of the zero cone**
 
-	IndZero()
+    IndZero()
 
 Returns the indicator function of the set containing the origin, the "zero cone".
 """
@@ -18,19 +18,19 @@ is_cone(f::IndZero) = true
 is_affine(f::IndZero) = true
 
 function (f::IndZero)(x::AbstractArray{C}) where {R <: Real, C <: Union{R, Complex{R}}}
-	for k in eachindex(x)
-		if x[k] != C(0)
-			return R(Inf)
-		end
-	end
-	return R(0)
+    for k in eachindex(x)
+        if x[k] != C(0)
+            return R(Inf)
+        end
+    end
+    return R(0)
 end
 
 function prox!(y::AbstractArray{C}, f::IndZero, x::AbstractArray{C}, gamma=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
-	for k in eachindex(x)
-		y[k] = C(0)
-	end
-	return R(0)
+    for k in eachindex(x)
+        y[k] = C(0)
+    end
+    return R(0)
 end
 
 fun_name(f::IndZero) = "indicator of the zero cone"
@@ -39,5 +39,5 @@ fun_expr(f::IndZero) = "x ↦ 0 if all(x = 0), +∞ otherwise"
 fun_params(f::IndZero) = "none"
 
 function prox_naive(f::IndZero, x::AbstractArray{C}, gamma=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
-	return zero(x), R(0)
+    return zero(x), R(0)
 end

--- a/src/functions/indZero.jl
+++ b/src/functions/indZero.jl
@@ -5,7 +5,7 @@ export IndZero
 """
 **Indicator of the zero cone**
 
-    IndZero()
+	IndZero()
 
 Returns the indicator function of the set containing the origin, the "zero cone".
 """
@@ -18,19 +18,19 @@ is_cone(f::IndZero) = true
 is_affine(f::IndZero) = true
 
 function (f::IndZero)(x::AbstractArray{C}) where {R <: Real, C <: Union{R, Complex{R}}}
-    for k in eachindex(x)
-        if x[k] != zero(C)
-            return R(Inf)
-        end
-    end
-    return zero(R)
+	for k in eachindex(x)
+		if x[k] != zero(C)
+			return R(Inf)
+		end
+	end
+	return zero(R)
 end
 
 function prox!(y::AbstractArray{C}, f::IndZero, x::AbstractArray{C}, gamma=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
-    for k in eachindex(x)
-        y[k] = zero(C)
-    end
-    return zero(R)
+	for k in eachindex(x)
+		y[k] = zero(C)
+	end
+	return zero(R)
 end
 
 fun_name(f::IndZero) = "indicator of the zero cone"
@@ -39,5 +39,5 @@ fun_expr(f::IndZero) = "x ↦ 0 if all(x = 0), +∞ otherwise"
 fun_params(f::IndZero) = "none"
 
 function prox_naive(f::IndZero, x::AbstractArray{C}, gamma=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
-  return zero(x), zero(R)
+	return zero(x), zero(R)
 end

--- a/src/functions/indZero.jl
+++ b/src/functions/indZero.jl
@@ -19,18 +19,18 @@ is_affine(f::IndZero) = true
 
 function (f::IndZero)(x::AbstractArray{C}) where {R <: Real, C <: Union{R, Complex{R}}}
 	for k in eachindex(x)
-		if x[k] != zero(C)
+		if x[k] != C(0)
 			return R(Inf)
 		end
 	end
-	return zero(R)
+	return R(0)
 end
 
-function prox!(y::AbstractArray{C}, f::IndZero, x::AbstractArray{C}, gamma=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
+function prox!(y::AbstractArray{C}, f::IndZero, x::AbstractArray{C}, gamma=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
 	for k in eachindex(x)
-		y[k] = zero(C)
+		y[k] = C(0)
 	end
-	return zero(R)
+	return R(0)
 end
 
 fun_name(f::IndZero) = "indicator of the zero cone"
@@ -38,6 +38,6 @@ fun_dom(f::IndZero) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndZero) = "x ↦ 0 if all(x = 0), +∞ otherwise"
 fun_params(f::IndZero) = "none"
 
-function prox_naive(f::IndZero, x::AbstractArray{C}, gamma=one(R)) where {R <: Real, C <: Union{R, Complex{R}}}
-	return zero(x), zero(R)
+function prox_naive(f::IndZero, x::AbstractArray{C}, gamma=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
+	return zero(x), R(0)
 end

--- a/src/functions/leastSquares.jl
+++ b/src/functions/leastSquares.jl
@@ -17,7 +17,7 @@ fun_name(f::LeastSquares) = "Least squares penalty"
 """
 **Least squares penalty**
 
-    LeastSquares(A, b, λ=1.0; iterative=false)
+	LeastSquares(A, b, λ=1.0; iterative=false)
 
 For a matrix `A`, a vector `b` and a scalar `λ`, returns the function
 ```math
@@ -27,11 +27,11 @@ By default, a direct method (based on Cholesky factorization) is used to evaluat
 If `iterative=true`, then `prox!` is evaluated approximately using an iterative method instead.
 """
 function LeastSquares(A::M, b::V, lam::R=one(R); iterative=false) where {R <: Real, RC <: RealOrComplex{R}, V <: AbstractArray{RC}, M}
-  if iterative == false
-    LeastSquaresDirect(A, b, lam)
-  else
-    LeastSquaresIterative(A, b, lam)
-  end
+	if iterative == false
+		LeastSquaresDirect(A, b, lam)
+	else
+		LeastSquaresIterative(A, b, lam)
+	end
 end
 
 ### INCLUDE CONCRETE TYPES

--- a/src/functions/leastSquares.jl
+++ b/src/functions/leastSquares.jl
@@ -17,7 +17,7 @@ fun_name(f::LeastSquares) = "Least squares penalty"
 """
 **Least squares penalty**
 
-	LeastSquares(A, b, λ=1.0; iterative=false)
+    LeastSquares(A, b, λ=1.0; iterative=false)
 
 For a matrix `A`, a vector `b` and a scalar `λ`, returns the function
 ```math
@@ -27,11 +27,11 @@ By default, a direct method (based on Cholesky factorization) is used to evaluat
 If `iterative=true`, then `prox!` is evaluated approximately using an iterative method instead.
 """
 function LeastSquares(A::M, b::V, lam::R=R(1); iterative=false) where {R <: Real, RC <: RealOrComplex{R}, V <: AbstractArray{RC}, M}
-	if iterative == false
-		LeastSquaresDirect(A, b, lam)
-	else
-		LeastSquaresIterative(A, b, lam)
-	end
+    if iterative == false
+        LeastSquaresDirect(A, b, lam)
+    else
+        LeastSquaresIterative(A, b, lam)
+    end
 end
 
 ### INCLUDE CONCRETE TYPES

--- a/src/functions/leastSquares.jl
+++ b/src/functions/leastSquares.jl
@@ -26,7 +26,7 @@ f(x) = \\tfrac{\\lambda}{2}\\|Ax - b\\|^2.
 By default, a direct method (based on Cholesky factorization) is used to evaluate `prox!`.
 If `iterative=true`, then `prox!` is evaluated approximately using an iterative method instead.
 """
-function LeastSquares(A::M, b::V, lam::R=one(R); iterative=false) where {R <: Real, RC <: RealOrComplex{R}, V <: AbstractArray{RC}, M}
+function LeastSquares(A::M, b::V, lam::R=R(1); iterative=false) where {R <: Real, RC <: RealOrComplex{R}, V <: AbstractArray{RC}, M}
 	if iterative == false
 		LeastSquaresDirect(A, b, lam)
 	else

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -8,124 +8,124 @@ using SparseArrays
 using SuiteSparse
 
 mutable struct LeastSquaresDirect{R <: Real, RC <: RealOrComplex{R}, M <: AbstractMatrix{RC}, V <: AbstractVector{RC}, F <: Factorization} <: LeastSquares
-  A::M # m-by-n matrix
-  b::V
-  Atb::V
-  lambda::R
-  gamma::R
-  shape::Symbol
-  S::M
-  res::Vector{RC} # m-sized buffer
-  q::Vector{RC} # n-sized buffer
-  fact::F
-  function LeastSquaresDirect{R, RC, M, V, F}(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M <: AbstractMatrix{RC}, V <: AbstractVector{RC}, F <: Factorization}
-    if size(A, 1) != length(b)
-      error("A and b have incompatible dimensions")
-    end
-    if lambda <= 0
-      error("lambda must be positive")
-    end
-    m, n = size(A)
-    if m >= n
-      S = A'*A
-      shape = :Tall
-    else
-      S = A*A'
-      shape = :Fat
-    end
-    new(A, b, A'*b, lambda, -1, shape, S, zeros(RC, m), zeros(RC, n))
-  end
+	A::M # m-by-n matrix
+	b::V
+	Atb::V
+	lambda::R
+	gamma::R
+	shape::Symbol
+	S::M
+	res::Vector{RC} # m-sized buffer
+	q::Vector{RC} # n-sized buffer
+	fact::F
+	function LeastSquaresDirect{R, RC, M, V, F}(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M <: AbstractMatrix{RC}, V <: AbstractVector{RC}, F <: Factorization}
+		if size(A, 1) != length(b)
+			error("A and b have incompatible dimensions")
+		end
+		if lambda <= 0
+			error("lambda must be positive")
+		end
+		m, n = size(A)
+		if m >= n
+			S = A'*A
+			shape = :Tall
+		else
+			S = A*A'
+			shape = :Fat
+		end
+		new(A, b, A'*b, lambda, -1, shape, S, zeros(RC, m), zeros(RC, n))
+	end
 end
 
 function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, RC <: Union{R, Complex{R}}, M <: DenseMatrix{RC}, V <: AbstractVector{RC}}
-  LeastSquaresDirect{R, RC, M, V, Cholesky{RC, M}}(A, b, lambda)
+	LeastSquaresDirect{R, RC, M, V, Cholesky{RC, M}}(A, b, lambda)
 end
 
 function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, RC <: Union{R, Complex{R}}, I <: Integer, M <: SparseMatrixCSC{RC, I}, V <: AbstractVector{RC}}
-  LeastSquaresDirect{R, RC, M, V, SuiteSparse.CHOLMOD.Factor{RC}}(A, b, lambda)
+	LeastSquaresDirect{R, RC, M, V, SuiteSparse.CHOLMOD.Factor{RC}}(A, b, lambda)
 end
 
 function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, RC <: Union{R, Complex{R}}, M <: AbstractMatrix{RC}, V <: AbstractVector{RC}}
-  warn("Could not infer type of Factorization for $M in LeastSquaresDirect, this type will be type-unstable")
-  LeastSquaresDirect{R, RC, M, V, Factorization}(A, b, lambda)
+	warn("Could not infer type of Factorization for $M in LeastSquaresDirect, this type will be type-unstable")
+	LeastSquaresDirect{R, RC, M, V, Factorization}(A, b, lambda)
 end
 
 function (f::LeastSquaresDirect{R, RC, M, V, F})(x::AbstractVector{RC}) where {R, RC, M, V, F}
-  mul!(f.res, f.A, x)
-  f.res .-= f.b
-  return (f.lambda/2)*norm(f.res, 2)^2
+	mul!(f.res, f.A, x)
+	f.res .-= f.b
+	return (f.lambda/2)*norm(f.res, 2)^2
 end
 
 function prox!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}, gamma::R=one(R)) where {R, RC, M, V, F, D <: RealOrComplex{R}}
-  # if gamma different from f.gamma then call factor_step!
-  if gamma != f.gamma
-    factor_step!(f, gamma)
-  end
-  solve_step!(y, f, x, gamma)
-  mul!(f.res, f.A, y)
-  f.res .-= f.b
-  return (f.lambda/2)*norm(f.res, 2)^2
+	# if gamma different from f.gamma then call factor_step!
+	if gamma != f.gamma
+		factor_step!(f, gamma)
+	end
+	solve_step!(y, f, x, gamma)
+	mul!(f.res, f.A, y)
+	f.res .-= f.b
+	return (f.lambda/2)*norm(f.res, 2)^2
 end
 
 function factor_step!(f::LeastSquaresDirect{R, RC, M, V, F}, gamma::R) where {R, RC, M <: DenseMatrix, V, F}
-  lamgam = f.lambda*gamma
-  f.fact = cholesky(f.S + I/lamgam)
-  f.gamma = gamma
+	lamgam = f.lambda*gamma
+	f.fact = cholesky(f.S + I/lamgam)
+	f.gamma = gamma
 end
 
 function factor_step!(f::LeastSquaresDirect{R, RC, M, V, F}, gamma::R) where {R, RC, M <: SparseMatrixCSC, V, F}
-  lamgam = f.lambda*gamma
-  f.fact = ldlt(f.S; shift = 1.0/lamgam)
-  f.gamma = gamma
+	lamgam = f.lambda*gamma
+	f.fact = ldlt(f.S; shift = 1.0/lamgam)
+	f.gamma = gamma
 end
 
 function solve_step!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}, gamma::R) where {R, RC, M, V, F <: Cholesky{RC, M}, D <: RealOrComplex{R}}
-  lamgam = f.lambda*gamma
-  f.q .= f.Atb .+ x./lamgam
-  # two cases: (1) tall A, (2) fat A
-  if f.shape == :Tall
-    # y .= f.fact\f.q
-    y .= f.q
-    LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
-    LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
-  else # f.shape == :Fat
-    # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
-    mul!(f.res, f.A, f.q)
-    LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, f.res)
-    LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, f.res)
-    mul!(y, adjoint(f.A), f.res)
-    y .-= f.q
-    y .*= -lamgam
-  end
+	lamgam = f.lambda*gamma
+	f.q .= f.Atb .+ x./lamgam
+	# two cases: (1) tall A, (2) fat A
+	if f.shape == :Tall
+		# y .= f.fact\f.q
+		y .= f.q
+		LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
+		LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
+	else # f.shape == :Fat
+		# y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+		mul!(f.res, f.A, f.q)
+		LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, f.res)
+		LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, f.res)
+		mul!(y, adjoint(f.A), f.res)
+		y .-= f.q
+		y .*= -lamgam
+	end
 end
 
 function solve_step!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}, gamma::R) where {R, RC, M, V, F <: SuiteSparse.CHOLMOD.Factor{RC}, D <: RealOrComplex{R}}
-  lamgam = f.lambda*gamma
-  f.q .= f.Atb .+ x./lamgam
-  # two cases: (1) tall A, (2) fat A
-  if f.shape == :Tall
-    y .= f.fact\f.q
-  else # f.shape == :Fat
-    # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
-    mul!(f.res, f.A, f.q)
-    f.res .= f.fact\f.res
-    mul!(y, adjoint(f.A), f.res)
-    y .-= f.q
-    y .*= -lamgam
-  end
+	lamgam = f.lambda*gamma
+	f.q .= f.Atb .+ x./lamgam
+	# two cases: (1) tall A, (2) fat A
+	if f.shape == :Tall
+		y .= f.fact\f.q
+	else # f.shape == :Fat
+		# y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+		mul!(f.res, f.A, f.q)
+		f.res .= f.fact\f.res
+		mul!(y, adjoint(f.A), f.res)
+		y .-= f.q
+		y .*= -lamgam
+	end
 end
 
 function gradient!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}) where {R, RC, M, V, F, D <: Union{R, Complex{R}}}
-  mul!(f.res, f.A, x)
-  f.res .-= f.b
-  mul!(y, adjoint(f.A), f.res)
-  y .*= f.lambda
-  fy = (f.lambda/2)*dot(f.res, f.res)
+	mul!(f.res, f.A, x)
+	f.res .-= f.b
+	mul!(y, adjoint(f.A), f.res)
+	y .*= f.lambda
+	fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
 function prox_naive(f::LeastSquaresDirect, x::AbstractVector, gamma=1.0)
-  lamgam = f.lambda*gamma
-  y = (f.A'*f.A + I/lamgam)\(f.Atb + x/lamgam)
-  fy = (f.lambda/2)*norm(f.A*y-f.b)^2
-  return y, fy
+	lamgam = f.lambda*gamma
+	y = (f.A'*f.A + I/lamgam)\(f.Atb + x/lamgam)
+	fy = (f.lambda/2)*norm(f.A*y-f.b)^2
+	return y, fy
 end

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -8,124 +8,124 @@ using SparseArrays
 using SuiteSparse
 
 mutable struct LeastSquaresDirect{R <: Real, RC <: RealOrComplex{R}, M <: AbstractMatrix{RC}, V <: AbstractVector{RC}, F <: Factorization} <: LeastSquares
-	A::M # m-by-n matrix
-	b::V
-	Atb::V
-	lambda::R
-	gamma::R
-	shape::Symbol
-	S::M
-	res::Vector{RC} # m-sized buffer
-	q::Vector{RC} # n-sized buffer
-	fact::F
-	function LeastSquaresDirect{R, RC, M, V, F}(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M <: AbstractMatrix{RC}, V <: AbstractVector{RC}, F <: Factorization}
-		if size(A, 1) != length(b)
-			error("A and b have incompatible dimensions")
-		end
-		if lambda <= 0
-			error("lambda must be positive")
-		end
-		m, n = size(A)
-		if m >= n
-			S = A'*A
-			shape = :Tall
-		else
-			S = A*A'
-			shape = :Fat
-		end
-		new(A, b, A'*b, lambda, -1, shape, S, zeros(RC, m), zeros(RC, n))
-	end
+    A::M # m-by-n matrix
+    b::V
+    Atb::V
+    lambda::R
+    gamma::R
+    shape::Symbol
+    S::M
+    res::Vector{RC} # m-sized buffer
+    q::Vector{RC} # n-sized buffer
+    fact::F
+    function LeastSquaresDirect{R, RC, M, V, F}(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M <: AbstractMatrix{RC}, V <: AbstractVector{RC}, F <: Factorization}
+        if size(A, 1) != length(b)
+            error("A and b have incompatible dimensions")
+        end
+        if lambda <= 0
+            error("lambda must be positive")
+        end
+        m, n = size(A)
+        if m >= n
+            S = A'*A
+            shape = :Tall
+        else
+            S = A*A'
+            shape = :Fat
+        end
+        new(A, b, A'*b, lambda, -1, shape, S, zeros(RC, m), zeros(RC, n))
+    end
 end
 
 function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, RC <: Union{R, Complex{R}}, M <: DenseMatrix{RC}, V <: AbstractVector{RC}}
-	LeastSquaresDirect{R, RC, M, V, Cholesky{RC, M}}(A, b, lambda)
+    LeastSquaresDirect{R, RC, M, V, Cholesky{RC, M}}(A, b, lambda)
 end
 
 function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, RC <: Union{R, Complex{R}}, I <: Integer, M <: SparseMatrixCSC{RC, I}, V <: AbstractVector{RC}}
-	LeastSquaresDirect{R, RC, M, V, SuiteSparse.CHOLMOD.Factor{RC}}(A, b, lambda)
+    LeastSquaresDirect{R, RC, M, V, SuiteSparse.CHOLMOD.Factor{RC}}(A, b, lambda)
 end
 
 function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, RC <: Union{R, Complex{R}}, M <: AbstractMatrix{RC}, V <: AbstractVector{RC}}
-	warn("Could not infer type of Factorization for $M in LeastSquaresDirect, this type will be type-unstable")
-	LeastSquaresDirect{R, RC, M, V, Factorization}(A, b, lambda)
+    warn("Could not infer type of Factorization for $M in LeastSquaresDirect, this type will be type-unstable")
+    LeastSquaresDirect{R, RC, M, V, Factorization}(A, b, lambda)
 end
 
 function (f::LeastSquaresDirect{R, RC, M, V, F})(x::AbstractVector{RC}) where {R, RC, M, V, F}
-	mul!(f.res, f.A, x)
-	f.res .-= f.b
-	return (f.lambda/2)*norm(f.res, 2)^2
+    mul!(f.res, f.A, x)
+    f.res .-= f.b
+    return (f.lambda/2)*norm(f.res, 2)^2
 end
 
 function prox!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}, gamma::R=R(1)) where {R, RC, M, V, F, D <: RealOrComplex{R}}
-	# if gamma different from f.gamma then call factor_step!
-	if gamma != f.gamma
-		factor_step!(f, gamma)
-	end
-	solve_step!(y, f, x, gamma)
-	mul!(f.res, f.A, y)
-	f.res .-= f.b
-	return (f.lambda/2)*norm(f.res, 2)^2
+    # if gamma different from f.gamma then call factor_step!
+    if gamma != f.gamma
+        factor_step!(f, gamma)
+    end
+    solve_step!(y, f, x, gamma)
+    mul!(f.res, f.A, y)
+    f.res .-= f.b
+    return (f.lambda/2)*norm(f.res, 2)^2
 end
 
 function factor_step!(f::LeastSquaresDirect{R, RC, M, V, F}, gamma::R) where {R, RC, M <: DenseMatrix, V, F}
-	lamgam = f.lambda*gamma
-	f.fact = cholesky(f.S + I/lamgam)
-	f.gamma = gamma
+    lamgam = f.lambda*gamma
+    f.fact = cholesky(f.S + I/lamgam)
+    f.gamma = gamma
 end
 
 function factor_step!(f::LeastSquaresDirect{R, RC, M, V, F}, gamma::R) where {R, RC, M <: SparseMatrixCSC, V, F}
-	lamgam = f.lambda*gamma
-	f.fact = ldlt(f.S; shift = 1.0/lamgam)
-	f.gamma = gamma
+    lamgam = f.lambda*gamma
+    f.fact = ldlt(f.S; shift = 1.0/lamgam)
+    f.gamma = gamma
 end
 
 function solve_step!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}, gamma::R) where {R, RC, M, V, F <: Cholesky{RC, M}, D <: RealOrComplex{R}}
-	lamgam = f.lambda*gamma
-	f.q .= f.Atb .+ x./lamgam
-	# two cases: (1) tall A, (2) fat A
-	if f.shape == :Tall
-		# y .= f.fact\f.q
-		y .= f.q
-		LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
-		LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
-	else # f.shape == :Fat
-		# y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
-		mul!(f.res, f.A, f.q)
-		LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, f.res)
-		LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, f.res)
-		mul!(y, adjoint(f.A), f.res)
-		y .-= f.q
-		y .*= -lamgam
-	end
+    lamgam = f.lambda*gamma
+    f.q .= f.Atb .+ x./lamgam
+    # two cases: (1) tall A, (2) fat A
+    if f.shape == :Tall
+        # y .= f.fact\f.q
+        y .= f.q
+        LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
+        LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
+    else # f.shape == :Fat
+        # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+        mul!(f.res, f.A, f.q)
+        LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, f.res)
+        LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, f.res)
+        mul!(y, adjoint(f.A), f.res)
+        y .-= f.q
+        y .*= -lamgam
+    end
 end
 
 function solve_step!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}, gamma::R) where {R, RC, M, V, F <: SuiteSparse.CHOLMOD.Factor{RC}, D <: RealOrComplex{R}}
-	lamgam = f.lambda*gamma
-	f.q .= f.Atb .+ x./lamgam
-	# two cases: (1) tall A, (2) fat A
-	if f.shape == :Tall
-		y .= f.fact\f.q
-	else # f.shape == :Fat
-		# y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
-		mul!(f.res, f.A, f.q)
-		f.res .= f.fact\f.res
-		mul!(y, adjoint(f.A), f.res)
-		y .-= f.q
-		y .*= -lamgam
-	end
+    lamgam = f.lambda*gamma
+    f.q .= f.Atb .+ x./lamgam
+    # two cases: (1) tall A, (2) fat A
+    if f.shape == :Tall
+        y .= f.fact\f.q
+    else # f.shape == :Fat
+        # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+        mul!(f.res, f.A, f.q)
+        f.res .= f.fact\f.res
+        mul!(y, adjoint(f.A), f.res)
+        y .-= f.q
+        y .*= -lamgam
+    end
 end
 
 function gradient!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}) where {R, RC, M, V, F, D <: Union{R, Complex{R}}}
-	mul!(f.res, f.A, x)
-	f.res .-= f.b
-	mul!(y, adjoint(f.A), f.res)
-	y .*= f.lambda
-	fy = (f.lambda/2)*dot(f.res, f.res)
+    mul!(f.res, f.A, x)
+    f.res .-= f.b
+    mul!(y, adjoint(f.A), f.res)
+    y .*= f.lambda
+    fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
 function prox_naive(f::LeastSquaresDirect, x::AbstractVector{D}, gamma::R=R(1)) where {R, D <: RealOrComplex{R}}
-	lamgam = f.lambda*gamma
-	y = (f.A'*f.A + I/lamgam)\(f.Atb + x/lamgam)
-	fy = (f.lambda/2)*norm(f.A*y-f.b)^2
-	return y, fy
+    lamgam = f.lambda*gamma
+    y = (f.A'*f.A + I/lamgam)\(f.Atb + x/lamgam)
+    fy = (f.lambda/2)*norm(f.A*y-f.b)^2
+    return y, fy
 end

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -56,7 +56,7 @@ function (f::LeastSquaresDirect{R, RC, M, V, F})(x::AbstractVector{RC}) where {R
 	return (f.lambda/2)*norm(f.res, 2)^2
 end
 
-function prox!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}, gamma::R=one(R)) where {R, RC, M, V, F, D <: RealOrComplex{R}}
+function prox!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, x::AbstractVector{D}, gamma::R=R(1)) where {R, RC, M, V, F, D <: RealOrComplex{R}}
 	# if gamma different from f.gamma then call factor_step!
 	if gamma != f.gamma
 		factor_step!(f, gamma)
@@ -123,7 +123,7 @@ function gradient!(y::AbstractVector{D}, f::LeastSquaresDirect{R, RC, M, V, F}, 
 	fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
-function prox_naive(f::LeastSquaresDirect, x::AbstractVector, gamma=1.0)
+function prox_naive(f::LeastSquaresDirect, x::AbstractVector{D}, gamma::R=R(1)) where {R, D <: RealOrComplex{R}}
 	lamgam = f.lambda*gamma
 	y = (f.A'*f.A + I/lamgam)\(f.Atb + x/lamgam)
 	fy = (f.lambda/2)*norm(f.A*y-f.b)^2

--- a/src/functions/leastSquaresIterative.jl
+++ b/src/functions/leastSquaresIterative.jl
@@ -5,76 +5,76 @@
 using LinearAlgebra
 
 struct LeastSquaresIterative{R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractVector{RC}, O} <: LeastSquares
-	A::M # m-by-n operator
-	b::V
-	Atb::V
-	lambda::R
-	shape::Symbol
-	S::O
-	res::Vector{RC} # m-sized buffer
-	res2::Vector{RC} # m-sized buffer
-	q::Vector{RC} # n-sized buffer
+    A::M # m-by-n operator
+    b::V
+    Atb::V
+    lambda::R
+    shape::Symbol
+    S::O
+    res::Vector{RC} # m-sized buffer
+    res2::Vector{RC} # m-sized buffer
+    q::Vector{RC} # n-sized buffer
 end
 
 is_prox_accurate(f::LeastSquaresIterative) = false
 
 function LeastSquaresIterative(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractVector{RC}}
-	if size(A, 1) != length(b)
-		error("A and b have incompatible dimensions")
-	end
-	if lambda <= 0
-		error("lambda must be positive")
-	end
-	m, n = size(A)
-	if m >= n
-		shape = :Tall
-		S = AcA(A)
-		LeastSquaresIterative{R, RC, M, V, AcA}(A, b, A'*b, lambda, shape, S, zeros(RC, m), [], zeros(RC, n))
-	else
-		shape = :Fat
-		S = AAc(A)
-		LeastSquaresIterative{R, RC, M, V, AAc}(A, b, A'*b, lambda, shape, S, zeros(RC, m), zeros(RC, m), zeros(RC, n))
-	end
+    if size(A, 1) != length(b)
+        error("A and b have incompatible dimensions")
+    end
+    if lambda <= 0
+        error("lambda must be positive")
+    end
+    m, n = size(A)
+    if m >= n
+        shape = :Tall
+        S = AcA(A)
+        LeastSquaresIterative{R, RC, M, V, AcA}(A, b, A'*b, lambda, shape, S, zeros(RC, m), [], zeros(RC, n))
+    else
+        shape = :Fat
+        S = AAc(A)
+        LeastSquaresIterative{R, RC, M, V, AAc}(A, b, A'*b, lambda, shape, S, zeros(RC, m), zeros(RC, m), zeros(RC, n))
+    end
 end
 
 function (f::LeastSquaresIterative{R, RC, M, V})(x::AbstractVector{RC}) where {R, RC, M, V}
-	mul!(f.res, f.A, x)
-	f.res .-= f.b
-	return (f.lambda/2)*norm(f.res, 2)^2
+    mul!(f.res, f.A, x)
+    f.res .-= f.b
+    return (f.lambda/2)*norm(f.res, 2)^2
 end
 
 function prox!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}, gamma::R=R(1)) where {R, RC, M, V, D <: RealOrComplex{R}}
-	lamgam = f.lambda*gamma
-	f.q .= f.Atb .+ x./lamgam
-	# two cases: (1) tall A, (2) fat A
-	if f.shape == :Tall
-		op = Shift(f.S, R(1)/lamgam)
-		IterativeSolvers.cg!(y, op, f.q)
-	else # f.shape == :Fat
-		# y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
-		mul!(f.res, f.A, f.q)
-		op = Shift(f.S, R(1)/lamgam)
-		IterativeSolvers.cg!(f.res2, op, f.res)
-		mul!(y, adjoint(f.A), f.res2)
-		y .-= f.q
-		y .*= -lamgam
-	end
-	mul!(f.res, f.A, y)
-	f.res .-= f.b
-	return (f.lambda/2)*norm(f.res, 2)^2
+    lamgam = f.lambda*gamma
+    f.q .= f.Atb .+ x./lamgam
+    # two cases: (1) tall A, (2) fat A
+    if f.shape == :Tall
+        op = Shift(f.S, R(1)/lamgam)
+        IterativeSolvers.cg!(y, op, f.q)
+    else # f.shape == :Fat
+        # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+        mul!(f.res, f.A, f.q)
+        op = Shift(f.S, R(1)/lamgam)
+        IterativeSolvers.cg!(f.res2, op, f.res)
+        mul!(y, adjoint(f.A), f.res2)
+        y .-= f.q
+        y .*= -lamgam
+    end
+    mul!(f.res, f.A, y)
+    f.res .-= f.b
+    return (f.lambda/2)*norm(f.res, 2)^2
 end
 
 function gradient!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}) where {R, RC, M, V, D <: Union{R, Complex{R}}}
-	mul!(f.res, f.A, x)
-	f.res .-= f.b
-	mul!(y, adjoint(f.A), f.res)
-	y .*= f.lambda
-	fy = (f.lambda/2)*dot(f.res, f.res)
+    mul!(f.res, f.A, x)
+    f.res .-= f.b
+    mul!(y, adjoint(f.A), f.res)
+    y .*= f.lambda
+    fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
 function prox_naive(f::LeastSquaresIterative, x::AbstractVector{D}, gamma::R=R(1)) where {R, D <: RealOrComplex{R}}
-	lamgam = f.lambda*gamma
-	y = IterativeSolvers.cg(f.A'*f.A + I/lamgam, f.Atb + x/lamgam)
-	fy = (f.lambda/2)*norm(f.A*y-f.b)^2
-	return y, fy
+    lamgam = f.lambda*gamma
+    y = IterativeSolvers.cg(f.A'*f.A + I/lamgam, f.Atb + x/lamgam)
+    fy = (f.lambda/2)*norm(f.A*y-f.b)^2
+    return y, fy
 end

--- a/src/functions/leastSquaresIterative.jl
+++ b/src/functions/leastSquaresIterative.jl
@@ -5,76 +5,76 @@
 using LinearAlgebra
 
 struct LeastSquaresIterative{R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractVector{RC}, O} <: LeastSquares
-  A::M # m-by-n operator
-  b::V
-  Atb::V
-  lambda::R
-  shape::Symbol
-  S::O
-  res::Vector{RC} # m-sized buffer
-  res2::Vector{RC} # m-sized buffer
-  q::Vector{RC} # n-sized buffer
+	A::M # m-by-n operator
+	b::V
+	Atb::V
+	lambda::R
+	shape::Symbol
+	S::O
+	res::Vector{RC} # m-sized buffer
+	res2::Vector{RC} # m-sized buffer
+	q::Vector{RC} # n-sized buffer
 end
 
 is_prox_accurate(f::LeastSquaresIterative) = false
 
 function LeastSquaresIterative(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractVector{RC}}
-  if size(A, 1) != length(b)
-    error("A and b have incompatible dimensions")
-  end
-  if lambda <= 0
-    error("lambda must be positive")
-  end
-  m, n = size(A)
-  if m >= n
-    shape = :Tall
-    S = AcA(A)
-    LeastSquaresIterative{R, RC, M, V, AcA}(A, b, A'*b, lambda, shape, S, zeros(RC, m), [], zeros(RC, n))
-  else
-    shape = :Fat
-    S = AAc(A)
-    LeastSquaresIterative{R, RC, M, V, AAc}(A, b, A'*b, lambda, shape, S, zeros(RC, m), zeros(RC, m), zeros(RC, n))
-  end
+	if size(A, 1) != length(b)
+		error("A and b have incompatible dimensions")
+	end
+	if lambda <= 0
+		error("lambda must be positive")
+	end
+	m, n = size(A)
+	if m >= n
+		shape = :Tall
+		S = AcA(A)
+		LeastSquaresIterative{R, RC, M, V, AcA}(A, b, A'*b, lambda, shape, S, zeros(RC, m), [], zeros(RC, n))
+	else
+		shape = :Fat
+		S = AAc(A)
+		LeastSquaresIterative{R, RC, M, V, AAc}(A, b, A'*b, lambda, shape, S, zeros(RC, m), zeros(RC, m), zeros(RC, n))
+	end
 end
 
 function (f::LeastSquaresIterative{R, RC, M, V})(x::AbstractVector{RC}) where {R, RC, M, V}
-  mul!(f.res, f.A, x)
-  f.res .-= f.b
-  return (f.lambda/2)*norm(f.res, 2)^2
+	mul!(f.res, f.A, x)
+	f.res .-= f.b
+	return (f.lambda/2)*norm(f.res, 2)^2
 end
 
 function prox!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}, gamma::R=one(R)) where {R, RC, M, V, D <: RealOrComplex{R}}
-  lamgam = f.lambda*gamma
-  f.q .= f.Atb .+ x./lamgam
-  # two cases: (1) tall A, (2) fat A
-  if f.shape == :Tall
-    op = Shift(f.S, one(R)/lamgam)
-    IterativeSolvers.cg!(y, op, f.q)
-  else # f.shape == :Fat
-    # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
-    mul!(f.res, f.A, f.q)
-    op = Shift(f.S, one(R)/lamgam)
-    IterativeSolvers.cg!(f.res2, op, f.res)
-    mul!(y, adjoint(f.A), f.res2)
-    y .-= f.q
-    y .*= -lamgam
-  end
-  mul!(f.res, f.A, y)
-  f.res .-= f.b
-  return (f.lambda/2)*norm(f.res, 2)^2
+	lamgam = f.lambda*gamma
+	f.q .= f.Atb .+ x./lamgam
+	# two cases: (1) tall A, (2) fat A
+	if f.shape == :Tall
+		op = Shift(f.S, one(R)/lamgam)
+		IterativeSolvers.cg!(y, op, f.q)
+	else # f.shape == :Fat
+		# y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+		mul!(f.res, f.A, f.q)
+		op = Shift(f.S, one(R)/lamgam)
+		IterativeSolvers.cg!(f.res2, op, f.res)
+		mul!(y, adjoint(f.A), f.res2)
+		y .-= f.q
+		y .*= -lamgam
+	end
+	mul!(f.res, f.A, y)
+	f.res .-= f.b
+	return (f.lambda/2)*norm(f.res, 2)^2
 end
 
 function gradient!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}) where {R, RC, M, V, D <: Union{R, Complex{R}}}
-  mul!(f.res, f.A, x)
-  f.res .-= f.b
-  mul!(y, adjoint(f.A), f.res)
-  y .*= f.lambda
-  fy = (f.lambda/2)*dot(f.res, f.res)
+	mul!(f.res, f.A, x)
+	f.res .-= f.b
+	mul!(y, adjoint(f.A), f.res)
+	y .*= f.lambda
+	fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
 function prox_naive(f::LeastSquaresIterative, x::AbstractVector, gamma=1.0)
-  lamgam = f.lambda*gamma
-  y = IterativeSolvers.cg(f.A'*f.A + I/lamgam, f.Atb + x/lamgam)
-  fy = (f.lambda/2)*norm(f.A*y-f.b)^2
-  return y, fy
+	lamgam = f.lambda*gamma
+	y = IterativeSolvers.cg(f.A'*f.A + I/lamgam, f.Atb + x/lamgam)
+	fy = (f.lambda/2)*norm(f.A*y-f.b)^2
+	return y, fy
 end

--- a/src/functions/leastSquaresIterative.jl
+++ b/src/functions/leastSquaresIterative.jl
@@ -43,17 +43,17 @@ function (f::LeastSquaresIterative{R, RC, M, V})(x::AbstractVector{RC}) where {R
 	return (f.lambda/2)*norm(f.res, 2)^2
 end
 
-function prox!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}, gamma::R=one(R)) where {R, RC, M, V, D <: RealOrComplex{R}}
+function prox!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}, gamma::R=R(1)) where {R, RC, M, V, D <: RealOrComplex{R}}
 	lamgam = f.lambda*gamma
 	f.q .= f.Atb .+ x./lamgam
 	# two cases: (1) tall A, (2) fat A
 	if f.shape == :Tall
-		op = Shift(f.S, one(R)/lamgam)
+		op = Shift(f.S, R(1)/lamgam)
 		IterativeSolvers.cg!(y, op, f.q)
 	else # f.shape == :Fat
 		# y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
 		mul!(f.res, f.A, f.q)
-		op = Shift(f.S, one(R)/lamgam)
+		op = Shift(f.S, R(1)/lamgam)
 		IterativeSolvers.cg!(f.res2, op, f.res)
 		mul!(y, adjoint(f.A), f.res2)
 		y .-= f.q
@@ -72,7 +72,7 @@ function gradient!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, 
 	fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
-function prox_naive(f::LeastSquaresIterative, x::AbstractVector, gamma=1.0)
+function prox_naive(f::LeastSquaresIterative, x::AbstractVector{D}, gamma::R=R(1)) where {R, D <: RealOrComplex{R}}
 	lamgam = f.lambda*gamma
 	y = IterativeSolvers.cg(f.A'*f.A + I/lamgam, f.Atb + x/lamgam)
 	fy = (f.lambda/2)*norm(f.A*y-f.b)^2

--- a/src/functions/linear.jl
+++ b/src/functions/linear.jl
@@ -3,7 +3,7 @@ export Linear
 """
 **Linear function**
 
-    Linear(c)
+	Linear(c)
 
 Returns the function
 ```math
@@ -11,7 +11,7 @@ f(x) = \\langle c, x \\rangle.
 ```
 """
 struct Linear{R <: Real, A <: AbstractArray{R}} <: ProximableFunction
-  c::A
+	c::A
 end
 
 is_separable(f::Linear) = true
@@ -19,25 +19,25 @@ is_convex(f::Linear) = true
 is_smooth(f::Linear) = true
 
 function (f::Linear{R})(x::AbstractArray{R}) where R
-  return dot(f.c, x)
+	return dot(f.c, x)
 end
 
 function prox!(y::AbstractArray{R}, f::Linear{R}, x::AbstractArray{R}, gamma::Union{R, AbstractArray{R}}=1.0) where R
-  y .= x .- gamma.*(f.c)
-  fy = dot(f.c, y)
-  return fy
+	y .= x .- gamma.*(f.c)
+	fy = dot(f.c, y)
+	return fy
 end
 
 function gradient!(y::AbstractArray{R}, f::Linear{R}, x::AbstractArray{R}) where R
-  y .= f.c
-  return dot(f.c, x)
+	y .= f.c
+	return dot(f.c, x)
 end
 
 fun_name(f::Linear) = "Linear function"
 fun_expr(f::Linear) = "x ↦ c'x"
 
 function prox_naive(f::Linear, x, gamma)
-  y = x - gamma.*(f.c)
-  fy = dot(f.c, y)
-  return y, fy
+	y = x - gamma.*(f.c)
+	fy = dot(f.c, y)
+	return y, fy
 end

--- a/src/functions/linear.jl
+++ b/src/functions/linear.jl
@@ -3,7 +3,7 @@ export Linear
 """
 **Linear function**
 
-	Linear(c)
+    Linear(c)
 
 Returns the function
 ```math
@@ -11,7 +11,7 @@ f(x) = \\langle c, x \\rangle.
 ```
 """
 struct Linear{R <: Real, A <: AbstractArray{R}} <: ProximableFunction
-	c::A
+    c::A
 end
 
 is_separable(f::Linear) = true
@@ -19,25 +19,25 @@ is_convex(f::Linear) = true
 is_smooth(f::Linear) = true
 
 function (f::Linear{R})(x::AbstractArray{R}) where R
-	return dot(f.c, x)
+    return dot(f.c, x)
 end
 
 function prox!(y::AbstractArray{R}, f::Linear{R}, x::AbstractArray{R}, gamma::Union{R, AbstractArray{R}}=1.0) where R
-	y .= x .- gamma.*(f.c)
-	fy = dot(f.c, y)
-	return fy
+    y .= x .- gamma.*(f.c)
+    fy = dot(f.c, y)
+    return fy
 end
 
 function gradient!(y::AbstractArray{R}, f::Linear{R}, x::AbstractArray{R}) where R
-	y .= f.c
-	return dot(f.c, x)
+    y .= f.c
+    return dot(f.c, x)
 end
 
 fun_name(f::Linear) = "Linear function"
 fun_expr(f::Linear) = "x ↦ c'x"
 
 function prox_naive(f::Linear, x, gamma)
-	y = x - gamma.*(f.c)
-	fy = dot(f.c, y)
-	return y, fy
+    y = x - gamma.*(f.c)
+    fy = dot(f.c, y)
+    return y, fy
 end

--- a/src/functions/logBarrier.jl
+++ b/src/functions/logBarrier.jl
@@ -32,11 +32,11 @@ is_convex(f::LogBarrier) = true
 LogBarrier(a::T=1.0, b::T=0.0, mu::T=1.0) where {T <: Real} = LogBarrier{T}(a, b, mu)
 
 function (f::LogBarrier)(x::AbstractArray{T}) where T <: Real
-	sumf = zero(T)
-	v = zero(T)
+	sumf = T(0)
+	v = T(0)
 	for i in eachindex(x)
 		v = f.a*x[i]+f.b
-		if v <= zero(T)
+		if v <= T(0)
 			return +Inf
 		end
 		sumf += log(v)
@@ -46,9 +46,9 @@ end
 
 function prox!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
 	par = 4*gamma*f.mu*f.a*f.a
-	sumf = zero(T)
-	z = zero(T)
-	v = zero(T)
+	sumf = T(0)
+	z = T(0)
+	v = T(0)
 	for i in eachindex(x)
 		z = f.a*x[i] + f.b
 		v = (z + sqrt(z*z + par))/2
@@ -60,9 +60,9 @@ end
 
 function prox!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}, gamma::AbstractArray) where T <: Real
 	par = 4*f.mu*f.a*f.a
-	sumf = zero(T)
-	z = zero(T)
-	v = zero(T)
+	sumf = T(0)
+	z = T(0)
+	v = T(0)
 	for i in eachindex(x)
 		par_i = gamma[i]*par
 		z = f.a*x[i] + f.b
@@ -74,7 +74,7 @@ function prox!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}, gamma::A
 end
 
 function gradient!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}) where T <: Real
-	sum = zero(T)
+	sum = T(0)
 	for i in eachindex(x)
 		logarg = f.a*x[i]+f.b
 		y[i] = -f.mu*f.a/logarg

--- a/src/functions/logBarrier.jl
+++ b/src/functions/logBarrier.jl
@@ -5,7 +5,7 @@ export LogBarrier
 """
 **Logarithmic barrier**
 
-	LogBarrier(a=1.0, b=0.0, μ=1.0)
+    LogBarrier(a=1.0, b=0.0, μ=1.0)
 
 Returns the function
 ```math
@@ -14,16 +14,16 @@ f(x) = -μ⋅∑_i\\log(a⋅x_i+b),
 for a nonnegative parameter `μ`.
 """
 struct LogBarrier{T <: Real} <: ProximableFunction
-	a::T
-	b::T
-	mu::T
-	function LogBarrier{T}(a::T, b::T, mu::T) where {T <: Real}
-		if mu <= 0
-			error("parameter mu must be positive")
-		else
-			new(a, b, mu)
-		end
-	end
+    a::T
+    b::T
+    mu::T
+    function LogBarrier{T}(a::T, b::T, mu::T) where {T <: Real}
+        if mu <= 0
+            error("parameter mu must be positive")
+        else
+            new(a, b, mu)
+        end
+    end
 end
 
 is_separable(f::LogBarrier) = true
@@ -32,56 +32,56 @@ is_convex(f::LogBarrier) = true
 LogBarrier(a::T=1.0, b::T=0.0, mu::T=1.0) where {T <: Real} = LogBarrier{T}(a, b, mu)
 
 function (f::LogBarrier)(x::AbstractArray{T}) where T <: Real
-	sumf = T(0)
-	v = T(0)
-	for i in eachindex(x)
-		v = f.a*x[i]+f.b
-		if v <= T(0)
-			return +Inf
-		end
-		sumf += log(v)
-	end
-	return -f.mu*sumf
+    sumf = T(0)
+    v = T(0)
+    for i in eachindex(x)
+        v = f.a*x[i]+f.b
+        if v <= T(0)
+            return +Inf
+        end
+        sumf += log(v)
+    end
+    return -f.mu*sumf
 end
 
 function prox!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-	par = 4*gamma*f.mu*f.a*f.a
-	sumf = T(0)
-	z = T(0)
-	v = T(0)
-	for i in eachindex(x)
-		z = f.a*x[i] + f.b
-		v = (z + sqrt(z*z + par))/2
-		y[i] = (v - f.b)/f.a
-		sumf += log(v)
-	end
-	return -f.mu*sumf
+    par = 4*gamma*f.mu*f.a*f.a
+    sumf = T(0)
+    z = T(0)
+    v = T(0)
+    for i in eachindex(x)
+        z = f.a*x[i] + f.b
+        v = (z + sqrt(z*z + par))/2
+        y[i] = (v - f.b)/f.a
+        sumf += log(v)
+    end
+    return -f.mu*sumf
 end
 
 function prox!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}, gamma::AbstractArray) where T <: Real
-	par = 4*f.mu*f.a*f.a
-	sumf = T(0)
-	z = T(0)
-	v = T(0)
-	for i in eachindex(x)
-		par_i = gamma[i]*par
-		z = f.a*x[i] + f.b
-		v = (z + sqrt(z*z + par_i))/2
-		y[i] = (v - f.b)/f.a
-		sumf += log(v)
-	end
-	return -f.mu*sumf
+    par = 4*f.mu*f.a*f.a
+    sumf = T(0)
+    z = T(0)
+    v = T(0)
+    for i in eachindex(x)
+        par_i = gamma[i]*par
+        z = f.a*x[i] + f.b
+        v = (z + sqrt(z*z + par_i))/2
+        y[i] = (v - f.b)/f.a
+        sumf += log(v)
+    end
+    return -f.mu*sumf
 end
 
 function gradient!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}) where T <: Real
-	sum = T(0)
-	for i in eachindex(x)
-		logarg = f.a*x[i]+f.b
-		y[i] = -f.mu*f.a/logarg
-		sum += log(logarg)
-	end
-	sum *= -f.mu
-	return sum
+    sum = T(0)
+    for i in eachindex(x)
+        logarg = f.a*x[i]+f.b
+        y[i] = -f.mu*f.a/logarg
+        sum += log(logarg)
+    end
+    sum *= -f.mu
+    return sum
 end
 
 fun_name(f::LogBarrier) = "logarithmic barrier"
@@ -90,9 +90,9 @@ fun_expr(f::LogBarrier) = "x ↦ -μ * sum( log(a*x_i+b), i=1,...,n )"
 fun_params(f::LogBarrier) = "a = $(f.a), b = $(f.b), μ = $(f.mu)"
 
 function prox_naive(f::LogBarrier, x::AbstractArray{T,1}, gamma::Union{Real, AbstractArray}=1.0) where T <: Real
-	asqr = f.a*f.a
-	z = f.a*x .+ f.b
-	y = ((z .+ sqrt.(z.*z .+ 4*gamma*f.mu*asqr))/2 .- f.b)/f.a
-	fy = -f.mu * sum(log.(f.a .* y .+ f.b))
-	return y, fy
+    asqr = f.a*f.a
+    z = f.a*x .+ f.b
+    y = ((z .+ sqrt.(z.*z .+ 4*gamma*f.mu*asqr))/2 .- f.b)/f.a
+    fy = -f.mu * sum(log.(f.a .* y .+ f.b))
+    return y, fy
 end

--- a/src/functions/logBarrier.jl
+++ b/src/functions/logBarrier.jl
@@ -5,7 +5,7 @@ export LogBarrier
 """
 **Logarithmic barrier**
 
-    LogBarrier(a=1.0, b=0.0, μ=1.0)
+	LogBarrier(a=1.0, b=0.0, μ=1.0)
 
 Returns the function
 ```math
@@ -14,16 +14,16 @@ f(x) = -μ⋅∑_i\\log(a⋅x_i+b),
 for a nonnegative parameter `μ`.
 """
 struct LogBarrier{T <: Real} <: ProximableFunction
-  a::T
-  b::T
-  mu::T
-  function LogBarrier{T}(a::T, b::T, mu::T) where {T <: Real}
-    if mu <= 0
-      error("parameter mu must be positive")
-    else
-      new(a, b, mu)
-    end
-  end
+	a::T
+	b::T
+	mu::T
+	function LogBarrier{T}(a::T, b::T, mu::T) where {T <: Real}
+		if mu <= 0
+			error("parameter mu must be positive")
+		else
+			new(a, b, mu)
+		end
+	end
 end
 
 is_separable(f::LogBarrier) = true
@@ -32,56 +32,56 @@ is_convex(f::LogBarrier) = true
 LogBarrier(a::T=1.0, b::T=0.0, mu::T=1.0) where {T <: Real} = LogBarrier{T}(a, b, mu)
 
 function (f::LogBarrier)(x::AbstractArray{T}) where T <: Real
-  sumf = zero(T)
-  v = zero(T)
-  for i in eachindex(x)
-    v = f.a*x[i]+f.b
-    if v <= zero(T)
-      return +Inf
-    end
-    sumf += log(v)
-  end
-  return -f.mu*sumf
+	sumf = zero(T)
+	v = zero(T)
+	for i in eachindex(x)
+		v = f.a*x[i]+f.b
+		if v <= zero(T)
+			return +Inf
+		end
+		sumf += log(v)
+	end
+	return -f.mu*sumf
 end
 
 function prox!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-  par = 4*gamma*f.mu*f.a*f.a
-  sumf = zero(T)
-  z = zero(T)
-  v = zero(T)
-  for i in eachindex(x)
-    z = f.a*x[i] + f.b
-    v = (z + sqrt(z*z + par))/2
-    y[i] = (v - f.b)/f.a
-    sumf += log(v)
-  end
-  return -f.mu*sumf
+	par = 4*gamma*f.mu*f.a*f.a
+	sumf = zero(T)
+	z = zero(T)
+	v = zero(T)
+	for i in eachindex(x)
+		z = f.a*x[i] + f.b
+		v = (z + sqrt(z*z + par))/2
+		y[i] = (v - f.b)/f.a
+		sumf += log(v)
+	end
+	return -f.mu*sumf
 end
 
 function prox!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}, gamma::AbstractArray) where T <: Real
-  par = 4*f.mu*f.a*f.a
-  sumf = zero(T)
-  z = zero(T)
-  v = zero(T)
-  for i in eachindex(x)
-    par_i = gamma[i]*par
-    z = f.a*x[i] + f.b
-    v = (z + sqrt(z*z + par_i))/2
-    y[i] = (v - f.b)/f.a
-    sumf += log(v)
-  end
-  return -f.mu*sumf
+	par = 4*f.mu*f.a*f.a
+	sumf = zero(T)
+	z = zero(T)
+	v = zero(T)
+	for i in eachindex(x)
+		par_i = gamma[i]*par
+		z = f.a*x[i] + f.b
+		v = (z + sqrt(z*z + par_i))/2
+		y[i] = (v - f.b)/f.a
+		sumf += log(v)
+	end
+	return -f.mu*sumf
 end
 
 function gradient!(y::AbstractArray{T}, f::LogBarrier, x::AbstractArray{T}) where T <: Real
-  sum = zero(T)
-  for i in eachindex(x)
-    logarg = f.a*x[i]+f.b
-    y[i] = -f.mu*f.a/logarg
-    sum += log(logarg)
-  end
-  sum *= -f.mu
-  return sum
+	sum = zero(T)
+	for i in eachindex(x)
+		logarg = f.a*x[i]+f.b
+		y[i] = -f.mu*f.a/logarg
+		sum += log(logarg)
+	end
+	sum *= -f.mu
+	return sum
 end
 
 fun_name(f::LogBarrier) = "logarithmic barrier"
@@ -90,9 +90,9 @@ fun_expr(f::LogBarrier) = "x ↦ -μ * sum( log(a*x_i+b), i=1,...,n )"
 fun_params(f::LogBarrier) = "a = $(f.a), b = $(f.b), μ = $(f.mu)"
 
 function prox_naive(f::LogBarrier, x::AbstractArray{T,1}, gamma::Union{Real, AbstractArray}=1.0) where T <: Real
-  asqr = f.a*f.a
-  z = f.a*x .+ f.b
-  y = ((z .+ sqrt.(z.*z .+ 4*gamma*f.mu*asqr))/2 .- f.b)/f.a
-  fy = -f.mu * sum(log.(f.a .* y .+ f.b))
-  return y, fy
+	asqr = f.a*f.a
+	z = f.a*x .+ f.b
+	y = ((z .+ sqrt.(z.*z .+ 4*gamma*f.mu*asqr))/2 .- f.b)/f.a
+	fy = -f.mu * sum(log.(f.a .* y .+ f.b))
+	return y, fy
 end

--- a/src/functions/logisticLoss.jl
+++ b/src/functions/logisticLoss.jl
@@ -17,14 +17,14 @@ struct LogisticLoss{T <: AbstractArray, R <: Real} <: ProximableFunction
 	y::T
 	mu::R
 	function LogisticLoss{T, R}(y::T, mu::R) where {T, R}
-		if mu <= zero(R)
+		if mu <= R(0)
 			error("parameter mu must be positive")
 		end
 		new(y, mu)
 	end
 end
 
-LogisticLoss(y::T, mu::R=one(R)) where {R, T <: AbstractArray{R}} = LogisticLoss{T, R}(y, mu)
+LogisticLoss(y::T, mu::R=R(1)) where {R, T <: AbstractArray{R}} = LogisticLoss{T, R}(y, mu)
 
 is_separable(f::LogisticLoss) = true
 is_convex(f::LogisticLoss) = true
@@ -34,7 +34,7 @@ is_prox_accurate(f::LogisticLoss) = false
 # f(x)  =  mu log(1 + exp(-y x))
 
 function (f::LogisticLoss{T, R})(x::AbstractArray{R}) where {T, R}
-	val = zero(R)
+	val = R(0)
 	for k in eachindex(x)
 		expyx = exp(f.y[k]*x[k])
 		val += log(1.0 + 1.0/expyx)
@@ -48,7 +48,7 @@ end
 # Lipschitz constant of gradient: (mu y)
 
 function gradient!(g::AbstractArray{R}, f::LogisticLoss{T, R}, x::AbstractArray{R}) where {T, R}
-	val = zero(R)
+	val = R(0)
 	for k in eachindex(x)
 		expyx = exp(f.y[k]*x[k])
 		g[k] = -f.mu * f.y[k] / (1.0 + expyx)
@@ -74,7 +74,7 @@ end
 #
 # Alternatively we can use gradient methods with constant step size.
 
-function prox!(z::AbstractArray{R}, f::LogisticLoss{T, R}, x::AbstractArray{R}, gamma::R=one(R)) where {T, R}
+function prox!(z::AbstractArray{R}, f::LogisticLoss{T, R}, x::AbstractArray{R}, gamma::R=R(1)) where {T, R}
 	c = 1.0/gamma # convexity modulus
 	L = maximum(abs, f.mu .* f.y) + c # Lipschitz constants
 	z .= x
@@ -87,7 +87,7 @@ function prox!(z::AbstractArray{R}, f::LogisticLoss{T, R}, x::AbstractArray{R}, 
 		z .-= Fz ./ L
 	end
 	expyz .= exp.(f.y .* z)
-	val = zero(R)
+	val = R(0)
 	for k in eachindex(expyz)
 		val += log(1.0 + 1.0/expyz[k])
 	end

--- a/src/functions/logisticLoss.jl
+++ b/src/functions/logisticLoss.jl
@@ -5,7 +5,7 @@ export LogisticLoss
 """
 **Logistic loss**
 
-  LogisticLoss(y, μ=1.0)
+	LogisticLoss(y, μ=1.0)
 
 Returns the function
 ```math
@@ -14,14 +14,14 @@ f(x) = μ⋅∑_i log(1+exp(-y_i⋅x_i))
 where `y` is an array and `μ` is a positive parameter.
 """
 struct LogisticLoss{T <: AbstractArray, R <: Real} <: ProximableFunction
-    y::T
-    mu::R
-    function LogisticLoss{T, R}(y::T, mu::R) where {T, R}
-        if mu <= zero(R)
-            error("parameter mu must be positive")
-        end
-        new(y, mu)
-    end
+	y::T
+	mu::R
+	function LogisticLoss{T, R}(y::T, mu::R) where {T, R}
+		if mu <= zero(R)
+			error("parameter mu must be positive")
+		end
+		new(y, mu)
+	end
 end
 
 LogisticLoss(y::T, mu::R=one(R)) where {R, T <: AbstractArray{R}} = LogisticLoss{T, R}(y, mu)
@@ -34,27 +34,27 @@ is_prox_accurate(f::LogisticLoss) = false
 # f(x)  =  mu log(1 + exp(-y x))
 
 function (f::LogisticLoss{T, R})(x::AbstractArray{R}) where {T, R}
-    val = zero(R)
-    for k in eachindex(x)
-        expyx = exp(f.y[k]*x[k])
-        val += log(1.0 + 1.0/expyx)
-    end
-    return f.mu * val
+	val = zero(R)
+	for k in eachindex(x)
+		expyx = exp(f.y[k]*x[k])
+		val += log(1.0 + 1.0/expyx)
+	end
+	return f.mu * val
 end
 
 # f'(x) = -mu y exp(-y x) / (1 + exp(-y x))
-#       = -mu y / (1 + exp(y x))
+#	   = -mu y / (1 + exp(y x))
 #
 # Lipschitz constant of gradient: (mu y)
 
 function gradient!(g::AbstractArray{R}, f::LogisticLoss{T, R}, x::AbstractArray{R}) where {T, R}
-    val = zero(R)
-    for k in eachindex(x)
-        expyx = exp(f.y[k]*x[k])
-        g[k] = -f.mu * f.y[k] / (1.0 + expyx)
-        val += log(1.0 + 1.0/expyx)
-    end
-    return f.mu * val
+	val = zero(R)
+	for k in eachindex(x)
+		expyx = exp(f.y[k]*x[k])
+		g[k] = -f.mu * f.y[k] / (1.0 + expyx)
+		val += log(1.0 + 1.0/expyx)
+	end
+	return f.mu * val
 end
 
 # Computing proximal operator:
@@ -75,21 +75,21 @@ end
 # Alternatively we can use gradient methods with constant step size.
 
 function prox!(z::AbstractArray{R}, f::LogisticLoss{T, R}, x::AbstractArray{R}, gamma::R=one(R)) where {T, R}
-    c = 1.0/gamma # convexity modulus
-    L = maximum(abs, f.mu .* f.y) + c # Lipschitz constants
-    z .= x
-    expyz = similar(z)
-    Fz = similar(z)
-    F1z = similar(z)
-    for k = 1:20
-        expyz .= exp.(f.y .* z)
-        Fz .= z .- x .- f.mu * gamma * (f.y ./ (1 .+ expyz))
-        z .-= Fz ./ L
-    end
-    expyz .= exp.(f.y .* z)
-    val = zero(R)
-    for k in eachindex(expyz)
-        val += log(1.0 + 1.0/expyz[k])
-    end
-    return f.mu * val
+	c = 1.0/gamma # convexity modulus
+	L = maximum(abs, f.mu .* f.y) + c # Lipschitz constants
+	z .= x
+	expyz = similar(z)
+	Fz = similar(z)
+	F1z = similar(z)
+	for k = 1:20
+		expyz .= exp.(f.y .* z)
+		Fz .= z .- x .- f.mu * gamma * (f.y ./ (1 .+ expyz))
+		z .-= Fz ./ L
+	end
+	expyz .= exp.(f.y .* z)
+	val = zero(R)
+	for k in eachindex(expyz)
+		val += log(1.0 + 1.0/expyz[k])
+	end
+	return f.mu * val
 end

--- a/src/functions/logisticLoss.jl
+++ b/src/functions/logisticLoss.jl
@@ -5,7 +5,7 @@ export LogisticLoss
 """
 **Logistic loss**
 
-	LogisticLoss(y, μ=1.0)
+    LogisticLoss(y, μ=1.0)
 
 Returns the function
 ```math
@@ -14,14 +14,14 @@ f(x) = μ⋅∑_i log(1+exp(-y_i⋅x_i))
 where `y` is an array and `μ` is a positive parameter.
 """
 struct LogisticLoss{T <: AbstractArray, R <: Real} <: ProximableFunction
-	y::T
-	mu::R
-	function LogisticLoss{T, R}(y::T, mu::R) where {T, R}
-		if mu <= R(0)
-			error("parameter mu must be positive")
-		end
-		new(y, mu)
-	end
+    y::T
+    mu::R
+    function LogisticLoss{T, R}(y::T, mu::R) where {T, R}
+        if mu <= R(0)
+            error("parameter mu must be positive")
+        end
+        new(y, mu)
+    end
 end
 
 LogisticLoss(y::T, mu::R=R(1)) where {R, T <: AbstractArray{R}} = LogisticLoss{T, R}(y, mu)
@@ -34,27 +34,27 @@ is_prox_accurate(f::LogisticLoss) = false
 # f(x)  =  mu log(1 + exp(-y x))
 
 function (f::LogisticLoss{T, R})(x::AbstractArray{R}) where {T, R}
-	val = R(0)
-	for k in eachindex(x)
-		expyx = exp(f.y[k]*x[k])
-		val += log(1.0 + 1.0/expyx)
-	end
-	return f.mu * val
+    val = R(0)
+    for k in eachindex(x)
+        expyx = exp(f.y[k]*x[k])
+        val += log(1.0 + 1.0/expyx)
+    end
+    return f.mu * val
 end
 
 # f'(x) = -mu y exp(-y x) / (1 + exp(-y x))
-#	   = -mu y / (1 + exp(y x))
+#       = -mu y / (1 + exp(y x))
 #
 # Lipschitz constant of gradient: (mu y)
 
 function gradient!(g::AbstractArray{R}, f::LogisticLoss{T, R}, x::AbstractArray{R}) where {T, R}
-	val = R(0)
-	for k in eachindex(x)
-		expyx = exp(f.y[k]*x[k])
-		g[k] = -f.mu * f.y[k] / (1.0 + expyx)
-		val += log(1.0 + 1.0/expyx)
-	end
-	return f.mu * val
+    val = R(0)
+    for k in eachindex(x)
+        expyx = exp(f.y[k]*x[k])
+        g[k] = -f.mu * f.y[k] / (1.0 + expyx)
+        val += log(1.0 + 1.0/expyx)
+    end
+    return f.mu * val
 end
 
 # Computing proximal operator:
@@ -75,21 +75,21 @@ end
 # Alternatively we can use gradient methods with constant step size.
 
 function prox!(z::AbstractArray{R}, f::LogisticLoss{T, R}, x::AbstractArray{R}, gamma::R=R(1)) where {T, R}
-	c = 1.0/gamma # convexity modulus
-	L = maximum(abs, f.mu .* f.y) + c # Lipschitz constants
-	z .= x
-	expyz = similar(z)
-	Fz = similar(z)
-	F1z = similar(z)
-	for k = 1:20
-		expyz .= exp.(f.y .* z)
-		Fz .= z .- x .- f.mu * gamma * (f.y ./ (1 .+ expyz))
-		z .-= Fz ./ L
-	end
-	expyz .= exp.(f.y .* z)
-	val = R(0)
-	for k in eachindex(expyz)
-		val += log(1.0 + 1.0/expyz[k])
-	end
-	return f.mu * val
+    c = 1.0/gamma # convexity modulus
+    L = maximum(abs, f.mu .* f.y) + c # Lipschitz constants
+    z .= x
+    expyz = similar(z)
+    Fz = similar(z)
+    F1z = similar(z)
+    for k = 1:20
+        expyz .= exp.(f.y .* z)
+        Fz .= z .- x .- f.mu * gamma * (f.y ./ (1 .+ expyz))
+        z .-= Fz ./ L
+    end
+    expyz .= exp.(f.y .* z)
+    val = R(0)
+    for k in eachindex(expyz)
+        val += log(1.0 + 1.0/expyz[k])
+    end
+    return f.mu * val
 end

--- a/src/functions/maximum.jl
+++ b/src/functions/maximum.jl
@@ -5,7 +5,7 @@ export Maximum
 """
 **Maximum coefficient**
 
-	Maximum(λ=1.0)
+    Maximum(λ=1.0)
 
 For a nonnegative parameter `λ ⩾ 0`, returns the function
 ```math

--- a/src/functions/maximum.jl
+++ b/src/functions/maximum.jl
@@ -5,7 +5,7 @@ export Maximum
 """
 **Maximum coefficient**
 
-    Maximum(λ=1.0)
+	Maximum(λ=1.0)
 
 For a nonnegative parameter `λ ⩾ 0`, returns the function
 ```math

--- a/src/functions/normL0.jl
+++ b/src/functions/normL0.jl
@@ -5,7 +5,7 @@ export NormL0
 """
 **``L_0`` pseudo-norm**
 
-    NormL0(λ=1.0)
+	NormL0(λ=1.0)
 
 Returns the function
 ```math
@@ -14,31 +14,31 @@ f(x) = λ\\cdot\\mathrm{nnz}(x)
 for a nonnegative parameter `λ`.
 """
 struct NormL0{R <: Real} <: ProximableFunction
-    lambda::R
-    function NormL0{R}(lambda::R) where {R <: Real}
-        if lambda < 0
-            error("parameter λ must be nonnegative")
-        else
-            new(lambda)
-        end
-    end
+	lambda::R
+	function NormL0{R}(lambda::R) where {R <: Real}
+		if lambda < 0
+			error("parameter λ must be nonnegative")
+		else
+			new(lambda)
+		end
+	end
 end
 
 NormL0(lambda::R=1.0) where {R <: Real} = NormL0{R}(lambda)
 
 function (f::NormL0)(x::AbstractArray{T}) where T <: RealOrComplex
-    return f.lambda*count(v -> v != 0, x)
+	return f.lambda*count(v -> v != 0, x)
 end
 
 function prox!(y::AbstractArray{T}, f::NormL0, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-    countnzy = 0
-    gl = gamma*f.lambda
-    for i in eachindex(x)
-        over = abs(x[i]) > sqrt(2*gl)
-        y[i] = over*x[i]
-        countnzy += over
-    end
-    return f.lambda*countnzy
+	countnzy = 0
+	gl = gamma*f.lambda
+	for i in eachindex(x)
+		over = abs(x[i]) > sqrt(2*gl)
+		y[i] = over*x[i]
+		countnzy += over
+	end
+	return f.lambda*countnzy
 end
 
 fun_name(f::NormL0) = "weighted L0 pseudo-norm"
@@ -47,7 +47,7 @@ fun_expr(f::NormL0) = "x ↦ λ countnz(x)"
 fun_params(f::NormL0) = "λ = $(f.lambda)"
 
 function prox_naive(f::NormL0, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-    over = abs.(x) .> sqrt(2*gamma*f.lambda)
-    y = x.*over
-    return y, f.lambda*count(v -> v != 0, y)
+	over = abs.(x) .> sqrt(2*gamma*f.lambda)
+	y = x.*over
+	return y, f.lambda*count(v -> v != 0, y)
 end

--- a/src/functions/normL0.jl
+++ b/src/functions/normL0.jl
@@ -5,7 +5,7 @@ export NormL0
 """
 **``L_0`` pseudo-norm**
 
-	NormL0(λ=1.0)
+    NormL0(λ=1.0)
 
 Returns the function
 ```math
@@ -14,31 +14,31 @@ f(x) = λ\\cdot\\mathrm{nnz}(x)
 for a nonnegative parameter `λ`.
 """
 struct NormL0{R <: Real} <: ProximableFunction
-	lambda::R
-	function NormL0{R}(lambda::R) where {R <: Real}
-		if lambda < 0
-			error("parameter λ must be nonnegative")
-		else
-			new(lambda)
-		end
-	end
+    lambda::R
+    function NormL0{R}(lambda::R) where {R <: Real}
+        if lambda < 0
+            error("parameter λ must be nonnegative")
+        else
+            new(lambda)
+        end
+    end
 end
 
 NormL0(lambda::R=1.0) where {R <: Real} = NormL0{R}(lambda)
 
 function (f::NormL0)(x::AbstractArray{T}) where T <: RealOrComplex
-	return f.lambda*count(v -> v != 0, x)
+    return f.lambda*count(v -> v != 0, x)
 end
 
 function prox!(y::AbstractArray{T}, f::NormL0, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-	countnzy = 0
-	gl = gamma*f.lambda
-	for i in eachindex(x)
-		over = abs(x[i]) > sqrt(2*gl)
-		y[i] = over*x[i]
-		countnzy += over
-	end
-	return f.lambda*countnzy
+    countnzy = 0
+    gl = gamma*f.lambda
+    for i in eachindex(x)
+        over = abs(x[i]) > sqrt(2*gl)
+        y[i] = over*x[i]
+        countnzy += over
+    end
+    return f.lambda*countnzy
 end
 
 fun_name(f::NormL0) = "weighted L0 pseudo-norm"
@@ -47,7 +47,7 @@ fun_expr(f::NormL0) = "x ↦ λ countnz(x)"
 fun_params(f::NormL0) = "λ = $(f.lambda)"
 
 function prox_naive(f::NormL0, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-	over = abs.(x) .> sqrt(2*gamma*f.lambda)
-	y = x.*over
-	return y, f.lambda*count(v -> v != 0, y)
+    over = abs.(x) .> sqrt(2*gamma*f.lambda)
+    y = x.*over
+    return y, f.lambda*count(v -> v != 0, y)
 end

--- a/src/functions/normL1.jl
+++ b/src/functions/normL1.jl
@@ -58,7 +58,7 @@ end
 
 function prox!(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::Real=1.0) where {A <: AbstractArray, R <: Real}
 	@assert length(y) == length(x) == length(f.lambda)
-	fy = zero(R)
+	fy = R(0)
 	@inbounds @simd for i in eachindex(x)
 		gl = gamma*f.lambda[i]
 		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
@@ -68,7 +68,7 @@ end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::Real=1.0) where {A <: AbstractArray, R <: Real}
 	@assert length(y) == length(x) == length(f.lambda)
-	fy = zero(R)
+	fy = R(0)
 	@inbounds @simd for i in eachindex(x)
 		gl = gamma*f.lambda[i]
 		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
@@ -78,7 +78,7 @@ end
 
 function prox!(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::Real=1.0) where {T <: Real, R <: Real}
 	@assert length(y) == length(x)
-	n1y = zero(R)
+	n1y = R(0)
 	gl = gamma*f.lambda
 	@inbounds @simd for i in eachindex(x)
 		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
@@ -90,7 +90,7 @@ end
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::Real=1.0) where {T <: Real, R <: Real}
 	@assert length(y) == length(x)
 	gl = gamma*f.lambda
-	n1y = zero(R)
+	n1y = R(0)
 	@inbounds @simd for i in eachindex(x)
 		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
 		n1y += abs(y[i])
@@ -100,7 +100,7 @@ end
 
 function prox!(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::AbstractArray) where {A <: AbstractArray, R <: Real}
 	@assert length(y) == length(x) == length(f.lambda) == length(gamma)
-	fy = zero(R)
+	fy = R(0)
 	@inbounds @simd for i in eachindex(x)
 		gl = gamma[i]*f.lambda[i]
 		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
@@ -110,7 +110,7 @@ end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::AbstractArray) where {A <: AbstractArray, R <: Real}
 	@assert length(y) == length(x) == length(f.lambda) == length(gamma)
-	fy = zero(R)
+	fy = R(0)
 	@inbounds @simd for i in eachindex(x)
 		gl = gamma[i]*f.lambda[i]
 		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
@@ -120,7 +120,7 @@ end
 
 function prox!(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::AbstractArray) where {T <: Real, R <: Real}
 	@assert length(y) == length(x) == length(gamma)
-	n1y = zero(R)
+	n1y = R(0)
 	@inbounds @simd for i in eachindex(x)
 		gl = gamma[i]*f.lambda
 		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
@@ -131,7 +131,7 @@ end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::AbstractArray) where {T <: Real, R <: Real}
 	@assert length(y) == length(x) == length(gamma)
-	n1y = zero(R)
+	n1y = R(0)
 	@inbounds @simd for i in eachindex(x)
 		gl = gamma[i]*f.lambda
 		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)

--- a/src/functions/normL1.jl
+++ b/src/functions/normL1.jl
@@ -5,7 +5,7 @@ export NormL1
 """
 **``L_1`` norm**
 
-	NormL1(λ=1.0)
+    NormL1(λ=1.0)
 
 With a nonnegative scalar parameter λ, returns the function
 ```math
@@ -17,31 +17,31 @@ f(x) = ∑_i λ_i|x_i|.
 ```
 """
 struct NormL1{T <: Union{Real, AbstractArray}} <: ProximableFunction
-	lambda::T
-	function NormL1{T}(lambda::T) where {T <: Union{Real, AbstractArray}}
-		if !(eltype(lambda) <: Real)
-			error("λ must be real")
-		end
-		if any(lambda .< 0)
-			error("λ must be nonnegative")
-		else
-			new(lambda)
-		end
-	end
+    lambda::T
+    function NormL1{T}(lambda::T) where {T <: Union{Real, AbstractArray}}
+        if !(eltype(lambda) <: Real)
+            error("λ must be real")
+        end
+        if any(lambda .< 0)
+            error("λ must be nonnegative")
+        else
+            new(lambda)
+        end
+    end
 end
 
 is_separable(f::NormL1) = true
 is_convex(f::NormL1) = true
 
 """
-	NormL1(λ::Real=1.0)
+    NormL1(λ::Real=1.0)
 
 Returns the function `g(x) = λ||x||_1`, for a real parameter `λ ⩾ 0`.
 """
 NormL1(lambda::R=1.0) where {R <: Real} = NormL1{R}(lambda)
 
 """
-	NormL1(λ::Array{Real})
+    NormL1(λ::Array{Real})
 
 Returns the function `g(x) = sum(λ_i|x_i|, i = 1,...,n)`, for a vector of real
 parameters `λ_i ⩾ 0`.
@@ -49,100 +49,100 @@ parameters `λ_i ⩾ 0`.
 NormL1(lambda::A) where {A <: AbstractArray} = NormL1{A}(lambda)
 
 function (f::NormL1{R})(x::AbstractArray) where R <: Real
-	return f.lambda*norm(x, 1)
+    return f.lambda*norm(x, 1)
 end
 
 function (f::NormL1{A})(x::AbstractArray) where A <: AbstractArray
-	return norm(f.lambda .* x, 1)
+    return norm(f.lambda .* x, 1)
 end
 
 function prox!(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::Real=1.0) where {A <: AbstractArray, R <: Real}
-	@assert length(y) == length(x) == length(f.lambda)
-	fy = R(0)
-	@inbounds @simd for i in eachindex(x)
-		gl = gamma*f.lambda[i]
-		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
-	end
-	return sum(f.lambda .* abs.(y))
+    @assert length(y) == length(x) == length(f.lambda)
+    fy = R(0)
+    @inbounds @simd for i in eachindex(x)
+        gl = gamma*f.lambda[i]
+        y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
+    end
+    return sum(f.lambda .* abs.(y))
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::Real=1.0) where {A <: AbstractArray, R <: Real}
-	@assert length(y) == length(x) == length(f.lambda)
-	fy = R(0)
-	@inbounds @simd for i in eachindex(x)
-		gl = gamma*f.lambda[i]
-		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
-	end
-	return sum(f.lambda .* abs.(y))
+    @assert length(y) == length(x) == length(f.lambda)
+    fy = R(0)
+    @inbounds @simd for i in eachindex(x)
+        gl = gamma*f.lambda[i]
+        y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
+    end
+    return sum(f.lambda .* abs.(y))
 end
 
 function prox!(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::Real=1.0) where {T <: Real, R <: Real}
-	@assert length(y) == length(x)
-	n1y = R(0)
-	gl = gamma*f.lambda
-	@inbounds @simd for i in eachindex(x)
-		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
-		n1y += y[i] > 0 ? y[i] : -y[i]
-	end
-	return f.lambda*n1y
+    @assert length(y) == length(x)
+    n1y = R(0)
+    gl = gamma*f.lambda
+    @inbounds @simd for i in eachindex(x)
+        y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
+        n1y += y[i] > 0 ? y[i] : -y[i]
+    end
+    return f.lambda*n1y
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::Real=1.0) where {T <: Real, R <: Real}
-	@assert length(y) == length(x)
-	gl = gamma*f.lambda
-	n1y = R(0)
-	@inbounds @simd for i in eachindex(x)
-		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
-		n1y += abs(y[i])
-	end
-	return f.lambda*n1y
+    @assert length(y) == length(x)
+    gl = gamma*f.lambda
+    n1y = R(0)
+    @inbounds @simd for i in eachindex(x)
+        y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
+        n1y += abs(y[i])
+    end
+    return f.lambda*n1y
 end
 
 function prox!(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::AbstractArray) where {A <: AbstractArray, R <: Real}
-	@assert length(y) == length(x) == length(f.lambda) == length(gamma)
-	fy = R(0)
-	@inbounds @simd for i in eachindex(x)
-		gl = gamma[i]*f.lambda[i]
-		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
-	end
-	return sum(f.lambda .* abs.(y))
+    @assert length(y) == length(x) == length(f.lambda) == length(gamma)
+    fy = R(0)
+    @inbounds @simd for i in eachindex(x)
+        gl = gamma[i]*f.lambda[i]
+        y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
+    end
+    return sum(f.lambda .* abs.(y))
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::AbstractArray) where {A <: AbstractArray, R <: Real}
-	@assert length(y) == length(x) == length(f.lambda) == length(gamma)
-	fy = R(0)
-	@inbounds @simd for i in eachindex(x)
-		gl = gamma[i]*f.lambda[i]
-		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
-	end
-	return sum(f.lambda .* abs.(y))
+    @assert length(y) == length(x) == length(f.lambda) == length(gamma)
+    fy = R(0)
+    @inbounds @simd for i in eachindex(x)
+        gl = gamma[i]*f.lambda[i]
+        y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
+    end
+    return sum(f.lambda .* abs.(y))
 end
 
 function prox!(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::AbstractArray) where {T <: Real, R <: Real}
-	@assert length(y) == length(x) == length(gamma)
-	n1y = R(0)
-	@inbounds @simd for i in eachindex(x)
-		gl = gamma[i]*f.lambda
-		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
-		n1y += y[i] > 0 ? y[i] : -y[i]
-	end
-	return f.lambda*n1y
+    @assert length(y) == length(x) == length(gamma)
+    n1y = R(0)
+    @inbounds @simd for i in eachindex(x)
+        gl = gamma[i]*f.lambda
+        y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
+        n1y += y[i] > 0 ? y[i] : -y[i]
+    end
+    return f.lambda*n1y
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::AbstractArray) where {T <: Real, R <: Real}
-	@assert length(y) == length(x) == length(gamma)
-	n1y = R(0)
-	@inbounds @simd for i in eachindex(x)
-		gl = gamma[i]*f.lambda
-		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
-		n1y += abs(y[i])
-	end
-	return f.lambda*n1y
+    @assert length(y) == length(x) == length(gamma)
+    n1y = R(0)
+    @inbounds @simd for i in eachindex(x)
+        gl = gamma[i]*f.lambda
+        y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
+        n1y += abs(y[i])
+    end
+    return f.lambda*n1y
 end
 
 function gradient!(y::AbstractArray{T}, f::NormL1, x::AbstractArray{T}) where T <: Union{Real, Complex}
-	y .= f.lambda.*sign.(x)
-	return f(x)
+    y .= f.lambda.*sign.(x)
+    return f(x)
 end
 
 fun_name(f::NormL1) = "weighted L1 norm"
@@ -153,6 +153,6 @@ fun_params(f::NormL1{R}) where {R <: Real} = "λ = $(f.lambda)"
 fun_params(f::NormL1{A}) where {A <: AbstractArray} = string("λ = ", typeof(f.lambda), " of size ", size(f.lambda))
 
 function prox_naive(f::NormL1, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-	y = sign.(x).*max.(0.0, abs.(x) .- gamma .* f.lambda)
-	return y, norm(f.lambda .* y,1)
+    y = sign.(x).*max.(0.0, abs.(x) .- gamma .* f.lambda)
+    return y, norm(f.lambda .* y,1)
 end

--- a/src/functions/normL1.jl
+++ b/src/functions/normL1.jl
@@ -5,7 +5,7 @@ export NormL1
 """
 **``L_1`` norm**
 
-    NormL1(λ=1.0)
+	NormL1(λ=1.0)
 
 With a nonnegative scalar parameter λ, returns the function
 ```math
@@ -17,31 +17,31 @@ f(x) = ∑_i λ_i|x_i|.
 ```
 """
 struct NormL1{T <: Union{Real, AbstractArray}} <: ProximableFunction
-  lambda::T
-  function NormL1{T}(lambda::T) where {T <: Union{Real, AbstractArray}}
-    if !(eltype(lambda) <: Real)
-      error("λ must be real")
-    end
-    if any(lambda .< 0)
-      error("λ must be nonnegative")
-    else
-      new(lambda)
-    end
-  end
+	lambda::T
+	function NormL1{T}(lambda::T) where {T <: Union{Real, AbstractArray}}
+		if !(eltype(lambda) <: Real)
+			error("λ must be real")
+		end
+		if any(lambda .< 0)
+			error("λ must be nonnegative")
+		else
+			new(lambda)
+		end
+	end
 end
 
 is_separable(f::NormL1) = true
 is_convex(f::NormL1) = true
 
 """
-  NormL1(λ::Real=1.0)
+	NormL1(λ::Real=1.0)
 
 Returns the function `g(x) = λ||x||_1`, for a real parameter `λ ⩾ 0`.
 """
 NormL1(lambda::R=1.0) where {R <: Real} = NormL1{R}(lambda)
 
 """
-  NormL1(λ::Array{Real})
+	NormL1(λ::Array{Real})
 
 Returns the function `g(x) = sum(λ_i|x_i|, i = 1,...,n)`, for a vector of real
 parameters `λ_i ⩾ 0`.
@@ -49,100 +49,100 @@ parameters `λ_i ⩾ 0`.
 NormL1(lambda::A) where {A <: AbstractArray} = NormL1{A}(lambda)
 
 function (f::NormL1{R})(x::AbstractArray) where R <: Real
-  return f.lambda*norm(x, 1)
+	return f.lambda*norm(x, 1)
 end
 
 function (f::NormL1{A})(x::AbstractArray) where A <: AbstractArray
-  return norm(f.lambda .* x, 1)
+	return norm(f.lambda .* x, 1)
 end
 
 function prox!(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::Real=1.0) where {A <: AbstractArray, R <: Real}
-  @assert length(y) == length(x) == length(f.lambda)
-  fy = zero(R)
-  @inbounds @simd for i in eachindex(x)
-    gl = gamma*f.lambda[i]
-    y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
-  end
-  return sum(f.lambda .* abs.(y))
+	@assert length(y) == length(x) == length(f.lambda)
+	fy = zero(R)
+	@inbounds @simd for i in eachindex(x)
+		gl = gamma*f.lambda[i]
+		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
+	end
+	return sum(f.lambda .* abs.(y))
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::Real=1.0) where {A <: AbstractArray, R <: Real}
-  @assert length(y) == length(x) == length(f.lambda)
-  fy = zero(R)
-  @inbounds @simd for i in eachindex(x)
-    gl = gamma*f.lambda[i]
-    y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
-  end
-  return sum(f.lambda .* abs.(y))
+	@assert length(y) == length(x) == length(f.lambda)
+	fy = zero(R)
+	@inbounds @simd for i in eachindex(x)
+		gl = gamma*f.lambda[i]
+		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
+	end
+	return sum(f.lambda .* abs.(y))
 end
 
 function prox!(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::Real=1.0) where {T <: Real, R <: Real}
-  @assert length(y) == length(x)
-  n1y = zero(R)
-  gl = gamma*f.lambda
-  @inbounds @simd for i in eachindex(x)
-    y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
-    n1y += y[i] > 0 ? y[i] : -y[i]
-  end
-  return f.lambda*n1y
+	@assert length(y) == length(x)
+	n1y = zero(R)
+	gl = gamma*f.lambda
+	@inbounds @simd for i in eachindex(x)
+		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
+		n1y += y[i] > 0 ? y[i] : -y[i]
+	end
+	return f.lambda*n1y
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::Real=1.0) where {T <: Real, R <: Real}
-  @assert length(y) == length(x)
-  gl = gamma*f.lambda
-  n1y = zero(R)
-  @inbounds @simd for i in eachindex(x)
-    y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
-    n1y += abs(y[i])
-  end
-  return f.lambda*n1y
+	@assert length(y) == length(x)
+	gl = gamma*f.lambda
+	n1y = zero(R)
+	@inbounds @simd for i in eachindex(x)
+		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
+		n1y += abs(y[i])
+	end
+	return f.lambda*n1y
 end
 
 function prox!(y::AbstractArray{R}, f::NormL1{A}, x::AbstractArray{R}, gamma::AbstractArray) where {A <: AbstractArray, R <: Real}
-  @assert length(y) == length(x) == length(f.lambda) == length(gamma)
-  fy = zero(R)
-  @inbounds @simd for i in eachindex(x)
-    gl = gamma[i]*f.lambda[i]
-    y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
-  end
-  return sum(f.lambda .* abs.(y))
+	@assert length(y) == length(x) == length(f.lambda) == length(gamma)
+	fy = zero(R)
+	@inbounds @simd for i in eachindex(x)
+		gl = gamma[i]*f.lambda[i]
+		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
+	end
+	return sum(f.lambda .* abs.(y))
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{A}, x::AbstractArray{Complex{R}}, gamma::AbstractArray) where {A <: AbstractArray, R <: Real}
-  @assert length(y) == length(x) == length(f.lambda) == length(gamma)
-  fy = zero(R)
-  @inbounds @simd for i in eachindex(x)
-    gl = gamma[i]*f.lambda[i]
-    y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
-  end
-  return sum(f.lambda .* abs.(y))
+	@assert length(y) == length(x) == length(f.lambda) == length(gamma)
+	fy = zero(R)
+	@inbounds @simd for i in eachindex(x)
+		gl = gamma[i]*f.lambda[i]
+		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
+	end
+	return sum(f.lambda .* abs.(y))
 end
 
 function prox!(y::AbstractArray{R}, f::NormL1{T}, x::AbstractArray{R}, gamma::AbstractArray) where {T <: Real, R <: Real}
-  @assert length(y) == length(x) == length(gamma)
-  n1y = zero(R)
-  @inbounds @simd for i in eachindex(x)
-    gl = gamma[i]*f.lambda
-    y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
-    n1y += y[i] > 0 ? y[i] : -y[i]
-  end
-  return f.lambda*n1y
+	@assert length(y) == length(x) == length(gamma)
+	n1y = zero(R)
+	@inbounds @simd for i in eachindex(x)
+		gl = gamma[i]*f.lambda
+		y[i] = x[i] + (x[i] <= -gl ? gl : (x[i] >= gl ? -gl : -x[i]))
+		n1y += y[i] > 0 ? y[i] : -y[i]
+	end
+	return f.lambda*n1y
 end
 
 function prox!(y::AbstractArray{Complex{R}}, f::NormL1{T}, x::AbstractArray{Complex{R}}, gamma::AbstractArray) where {T <: Real, R <: Real}
-  @assert length(y) == length(x) == length(gamma)
-  n1y = zero(R)
-  @inbounds @simd for i in eachindex(x)
-    gl = gamma[i]*f.lambda
-    y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
-    n1y += abs(y[i])
-  end
-  return f.lambda*n1y
+	@assert length(y) == length(x) == length(gamma)
+	n1y = zero(R)
+	@inbounds @simd for i in eachindex(x)
+		gl = gamma[i]*f.lambda
+		y[i] = sign(x[i])*(abs(x[i]) <= gl ? 0 : abs(x[i]) - gl)
+		n1y += abs(y[i])
+	end
+	return f.lambda*n1y
 end
 
 function gradient!(y::AbstractArray{T}, f::NormL1, x::AbstractArray{T}) where T <: Union{Real, Complex}
-  y .= f.lambda.*sign.(x)
-  return f(x)
+	y .= f.lambda.*sign.(x)
+	return f(x)
 end
 
 fun_name(f::NormL1) = "weighted L1 norm"
@@ -153,6 +153,6 @@ fun_params(f::NormL1{R}) where {R <: Real} = "λ = $(f.lambda)"
 fun_params(f::NormL1{A}) where {A <: AbstractArray} = string("λ = ", typeof(f.lambda), " of size ", size(f.lambda))
 
 function prox_naive(f::NormL1, x::AbstractArray{T}, gamma::Union{Real, AbstractArray}=1.0) where T <: RealOrComplex
-  y = sign.(x).*max.(0.0, abs.(x) .- gamma .* f.lambda)
-  return y, norm(f.lambda .* y,1)
+	y = sign.(x).*max.(0.0, abs.(x) .- gamma .* f.lambda)
+	return y, norm(f.lambda .* y,1)
 end

--- a/src/functions/normL2.jl
+++ b/src/functions/normL2.jl
@@ -5,7 +5,7 @@ export NormL2
 """
 **``L_2`` norm**
 
-    NormL2(λ=1.0)
+	NormL2(λ=1.0)
 
 With a nonnegative scalar parameter λ, returns the function
 ```math
@@ -13,14 +13,14 @@ f(x) = λ\\cdot\\sqrt{x_1^2 + … + x_n^2}.
 ```
 """
 struct NormL2{R <: Real} <: ProximableFunction
-  lambda::R
-  function NormL2{R}(lambda::R) where {R <: Real}
-    if lambda < 0
-      error("parameter λ must be nonnegative")
-    else
-      new(lambda)
-    end
-  end
+	lambda::R
+	function NormL2{R}(lambda::R) where {R <: Real}
+		if lambda < 0
+			error("parameter λ must be nonnegative")
+		else
+			new(lambda)
+		end
+	end
 end
 
 is_convex(f::NormL2) = true
@@ -28,26 +28,26 @@ is_convex(f::NormL2) = true
 NormL2(lambda::R=1.0) where {R <: Real} = NormL2{R}(lambda)
 
 function (f::NormL2)(x::AbstractArray)
-  return f.lambda*norm(x)
+	return f.lambda*norm(x)
 end
 
 function prox!(y::AbstractArray{T}, f::NormL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-  normx = norm(x)
-  scale = max(0, 1-f.lambda*gamma/normx)
-  for i in eachindex(x)
-    y[i] = scale*x[i]
-  end
-  return f.lambda*scale*normx
+	normx = norm(x)
+	scale = max(0, 1-f.lambda*gamma/normx)
+	for i in eachindex(x)
+		y[i] = scale*x[i]
+	end
+	return f.lambda*scale*normx
 end
 
 function gradient!(y::AbstractArray{T}, f::NormL2, x::AbstractArray{T}) where T <: Union{Real, Complex}
-  fx = norm(x) # Value of f, without lambda
-  if fx == 0
-    y .= 0
-  else
-    y .= (f.lambda/fx).*x
-  end
-  return f.lambda*fx
+	fx = norm(x) # Value of f, without lambda
+	if fx == 0
+		y .= 0
+	else
+		y .= (f.lambda/fx).*x
+	end
+	return f.lambda*fx
 end
 
 fun_name(f::NormL2) = "Euclidean norm"
@@ -56,8 +56,8 @@ fun_expr(f::NormL2) = "x ↦ λ||x||_2"
 fun_params(f::NormL2) = "λ = $(f.lambda)"
 
 function prox_naive(f::NormL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-  normx = norm(x)
-  scale = max(0, 1-f.lambda*gamma/normx)
-  y = scale*x
-  return y, f.lambda*scale*normx
+	normx = norm(x)
+	scale = max(0, 1-f.lambda*gamma/normx)
+	y = scale*x
+	return y, f.lambda*scale*normx
 end

--- a/src/functions/normL2.jl
+++ b/src/functions/normL2.jl
@@ -5,7 +5,7 @@ export NormL2
 """
 **``L_2`` norm**
 
-	NormL2(λ=1.0)
+    NormL2(λ=1.0)
 
 With a nonnegative scalar parameter λ, returns the function
 ```math
@@ -13,14 +13,14 @@ f(x) = λ\\cdot\\sqrt{x_1^2 + … + x_n^2}.
 ```
 """
 struct NormL2{R <: Real} <: ProximableFunction
-	lambda::R
-	function NormL2{R}(lambda::R) where {R <: Real}
-		if lambda < 0
-			error("parameter λ must be nonnegative")
-		else
-			new(lambda)
-		end
-	end
+    lambda::R
+    function NormL2{R}(lambda::R) where {R <: Real}
+        if lambda < 0
+            error("parameter λ must be nonnegative")
+        else
+            new(lambda)
+        end
+    end
 end
 
 is_convex(f::NormL2) = true
@@ -28,26 +28,26 @@ is_convex(f::NormL2) = true
 NormL2(lambda::R=1.0) where {R <: Real} = NormL2{R}(lambda)
 
 function (f::NormL2)(x::AbstractArray)
-	return f.lambda*norm(x)
+    return f.lambda*norm(x)
 end
 
 function prox!(y::AbstractArray{T}, f::NormL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-	normx = norm(x)
-	scale = max(0, 1-f.lambda*gamma/normx)
-	for i in eachindex(x)
-		y[i] = scale*x[i]
-	end
-	return f.lambda*scale*normx
+    normx = norm(x)
+    scale = max(0, 1-f.lambda*gamma/normx)
+    for i in eachindex(x)
+        y[i] = scale*x[i]
+    end
+    return f.lambda*scale*normx
 end
 
 function gradient!(y::AbstractArray{T}, f::NormL2, x::AbstractArray{T}) where T <: Union{Real, Complex}
-	fx = norm(x) # Value of f, without lambda
-	if fx == 0
-		y .= 0
-	else
-		y .= (f.lambda/fx).*x
-	end
-	return f.lambda*fx
+    fx = norm(x) # Value of f, without lambda
+    if fx == 0
+        y .= 0
+    else
+        y .= (f.lambda/fx).*x
+    end
+    return f.lambda*fx
 end
 
 fun_name(f::NormL2) = "Euclidean norm"
@@ -56,8 +56,8 @@ fun_expr(f::NormL2) = "x ↦ λ||x||_2"
 fun_params(f::NormL2) = "λ = $(f.lambda)"
 
 function prox_naive(f::NormL2, x::AbstractArray{T}, gamma::Real=1.0) where T <: RealOrComplex
-	normx = norm(x)
-	scale = max(0, 1-f.lambda*gamma/normx)
-	y = scale*x
-	return y, f.lambda*scale*normx
+    normx = norm(x)
+    scale = max(0, 1-f.lambda*gamma/normx)
+    y = scale*x
+    return y, f.lambda*scale*normx
 end

--- a/src/functions/normL21.jl
+++ b/src/functions/normL21.jl
@@ -5,7 +5,7 @@ export NormL21
 """
 **Sum-of-``L_2`` norms**
 
-	NormL21(λ=1.0, dim=1)
+    NormL21(λ=1.0, dim=1)
 
 Returns the function
 ```math
@@ -15,15 +15,15 @@ for a nonnegative `λ`, where ``x_i`` is the ``i``-th column of ``X`` if `dim ==
 In words, it is the sum of the Euclidean norms of the columns or rows.
 """
 struct NormL21{R <: Real, I <: Integer} <: ProximableFunction
-	lambda::R
-	dim::I
-	function NormL21{R,I}(lambda::R, dim::I) where {R <: Real, I <: Integer}
-		if lambda < 0
-			error("parameter λ must be nonnegative")
-		else
-			new(lambda, dim)
-		end
-	end
+    lambda::R
+    dim::I
+    function NormL21{R,I}(lambda::R, dim::I) where {R <: Real, I <: Integer}
+        if lambda < 0
+            error("parameter λ must be nonnegative")
+        else
+            new(lambda, dim)
+        end
+    end
 end
 
 is_convex(f::NormL21) = true
@@ -31,62 +31,62 @@ is_convex(f::NormL21) = true
 NormL21(lambda::R=1.0, dim::I=1) where {R <: Real, I <: Integer} = NormL21{R, I}(lambda, dim)
 
 function (f::NormL21)(X::AbstractArray{T,2}) where T <: RealOrComplex
-	nslice = 0.0
-	n21X = 0.0
-	if f.dim == 1
-		for j = 1:size(X,2)
-			nslice = 0.0
-			for i = 1:size(X,1)
-				nslice += abs(X[i,j])^2
-			end
-			n21X += sqrt(nslice)
-		end
-	elseif f.dim == 2
-		for i = 1:size(X,1)
-			nslice = 0.0
-			for j = 1:size(X,2)
-				nslice += abs(X[i,j])^2
-			end
-			n21X += sqrt(nslice)
-		end
-	end
-	return f.lambda*n21X
+    nslice = 0.0
+    n21X = 0.0
+    if f.dim == 1
+        for j = 1:size(X,2)
+            nslice = 0.0
+            for i = 1:size(X,1)
+                nslice += abs(X[i,j])^2
+            end
+            n21X += sqrt(nslice)
+        end
+    elseif f.dim == 2
+        for i = 1:size(X,1)
+            nslice = 0.0
+            for j = 1:size(X,2)
+                nslice += abs(X[i,j])^2
+            end
+            n21X += sqrt(nslice)
+        end
+    end
+    return f.lambda*n21X
 end
 
 function prox!(Y::AbstractArray{T,2}, f::NormL21, X::AbstractArray{T,2}, gamma::Real=1.0) where T <: RealOrComplex
-	gl = gamma*f.lambda
-	nslice = zero(Float64)
-	n21X = zero(Float64)
-	if f.dim == 1
-		for j = 1:size(X,2)
-			nslice = 0.0
-			for i = 1:size(X,1)
-				nslice += abs(X[i,j])^2
-			end
-			nslice = sqrt(nslice)
-			scal = 1-gl/nslice
-			scal = scal <= 0.0 ? 0.0 : scal
-			for i = 1:size(X,1)
-				Y[i,j] = scal*X[i,j]
-			end
-			n21X += scal*nslice
-		end
-	elseif f.dim == 2
-		for i = 1:size(X,1)
-			nslice = 0.0
-			for j = 1:size(X,2)
-				nslice += abs(X[i,j])^2
-			end
-			nslice = sqrt(nslice)
-			scal = 1-gl/nslice
-			scal = scal <= 0.0 ? 0.0 : scal
-			for j = 1:size(X,2)
-				Y[i,j] = scal*X[i,j]
-			end
-			n21X += scal*nslice
-		end
-	end
-	return f.lambda*n21X
+    gl = gamma*f.lambda
+    nslice = zero(Float64)
+    n21X = zero(Float64)
+    if f.dim == 1
+        for j = 1:size(X,2)
+            nslice = 0.0
+            for i = 1:size(X,1)
+                nslice += abs(X[i,j])^2
+            end
+            nslice = sqrt(nslice)
+            scal = 1-gl/nslice
+            scal = scal <= 0.0 ? 0.0 : scal
+            for i = 1:size(X,1)
+                Y[i,j] = scal*X[i,j]
+            end
+            n21X += scal*nslice
+        end
+    elseif f.dim == 2
+        for i = 1:size(X,1)
+            nslice = 0.0
+            for j = 1:size(X,2)
+                nslice += abs(X[i,j])^2
+            end
+            nslice = sqrt(nslice)
+            scal = 1-gl/nslice
+            scal = scal <= 0.0 ? 0.0 : scal
+            for j = 1:size(X,2)
+                Y[i,j] = scal*X[i,j]
+            end
+            n21X += scal*nslice
+        end
+    end
+    return f.lambda*n21X
 end
 
 fun_name(f::NormL21) = "sum of Euclidean norms"
@@ -95,6 +95,6 @@ fun_expr(f::NormL21) = "x ↦ λsum(||x_i||)"
 fun_params(f::NormL21) = "λ = $(f.lambda), dim = $(f.dim)"
 
 function prox_naive(f::NormL21, X::AbstractArray{T,2}, gamma::Real=1.0) where T <: RealOrComplex
-	Y = max.(0, 1.0 .- f.lambda*gamma./sqrt.(sum(abs.(X).^2, dims=f.dim))).*X
-	return Y, f.lambda*sum(sqrt.(sum(abs.(Y).^2, dims=f.dim)))
+    Y = max.(0, 1.0 .- f.lambda*gamma./sqrt.(sum(abs.(X).^2, dims=f.dim))).*X
+    return Y, f.lambda*sum(sqrt.(sum(abs.(Y).^2, dims=f.dim)))
 end

--- a/src/functions/normL21.jl
+++ b/src/functions/normL21.jl
@@ -5,7 +5,7 @@ export NormL21
 """
 **Sum-of-``L_2`` norms**
 
-    NormL21(λ=1.0, dim=1)
+	NormL21(λ=1.0, dim=1)
 
 Returns the function
 ```math
@@ -15,15 +15,15 @@ for a nonnegative `λ`, where ``x_i`` is the ``i``-th column of ``X`` if `dim ==
 In words, it is the sum of the Euclidean norms of the columns or rows.
 """
 struct NormL21{R <: Real, I <: Integer} <: ProximableFunction
-  lambda::R
-  dim::I
-  function NormL21{R,I}(lambda::R, dim::I) where {R <: Real, I <: Integer}
-    if lambda < 0
-      error("parameter λ must be nonnegative")
-    else
-      new(lambda, dim)
-    end
-  end
+	lambda::R
+	dim::I
+	function NormL21{R,I}(lambda::R, dim::I) where {R <: Real, I <: Integer}
+		if lambda < 0
+			error("parameter λ must be nonnegative")
+		else
+			new(lambda, dim)
+		end
+	end
 end
 
 is_convex(f::NormL21) = true
@@ -31,62 +31,62 @@ is_convex(f::NormL21) = true
 NormL21(lambda::R=1.0, dim::I=1) where {R <: Real, I <: Integer} = NormL21{R, I}(lambda, dim)
 
 function (f::NormL21)(X::AbstractArray{T,2}) where T <: RealOrComplex
-  nslice = 0.0
-  n21X = 0.0
-  if f.dim == 1
-    for j = 1:size(X,2)
-      nslice = 0.0
-      for i = 1:size(X,1)
-      	nslice += abs(X[i,j])^2
-      end
-      n21X += sqrt(nslice)
-    end
-  elseif f.dim == 2
-    for i = 1:size(X,1)
-      nslice = 0.0
-      for j = 1:size(X,2)
-      	nslice += abs(X[i,j])^2
-      end
-      n21X += sqrt(nslice)
-    end
-  end
-  return f.lambda*n21X
+	nslice = 0.0
+	n21X = 0.0
+	if f.dim == 1
+		for j = 1:size(X,2)
+			nslice = 0.0
+			for i = 1:size(X,1)
+				nslice += abs(X[i,j])^2
+			end
+			n21X += sqrt(nslice)
+		end
+	elseif f.dim == 2
+		for i = 1:size(X,1)
+			nslice = 0.0
+			for j = 1:size(X,2)
+				nslice += abs(X[i,j])^2
+			end
+			n21X += sqrt(nslice)
+		end
+	end
+	return f.lambda*n21X
 end
 
 function prox!(Y::AbstractArray{T,2}, f::NormL21, X::AbstractArray{T,2}, gamma::Real=1.0) where T <: RealOrComplex
-  gl = gamma*f.lambda
-  nslice = zero(Float64)
-  n21X = zero(Float64)
-  if f.dim == 1
-    for j = 1:size(X,2)
-      nslice = 0.0
-      for i = 1:size(X,1)
-      	nslice += abs(X[i,j])^2
-      end
-      nslice = sqrt(nslice)
-      scal = 1-gl/nslice
-      scal = scal <= 0.0 ? 0.0 : scal
-      for i = 1:size(X,1)
-        Y[i,j] = scal*X[i,j]
-      end
-      n21X += scal*nslice
-    end
-  elseif f.dim == 2
-    for i = 1:size(X,1)
-      nslice = 0.0
-      for j = 1:size(X,2)
-      	nslice += abs(X[i,j])^2
-      end
-      nslice = sqrt(nslice)
-      scal = 1-gl/nslice
-      scal = scal <= 0.0 ? 0.0 : scal
-      for j = 1:size(X,2)
-        Y[i,j] = scal*X[i,j]
-      end
-      n21X += scal*nslice
-    end
-  end
-  return f.lambda*n21X
+	gl = gamma*f.lambda
+	nslice = zero(Float64)
+	n21X = zero(Float64)
+	if f.dim == 1
+		for j = 1:size(X,2)
+			nslice = 0.0
+			for i = 1:size(X,1)
+				nslice += abs(X[i,j])^2
+			end
+			nslice = sqrt(nslice)
+			scal = 1-gl/nslice
+			scal = scal <= 0.0 ? 0.0 : scal
+			for i = 1:size(X,1)
+				Y[i,j] = scal*X[i,j]
+			end
+			n21X += scal*nslice
+		end
+	elseif f.dim == 2
+		for i = 1:size(X,1)
+			nslice = 0.0
+			for j = 1:size(X,2)
+				nslice += abs(X[i,j])^2
+			end
+			nslice = sqrt(nslice)
+			scal = 1-gl/nslice
+			scal = scal <= 0.0 ? 0.0 : scal
+			for j = 1:size(X,2)
+				Y[i,j] = scal*X[i,j]
+			end
+			n21X += scal*nslice
+		end
+	end
+	return f.lambda*n21X
 end
 
 fun_name(f::NormL21) = "sum of Euclidean norms"
@@ -95,6 +95,6 @@ fun_expr(f::NormL21) = "x ↦ λsum(||x_i||)"
 fun_params(f::NormL21) = "λ = $(f.lambda), dim = $(f.dim)"
 
 function prox_naive(f::NormL21, X::AbstractArray{T,2}, gamma::Real=1.0) where T <: RealOrComplex
-  Y = max.(0, 1.0 .- f.lambda*gamma./sqrt.(sum(abs.(X).^2, dims=f.dim))).*X
-  return Y, f.lambda*sum(sqrt.(sum(abs.(Y).^2, dims=f.dim)))
+	Y = max.(0, 1.0 .- f.lambda*gamma./sqrt.(sum(abs.(X).^2, dims=f.dim))).*X
+	return Y, f.lambda*sum(sqrt.(sum(abs.(Y).^2, dims=f.dim)))
 end

--- a/src/functions/normLinf.jl
+++ b/src/functions/normLinf.jl
@@ -5,7 +5,7 @@ export NormLinf
 """
 **``L_∞`` norm**
 
-    NormLinf(λ=1.0)
+	NormLinf(λ=1.0)
 
 Returns the function
 ```math
@@ -16,14 +16,14 @@ for a nonnegative parameter `λ`.
 NormLinf(lambda::R=1.0) where {R <: Real} = Conjugate(IndBallL1(lambda))
 
 function (f::Conjugate{IndBallL1{R}})(x::AbstractArray{S}) where {R <: Real, S <: RealOrComplex}
-  return (f.f.r)*norm(x, Inf)
+	return (f.f.r)*norm(x, Inf)
 end
 
 function gradient!(y::AbstractArray{T}, f::Conjugate{IndBallL1{R}}, x::AbstractArray{T}) where {T <: RealOrComplex, R <: Real}
-  absxi, i = findmax(abs.(x)) # Largest absolute value
-  y .= 0
-  y[i] = f.f.r*sign(x[i])
-  return f.f.r*absxi
+	absxi, i = findmax(abs.(x)) # Largest absolute value
+	y .= 0
+	y[i] = f.f.r*sign(x[i])
+	return f.f.r*absxi
 end
 
 fun_name(f::Postcompose{Conjugate{IndBallL1{R}}, R}) where {R <: Real} = "weighted L-infinity norm"

--- a/src/functions/normLinf.jl
+++ b/src/functions/normLinf.jl
@@ -5,7 +5,7 @@ export NormLinf
 """
 **``L_∞`` norm**
 
-	NormLinf(λ=1.0)
+    NormLinf(λ=1.0)
 
 Returns the function
 ```math
@@ -16,14 +16,14 @@ for a nonnegative parameter `λ`.
 NormLinf(lambda::R=1.0) where {R <: Real} = Conjugate(IndBallL1(lambda))
 
 function (f::Conjugate{IndBallL1{R}})(x::AbstractArray{S}) where {R <: Real, S <: RealOrComplex}
-	return (f.f.r)*norm(x, Inf)
+    return (f.f.r)*norm(x, Inf)
 end
 
 function gradient!(y::AbstractArray{T}, f::Conjugate{IndBallL1{R}}, x::AbstractArray{T}) where {T <: RealOrComplex, R <: Real}
-	absxi, i = findmax(abs.(x)) # Largest absolute value
-	y .= 0
-	y[i] = f.f.r*sign(x[i])
-	return f.f.r*absxi
+    absxi, i = findmax(abs.(x)) # Largest absolute value
+    y .= 0
+    y[i] = f.f.r*sign(x[i])
+    return f.f.r*absxi
 end
 
 fun_name(f::Postcompose{Conjugate{IndBallL1{R}}, R}) where {R <: Real} = "weighted L-infinity norm"

--- a/src/functions/nuclearNorm.jl
+++ b/src/functions/nuclearNorm.jl
@@ -29,8 +29,8 @@ is_convex(f::NuclearNorm) = true
 NuclearNorm(lambda::R=1.0) where {R <: Real} = NuclearNorm{R}(lambda)
 
 function (f::NuclearNorm{R})(X::AbstractMatrix{T}) where {R <: Real, T <: Union{R, Complex{R}}}
-	F = svd(X);
-	return f.lambda * sum(F.S);
+	F = svd(X)
+	return f.lambda * sum(F.S)
 end
 
 function prox!(Y::AbstractMatrix{T}, f::NuclearNorm{R}, X::AbstractMatrix{T}, gamma::R=one(R)) where {R <: Real, T <: Union{R, Complex{R}}}
@@ -45,7 +45,7 @@ function prox!(Y::AbstractMatrix{T}, f::NuclearNorm{R}, X::AbstractMatrix{T}, ga
 	# TODO: the order of the following matrix products should depend on the shape of x
 	M = S_thresh[1:rankY] .* Vt_thresh
 	mul!(Y, U_thresh, M)
-	return f.lambda * sum(S_thresh);
+	return f.lambda * sum(S_thresh)
 end
 
 fun_name(f::NuclearNorm) = "nuclear norm"

--- a/src/functions/nuclearNorm.jl
+++ b/src/functions/nuclearNorm.jl
@@ -5,7 +5,7 @@ export NuclearNorm
 """
 **Nuclear norm**
 
-	NuclearNorm(λ=1.0)
+    NuclearNorm(λ=1.0)
 
 Returns the function
 ```math
@@ -14,14 +14,14 @@ f(X) = \\|X\\|_* = λ ∑_i σ_i(X),
 where `λ` is a positive parameter and ``σ_i(X)`` is ``i``-th singular value of matrix ``X``.
 """
 struct NuclearNorm{R <: Real} <: ProximableFunction
-	lambda::R
-	function NuclearNorm{R}(lambda::R) where {R <: Real}
-		if lambda < 0
-			error("parameter λ must be nonnegative")
-		else
-			new(lambda)
-		end
-	end
+    lambda::R
+    function NuclearNorm{R}(lambda::R) where {R <: Real}
+        if lambda < 0
+            error("parameter λ must be nonnegative")
+        else
+            new(lambda)
+        end
+    end
 end
 
 is_convex(f::NuclearNorm) = true
@@ -29,23 +29,23 @@ is_convex(f::NuclearNorm) = true
 NuclearNorm(lambda::R=1.0) where {R <: Real} = NuclearNorm{R}(lambda)
 
 function (f::NuclearNorm{R})(X::AbstractMatrix{T}) where {R <: Real, T <: Union{R, Complex{R}}}
-	F = svd(X)
-	return f.lambda * sum(F.S)
+    F = svd(X)
+    return f.lambda * sum(F.S)
 end
 
 function prox!(Y::AbstractMatrix{T}, f::NuclearNorm{R}, X::AbstractMatrix{T}, gamma::R=R(1)) where {R <: Real, T <: Union{R, Complex{R}}}
-	F = svd(X)
-	S_thresh = max.(R(0), F.S .- f.lambda*gamma)
-	rankY = findfirst(S_thresh .== R(0))
-	if rankY === nothing
-		rankY = minimum(size(X))
-	end
-	Vt_thresh = view(F.Vt, 1:rankY, :)
-	U_thresh = view(F.U, :, 1:rankY)
-	# TODO: the order of the following matrix products should depend on the shape of x
-	M = S_thresh[1:rankY] .* Vt_thresh
-	mul!(Y, U_thresh, M)
-	return f.lambda * sum(S_thresh)
+    F = svd(X)
+    S_thresh = max.(R(0), F.S .- f.lambda*gamma)
+    rankY = findfirst(S_thresh .== R(0))
+    if rankY === nothing
+        rankY = minimum(size(X))
+    end
+    Vt_thresh = view(F.Vt, 1:rankY, :)
+    U_thresh = view(F.U, :, 1:rankY)
+    # TODO: the order of the following matrix products should depend on the shape of x
+    M = S_thresh[1:rankY] .* Vt_thresh
+    mul!(Y, U_thresh, M)
+    return f.lambda * sum(S_thresh)
 end
 
 fun_name(f::NuclearNorm) = "nuclear norm"
@@ -54,8 +54,8 @@ fun_expr(f::NuclearNorm) = "X ↦ λ∑σ_i(X)"
 fun_params(f::NuclearNorm) = "λ = $(f.lambda)"
 
 function prox_naive(f::NuclearNorm, X::AbstractMatrix{T}, gamma::R=R(1)) where {R, T <: Union{R, Complex{R}}}
-	F = svd(X)
-	S = max.(0, F.S .- f.lambda*gamma)
-	Y = F.U * (Diagonal(S) * F.Vt)
-	return Y, f.lambda * sum(S)
+    F = svd(X)
+    S = max.(0, F.S .- f.lambda*gamma)
+    Y = F.U * (Diagonal(S) * F.Vt)
+    return Y, f.lambda * sum(S)
 end

--- a/src/functions/nuclearNorm.jl
+++ b/src/functions/nuclearNorm.jl
@@ -33,10 +33,10 @@ function (f::NuclearNorm{R})(X::AbstractMatrix{T}) where {R <: Real, T <: Union{
 	return f.lambda * sum(F.S)
 end
 
-function prox!(Y::AbstractMatrix{T}, f::NuclearNorm{R}, X::AbstractMatrix{T}, gamma::R=one(R)) where {R <: Real, T <: Union{R, Complex{R}}}
+function prox!(Y::AbstractMatrix{T}, f::NuclearNorm{R}, X::AbstractMatrix{T}, gamma::R=R(1)) where {R <: Real, T <: Union{R, Complex{R}}}
 	F = svd(X)
-	S_thresh = max.(zero(R), F.S .- f.lambda*gamma)
-	rankY = findfirst(S_thresh .== zero(R))
+	S_thresh = max.(R(0), F.S .- f.lambda*gamma)
+	rankY = findfirst(S_thresh .== R(0))
 	if rankY === nothing
 		rankY = minimum(size(X))
 	end
@@ -53,7 +53,7 @@ fun_dom(f::NuclearNorm) = "AbstractArray{Real,2}, AbstractArray{Complex,2}"
 fun_expr(f::NuclearNorm) = "X ↦ λ∑σ_i(X)"
 fun_params(f::NuclearNorm) = "λ = $(f.lambda)"
 
-function prox_naive(f::NuclearNorm, X::AbstractMatrix{T}, gamma=1.0) where T
+function prox_naive(f::NuclearNorm, X::AbstractMatrix{T}, gamma::R=R(1)) where {R, T <: Union{R, Complex{R}}}
 	F = svd(X)
 	S = max.(0, F.S .- f.lambda*gamma)
 	Y = F.U * (Diagonal(S) * F.Vt)

--- a/src/functions/nuclearNorm.jl
+++ b/src/functions/nuclearNorm.jl
@@ -5,7 +5,7 @@ export NuclearNorm
 """
 **Nuclear norm**
 
-    NuclearNorm(λ=1.0)
+	NuclearNorm(λ=1.0)
 
 Returns the function
 ```math
@@ -14,14 +14,14 @@ f(X) = \\|X\\|_* = λ ∑_i σ_i(X),
 where `λ` is a positive parameter and ``σ_i(X)`` is ``i``-th singular value of matrix ``X``.
 """
 struct NuclearNorm{R <: Real} <: ProximableFunction
-  lambda::R
-  function NuclearNorm{R}(lambda::R) where {R <: Real}
-    if lambda < 0
-      error("parameter λ must be nonnegative")
-    else
-      new(lambda)
-    end
-  end
+	lambda::R
+	function NuclearNorm{R}(lambda::R) where {R <: Real}
+		if lambda < 0
+			error("parameter λ must be nonnegative")
+		else
+			new(lambda)
+		end
+	end
 end
 
 is_convex(f::NuclearNorm) = true
@@ -29,23 +29,23 @@ is_convex(f::NuclearNorm) = true
 NuclearNorm(lambda::R=1.0) where {R <: Real} = NuclearNorm{R}(lambda)
 
 function (f::NuclearNorm{R})(X::AbstractMatrix{T}) where {R <: Real, T <: Union{R, Complex{R}}}
-  F = svd(X);
-  return f.lambda * sum(F.S);
+	F = svd(X);
+	return f.lambda * sum(F.S);
 end
 
 function prox!(Y::AbstractMatrix{T}, f::NuclearNorm{R}, X::AbstractMatrix{T}, gamma::R=one(R)) where {R <: Real, T <: Union{R, Complex{R}}}
-  F = svd(X)
-  S_thresh = max.(zero(R), F.S .- f.lambda*gamma)
-  rankY = findfirst(S_thresh .== zero(R))
-  if rankY === nothing
-    rankY = minimum(size(X))
-  end
-  Vt_thresh = view(F.Vt, 1:rankY, :)
-  U_thresh = view(F.U, :, 1:rankY)
-  # TODO: the order of the following matrix products should depend on the shape of x
-  M = S_thresh[1:rankY] .* Vt_thresh
-  mul!(Y, U_thresh, M)
-  return f.lambda * sum(S_thresh);
+	F = svd(X)
+	S_thresh = max.(zero(R), F.S .- f.lambda*gamma)
+	rankY = findfirst(S_thresh .== zero(R))
+	if rankY === nothing
+		rankY = minimum(size(X))
+	end
+	Vt_thresh = view(F.Vt, 1:rankY, :)
+	U_thresh = view(F.U, :, 1:rankY)
+	# TODO: the order of the following matrix products should depend on the shape of x
+	M = S_thresh[1:rankY] .* Vt_thresh
+	mul!(Y, U_thresh, M)
+	return f.lambda * sum(S_thresh);
 end
 
 fun_name(f::NuclearNorm) = "nuclear norm"
@@ -54,8 +54,8 @@ fun_expr(f::NuclearNorm) = "X ↦ λ∑σ_i(X)"
 fun_params(f::NuclearNorm) = "λ = $(f.lambda)"
 
 function prox_naive(f::NuclearNorm, X::AbstractMatrix{T}, gamma=1.0) where T
-  F = svd(X)
-  S = max.(0, F.S .- f.lambda*gamma)
-  Y = F.U * (Diagonal(S) * F.Vt)
-  return Y, f.lambda * sum(S)
+	F = svd(X)
+	S = max.(0, F.S .- f.lambda*gamma)
+	Y = F.U * (Diagonal(S) * F.Vt)
+	return Y, f.lambda * sum(S)
 end

--- a/src/functions/quadratic.jl
+++ b/src/functions/quadratic.jl
@@ -17,7 +17,7 @@ fun_name(f::Quadratic) = "Quadratic function"
 """
 **Quadratic function**
 
-    Quadratic(Q, q; iterative=false)
+	Quadratic(Q, q; iterative=false)
 
 For a matrix `Q` (dense or sparse, symmetric and positive semidefinite) and a vector `q`, returns the function
 ```math
@@ -27,11 +27,11 @@ By default, a direct method (based on Cholesky factorization) is used to evaluat
 If `iterative=true`, then `prox!` is evaluated approximately using an iterative method instead.
 """
 function Quadratic(Q::M, q::V; iterative=false) where {M, V}
-  if iterative == false
-    QuadraticDirect(Q, q)
-  else
-    QuadraticIterative(Q, q)
-  end
+	if iterative == false
+		QuadraticDirect(Q, q)
+	else
+		QuadraticIterative(Q, q)
+	end
 end
 
 ### INCLUDE CONCRETE TYPES

--- a/src/functions/quadratic.jl
+++ b/src/functions/quadratic.jl
@@ -17,7 +17,7 @@ fun_name(f::Quadratic) = "Quadratic function"
 """
 **Quadratic function**
 
-	Quadratic(Q, q; iterative=false)
+    Quadratic(Q, q; iterative=false)
 
 For a matrix `Q` (dense or sparse, symmetric and positive semidefinite) and a vector `q`, returns the function
 ```math
@@ -27,11 +27,11 @@ By default, a direct method (based on Cholesky factorization) is used to evaluat
 If `iterative=true`, then `prox!` is evaluated approximately using an iterative method instead.
 """
 function Quadratic(Q::M, q::V; iterative=false) where {M, V}
-	if iterative == false
-		QuadraticDirect(Q, q)
-	else
-		QuadraticIterative(Q, q)
-	end
+    if iterative == false
+        QuadraticDirect(Q, q)
+    else
+        QuadraticIterative(Q, q)
+    end
 end
 
 ### INCLUDE CONCRETE TYPES

--- a/src/functions/quadraticDirect.jl
+++ b/src/functions/quadraticDirect.jl
@@ -7,76 +7,76 @@ using SparseArrays
 using SuiteSparse
 
 mutable struct QuadraticDirect{R <: Real, M <: AbstractMatrix{R}, V <: AbstractVector{R}, F <: Factorization} <: Quadratic
-  Q::M
-  q::V
-  gamma::R
-  temp::V
-  fact::F
-  function QuadraticDirect{R, M, V, F}(Q::M, q::V) where {R <: Real, M <: AbstractMatrix{R}, V <: AbstractVector{R}, F <: Factorization}
-    if size(Q, 1) != size(Q, 2) || length(q) != size(Q, 2)
-      error("Q must be squared and q must be compatible with Q")
-    end
-    new(Q, q, -1, similar(q))
-  end
+	Q::M
+	q::V
+	gamma::R
+	temp::V
+	fact::F
+	function QuadraticDirect{R, M, V, F}(Q::M, q::V) where {R <: Real, M <: AbstractMatrix{R}, V <: AbstractVector{R}, F <: Factorization}
+		if size(Q, 1) != size(Q, 2) || length(q) != size(Q, 2)
+			error("Q must be squared and q must be compatible with Q")
+		end
+		new(Q, q, -1, similar(q))
+	end
 end
 
 function QuadraticDirect(Q::M, q::V) where {R <: Real, I <: Integer, M <: SparseMatrixCSC{R, I}, V <: AbstractVector{R}}
-  QuadraticDirect{R, M, V, SuiteSparse.CHOLMOD.Factor{R}}(Q, q)
+	QuadraticDirect{R, M, V, SuiteSparse.CHOLMOD.Factor{R}}(Q, q)
 end
 
 function QuadraticDirect(Q::M, q::V) where {R <: Real, M <: DenseMatrix{R}, V <: AbstractVector{R}}
-  QuadraticDirect{R, M, V, Cholesky{R}}(Q, q)
+	QuadraticDirect{R, M, V, Cholesky{R}}(Q, q)
 end
 
 function (f::QuadraticDirect{R, M, V, F})(x::AbstractArray{R}) where {R, M, V, F}
-  mul!(f.temp, f.Q, x)
-  return 0.5*dot(x, f.temp) + dot(x, f.q)
+	mul!(f.temp, f.Q, x)
+	return 0.5*dot(x, f.temp) + dot(x, f.q)
 end
 
 function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}, gamma::R=one(R)) where {R, M, V, F <: Cholesky}
-  if gamma != f.gamma
-    factor_step!(f, gamma)
-  end
-  y .= x./gamma
-  y .-= f.q
-  # Qy = U'Uy = b, therefore y = U\(U'\b)
-  LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
-  LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
-  mul!(f.temp, f.Q, y)
-  fy = 0.5*dot(y, f.temp) + dot(y, f.q)
-  return fy
+	if gamma != f.gamma
+		factor_step!(f, gamma)
+	end
+	y .= x./gamma
+	y .-= f.q
+	# Qy = U'Uy = b, therefore y = U\(U'\b)
+	LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
+	LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
+	mul!(f.temp, f.Q, y)
+	fy = 0.5*dot(y, f.temp) + dot(y, f.q)
+	return fy
 end
 
 function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}, gamma::R=one(R)) where {R, M, V, F <: SuiteSparse.CHOLMOD.Factor}
-  if gamma != f.gamma
-    factor_step!(f, gamma)
-  end
-  f.temp .= x./gamma
-  f.temp .-= f.q
-  y .= f.fact\f.temp
-  mul!(f.temp, f.Q, y)
-  fy = 0.5*dot(y, f.temp) + dot(y, f.q)
-  return fy
+	if gamma != f.gamma
+		factor_step!(f, gamma)
+	end
+	f.temp .= x./gamma
+	f.temp .-= f.q
+	y .= f.fact\f.temp
+	mul!(f.temp, f.Q, y)
+	fy = 0.5*dot(y, f.temp) + dot(y, f.q)
+	return fy
 end
 
 function factor_step!(f::QuadraticDirect{R, M, V, F}, gamma::R) where {R, M <: DenseMatrix{R}, V, F}
-  f.gamma = gamma
-  f.fact = cholesky(f.Q + I/gamma)
+	f.gamma = gamma
+	f.fact = cholesky(f.Q + I/gamma)
 end
 
 function factor_step!(f::QuadraticDirect{R, M, V, F}, gamma::R) where {R, I, M <: SparseMatrixCSC{R, I}, V, F}
-  f.gamma = gamma
-  f.fact = ldlt(f.Q; shift = 1/gamma)
+	f.gamma = gamma
+	f.fact = ldlt(f.Q; shift = 1/gamma)
 end
 
 function gradient!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}) where {R, M, V, F}
-  mul!(y, f.Q, x)
-  y .+= f.q
-  return 0.5*(dot(x, y) + dot(x, f.q))
+	mul!(y, f.Q, x)
+	y .+= f.q
+	return 0.5*(dot(x, y) + dot(x, f.q))
 end
 
 function prox_naive(f::QuadraticDirect, x, gamma=1.0)
-  y = (gamma*f.Q + I)\(x - gamma*f.q)
-  fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
-  return y, fy
+	y = (gamma*f.Q + I)\(x - gamma*f.q)
+	fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
+	return y, fy
 end

--- a/src/functions/quadraticDirect.jl
+++ b/src/functions/quadraticDirect.jl
@@ -33,7 +33,7 @@ function (f::QuadraticDirect{R, M, V, F})(x::AbstractArray{R}) where {R, M, V, F
 	return 0.5*dot(x, f.temp) + dot(x, f.q)
 end
 
-function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}, gamma::R=one(R)) where {R, M, V, F <: Cholesky}
+function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}, gamma::R=R(1)) where {R, M, V, F <: Cholesky}
 	if gamma != f.gamma
 		factor_step!(f, gamma)
 	end
@@ -47,7 +47,7 @@ function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractA
 	return fy
 end
 
-function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}, gamma::R=one(R)) where {R, M, V, F <: SuiteSparse.CHOLMOD.Factor}
+function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}, gamma::R=R(1)) where {R, M, V, F <: SuiteSparse.CHOLMOD.Factor}
 	if gamma != f.gamma
 		factor_step!(f, gamma)
 	end
@@ -75,7 +75,7 @@ function gradient!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::Abstr
 	return 0.5*(dot(x, y) + dot(x, f.q))
 end
 
-function prox_naive(f::QuadraticDirect, x, gamma=1.0)
+function prox_naive(f::QuadraticDirect, x::AbstractArray{R}, gamma::R=one(R)) where R
 	y = (gamma*f.Q + I)\(x - gamma*f.q)
 	fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
 	return y, fy

--- a/src/functions/quadraticDirect.jl
+++ b/src/functions/quadraticDirect.jl
@@ -7,76 +7,76 @@ using SparseArrays
 using SuiteSparse
 
 mutable struct QuadraticDirect{R <: Real, M <: AbstractMatrix{R}, V <: AbstractVector{R}, F <: Factorization} <: Quadratic
-	Q::M
-	q::V
-	gamma::R
-	temp::V
-	fact::F
-	function QuadraticDirect{R, M, V, F}(Q::M, q::V) where {R <: Real, M <: AbstractMatrix{R}, V <: AbstractVector{R}, F <: Factorization}
-		if size(Q, 1) != size(Q, 2) || length(q) != size(Q, 2)
-			error("Q must be squared and q must be compatible with Q")
-		end
-		new(Q, q, -1, similar(q))
-	end
+    Q::M
+    q::V
+    gamma::R
+    temp::V
+    fact::F
+    function QuadraticDirect{R, M, V, F}(Q::M, q::V) where {R <: Real, M <: AbstractMatrix{R}, V <: AbstractVector{R}, F <: Factorization}
+        if size(Q, 1) != size(Q, 2) || length(q) != size(Q, 2)
+            error("Q must be squared and q must be compatible with Q")
+        end
+        new(Q, q, -1, similar(q))
+    end
 end
 
 function QuadraticDirect(Q::M, q::V) where {R <: Real, I <: Integer, M <: SparseMatrixCSC{R, I}, V <: AbstractVector{R}}
-	QuadraticDirect{R, M, V, SuiteSparse.CHOLMOD.Factor{R}}(Q, q)
+    QuadraticDirect{R, M, V, SuiteSparse.CHOLMOD.Factor{R}}(Q, q)
 end
 
 function QuadraticDirect(Q::M, q::V) where {R <: Real, M <: DenseMatrix{R}, V <: AbstractVector{R}}
-	QuadraticDirect{R, M, V, Cholesky{R}}(Q, q)
+    QuadraticDirect{R, M, V, Cholesky{R}}(Q, q)
 end
 
 function (f::QuadraticDirect{R, M, V, F})(x::AbstractArray{R}) where {R, M, V, F}
-	mul!(f.temp, f.Q, x)
-	return 0.5*dot(x, f.temp) + dot(x, f.q)
+    mul!(f.temp, f.Q, x)
+    return 0.5*dot(x, f.temp) + dot(x, f.q)
 end
 
 function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}, gamma::R=R(1)) where {R, M, V, F <: Cholesky}
-	if gamma != f.gamma
-		factor_step!(f, gamma)
-	end
-	y .= x./gamma
-	y .-= f.q
-	# Qy = U'Uy = b, therefore y = U\(U'\b)
-	LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
-	LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
-	mul!(f.temp, f.Q, y)
-	fy = 0.5*dot(y, f.temp) + dot(y, f.q)
-	return fy
+    if gamma != f.gamma
+        factor_step!(f, gamma)
+    end
+    y .= x./gamma
+    y .-= f.q
+    # Qy = U'Uy = b, therefore y = U\(U'\b)
+    LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
+    LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
+    mul!(f.temp, f.Q, y)
+    fy = 0.5*dot(y, f.temp) + dot(y, f.q)
+    return fy
 end
 
 function prox!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}, gamma::R=R(1)) where {R, M, V, F <: SuiteSparse.CHOLMOD.Factor}
-	if gamma != f.gamma
-		factor_step!(f, gamma)
-	end
-	f.temp .= x./gamma
-	f.temp .-= f.q
-	y .= f.fact\f.temp
-	mul!(f.temp, f.Q, y)
-	fy = 0.5*dot(y, f.temp) + dot(y, f.q)
-	return fy
+    if gamma != f.gamma
+        factor_step!(f, gamma)
+    end
+    f.temp .= x./gamma
+    f.temp .-= f.q
+    y .= f.fact\f.temp
+    mul!(f.temp, f.Q, y)
+    fy = 0.5*dot(y, f.temp) + dot(y, f.q)
+    return fy
 end
 
 function factor_step!(f::QuadraticDirect{R, M, V, F}, gamma::R) where {R, M <: DenseMatrix{R}, V, F}
-	f.gamma = gamma
-	f.fact = cholesky(f.Q + I/gamma)
+    f.gamma = gamma
+    f.fact = cholesky(f.Q + I/gamma)
 end
 
 function factor_step!(f::QuadraticDirect{R, M, V, F}, gamma::R) where {R, I, M <: SparseMatrixCSC{R, I}, V, F}
-	f.gamma = gamma
-	f.fact = ldlt(f.Q; shift = 1/gamma)
+    f.gamma = gamma
+    f.fact = ldlt(f.Q; shift = 1/gamma)
 end
 
 function gradient!(y::AbstractArray{R}, f::QuadraticDirect{R, M, V, F}, x::AbstractArray{R}) where {R, M, V, F}
-	mul!(y, f.Q, x)
-	y .+= f.q
-	return 0.5*(dot(x, y) + dot(x, f.q))
+    mul!(y, f.Q, x)
+    y .+= f.q
+    return 0.5*(dot(x, y) + dot(x, f.q))
 end
 
 function prox_naive(f::QuadraticDirect, x::AbstractArray{R}, gamma::R=one(R)) where R
-	y = (gamma*f.Q + I)\(x - gamma*f.q)
-	fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
-	return y, fy
+    y = (gamma*f.Q + I)\(x - gamma*f.q)
+    fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
+    return y, fy
 end

--- a/src/functions/quadraticIterative.jl
+++ b/src/functions/quadraticIterative.jl
@@ -23,9 +23,9 @@ function (f::QuadraticIterative{R, M, V})(x::AbstractArray{R}) where {R, M, V}
 	return 0.5*dot(x, f.temp) + dot(x, f.q)
 end
 
-function prox!(y::AbstractArray{R}, f::QuadraticIterative{R, M, V}, x::AbstractArray{R}, gamma::R=one(R)) where {R, M, V}
+function prox!(y::AbstractArray{R}, f::QuadraticIterative{R, M, V}, x::AbstractArray{R}, gamma::R=R(1)) where {R, M, V}
 	f.temp .= x./gamma .- f.q
-	op = Shift(f.Q, one(R)/gamma)
+	op = Shift(f.Q, R(1)/gamma)
 	IterativeSolvers.cg!(y, op, f.temp)
 	mul!(f.temp, f.Q, y)
 	fy = 0.5*dot(y, f.temp) + dot(y, f.q)
@@ -38,7 +38,7 @@ function gradient!(y::AbstractArray{R}, f::QuadraticIterative{R, M, V}, x::Abstr
 	return 0.5*(dot(x, y) + dot(x, f.q))
 end
 
-function prox_naive(f::QuadraticIterative, x, gamma=1.0)
+function prox_naive(f::QuadraticIterative, x::AbstractArray{R}, gamma::R=R(1)) where R
 	y = IterativeSolvers.cg(gamma*f.Q + I, x - gamma*f.q)
 	fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
 	return y, fy

--- a/src/functions/quadraticIterative.jl
+++ b/src/functions/quadraticIterative.jl
@@ -4,42 +4,42 @@ using LinearAlgebra
 using IterativeSolvers
 
 struct QuadraticIterative{R <: Real, M, V <: AbstractVector{R}} <: Quadratic
-	Q::M
-	q::V
-	temp::V
+    Q::M
+    q::V
+    temp::V
 end
 
 is_prox_accurate(f::QuadraticIterative) = false
 
 function QuadraticIterative(Q::M, q::V) where {R <: Real, M, V <: AbstractVector{R}}
-	if size(Q, 1) != size(Q, 2) || length(q) != size(Q, 2)
-		error("Q must be squared and q must be compatible with Q")
-	end
-	QuadraticIterative{R, M, V}(Q, q, similar(q))
+    if size(Q, 1) != size(Q, 2) || length(q) != size(Q, 2)
+        error("Q must be squared and q must be compatible with Q")
+    end
+    QuadraticIterative{R, M, V}(Q, q, similar(q))
 end
 
 function (f::QuadraticIterative{R, M, V})(x::AbstractArray{R}) where {R, M, V}
-	mul!(f.temp, f.Q, x)
-	return 0.5*dot(x, f.temp) + dot(x, f.q)
+    mul!(f.temp, f.Q, x)
+    return 0.5*dot(x, f.temp) + dot(x, f.q)
 end
 
 function prox!(y::AbstractArray{R}, f::QuadraticIterative{R, M, V}, x::AbstractArray{R}, gamma::R=R(1)) where {R, M, V}
-	f.temp .= x./gamma .- f.q
-	op = Shift(f.Q, R(1)/gamma)
-	IterativeSolvers.cg!(y, op, f.temp)
-	mul!(f.temp, f.Q, y)
-	fy = 0.5*dot(y, f.temp) + dot(y, f.q)
-	return fy
+    f.temp .= x./gamma .- f.q
+    op = Shift(f.Q, R(1)/gamma)
+    IterativeSolvers.cg!(y, op, f.temp)
+    mul!(f.temp, f.Q, y)
+    fy = 0.5*dot(y, f.temp) + dot(y, f.q)
+    return fy
 end
 
 function gradient!(y::AbstractArray{R}, f::QuadraticIterative{R, M, V}, x::AbstractArray{R}) where {R, M, V}
-	mul!(y, f.Q, x)
-	y .+= f.q
-	return 0.5*(dot(x, y) + dot(x, f.q))
+    mul!(y, f.Q, x)
+    y .+= f.q
+    return 0.5*(dot(x, y) + dot(x, f.q))
 end
 
 function prox_naive(f::QuadraticIterative, x::AbstractArray{R}, gamma::R=R(1)) where R
-	y = IterativeSolvers.cg(gamma*f.Q + I, x - gamma*f.q)
-	fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
-	return y, fy
+    y = IterativeSolvers.cg(gamma*f.Q + I, x - gamma*f.q)
+    fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
+    return y, fy
 end

--- a/src/functions/quadraticIterative.jl
+++ b/src/functions/quadraticIterative.jl
@@ -4,42 +4,42 @@ using LinearAlgebra
 using IterativeSolvers
 
 struct QuadraticIterative{R <: Real, M, V <: AbstractVector{R}} <: Quadratic
-  Q::M
-  q::V
-  temp::V
+	Q::M
+	q::V
+	temp::V
 end
 
 is_prox_accurate(f::QuadraticIterative) = false
 
 function QuadraticIterative(Q::M, q::V) where {R <: Real, M, V <: AbstractVector{R}}
-  if size(Q, 1) != size(Q, 2) || length(q) != size(Q, 2)
-    error("Q must be squared and q must be compatible with Q")
-  end
-  QuadraticIterative{R, M, V}(Q, q, similar(q))
+	if size(Q, 1) != size(Q, 2) || length(q) != size(Q, 2)
+		error("Q must be squared and q must be compatible with Q")
+	end
+	QuadraticIterative{R, M, V}(Q, q, similar(q))
 end
 
 function (f::QuadraticIterative{R, M, V})(x::AbstractArray{R}) where {R, M, V}
-  mul!(f.temp, f.Q, x)
-  return 0.5*dot(x, f.temp) + dot(x, f.q)
+	mul!(f.temp, f.Q, x)
+	return 0.5*dot(x, f.temp) + dot(x, f.q)
 end
 
 function prox!(y::AbstractArray{R}, f::QuadraticIterative{R, M, V}, x::AbstractArray{R}, gamma::R=one(R)) where {R, M, V}
-  f.temp .= x./gamma .- f.q
-  op = Shift(f.Q, one(R)/gamma)
-  IterativeSolvers.cg!(y, op, f.temp)
-  mul!(f.temp, f.Q, y)
-  fy = 0.5*dot(y, f.temp) + dot(y, f.q)
-  return fy
+	f.temp .= x./gamma .- f.q
+	op = Shift(f.Q, one(R)/gamma)
+	IterativeSolvers.cg!(y, op, f.temp)
+	mul!(f.temp, f.Q, y)
+	fy = 0.5*dot(y, f.temp) + dot(y, f.q)
+	return fy
 end
 
 function gradient!(y::AbstractArray{R}, f::QuadraticIterative{R, M, V}, x::AbstractArray{R}) where {R, M, V}
-  mul!(y, f.Q, x)
-  y .+= f.q
-  return 0.5*(dot(x, y) + dot(x, f.q))
+	mul!(y, f.Q, x)
+	y .+= f.q
+	return 0.5*(dot(x, y) + dot(x, f.q))
 end
 
 function prox_naive(f::QuadraticIterative, x, gamma=1.0)
-  y = IterativeSolvers.cg(gamma*f.Q + I, x - gamma*f.q)
-  fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
-  return y, fy
+	y = IterativeSolvers.cg(gamma*f.Q + I, x - gamma*f.q)
+	fy = 0.5*dot(y, f.Q*y) + dot(y, f.q)
+	return y, fy
 end

--- a/src/functions/sqrHingeLoss.jl
+++ b/src/functions/sqrHingeLoss.jl
@@ -5,7 +5,7 @@ export SqrHingeLoss
 """
 **Squared Hinge loss**
 
-  SqrHingeLoss(y, μ=1.0)
+	SqrHingeLoss(y, μ=1.0)
 
 Returns the function
 ```math
@@ -14,15 +14,15 @@ f(x) = μ⋅∑_i \\max\\{0, 1 - y_i ⋅ x_i\\}^2,
 where `y` is an array and `μ` is a positive parameter.
 """
 struct SqrHingeLoss{R <: Real, T <: AbstractArray{R}} <: ProximableFunction
-  y::T
-  mu::R
-  function SqrHingeLoss{R, T}(y::T, mu::R) where {R <: Real, T <: AbstractArray{R}}
-    if mu <= 0
-      error("parameter mu must be positive")
-    else
-      new(y, mu)
-    end
-  end
+	y::T
+	mu::R
+	function SqrHingeLoss{R, T}(y::T, mu::R) where {R <: Real, T <: AbstractArray{R}}
+		if mu <= 0
+			error("parameter mu must be positive")
+		else
+			new(y, mu)
+		end
+	end
 end
 
 is_separable(f::SqrHingeLoss) = true
@@ -45,16 +45,16 @@ function gradient!(y::AbstractArray{R}, f::SqrHingeLoss{R, T}, x::AbstractArray{
 end
 
 function prox!(z::AbstractArray{R}, f::SqrHingeLoss{R, T}, x::AbstractArray{R}, gamma::R=one(R)) where {R, T}
-    v = zero(R)
-    for k in eachindex(x)
-        if f.y[k]*x[k] >= 1
-            z[k] = x[k]
-        else
-            z[k] = (x[k] + 2*f.mu*gamma*f.y[k])/(1+2*f.mu*gamma*f.y[k]^2)
-            v += (1-f.y[k]*z[k])^2
-        end
-    end
-    return f.mu*v
+	v = zero(R)
+	for k in eachindex(x)
+		if f.y[k]*x[k] >= 1
+			z[k] = x[k]
+		else
+			z[k] = (x[k] + 2*f.mu*gamma*f.y[k])/(1+2*f.mu*gamma*f.y[k]^2)
+			v += (1-f.y[k]*z[k])^2
+		end
+	end
+	return f.mu*v
 end
 
 fun_name(f::SqrHingeLoss) = "squared hinge loss"
@@ -63,8 +63,8 @@ fun_expr(f::SqrHingeLoss) = "x ↦ μ * sum( max(0,1-b*x_i)^2, i=1,...,n )"
 fun_params(f::SqrHingeLoss) = "b = $(typeof(f.y)), μ = $(f.mu)"
 
 function prox_naive(f::SqrHingeLoss{R, T}, x::AbstractArray{R}, gamma::R=one(R)) where {R, T}
-    flag = f.y.*x .<= 1
-    z = copy(x)
-    z[flag] = (x[flag] .+ 2 .* f.mu.*gamma.*f.y[flag])./(1. + 2 .* f.mu.*gamma.*f.y[flag].^2)
-    return z, f.mu*sum(max.(0.0, 1 .- f.y.*z).^2)
+	flag = f.y.*x .<= 1
+	z = copy(x)
+	z[flag] = (x[flag] .+ 2 .* f.mu.*gamma.*f.y[flag])./(1. + 2 .* f.mu.*gamma.*f.y[flag].^2)
+	return z, f.mu*sum(max.(0.0, 1 .- f.y.*z).^2)
 end

--- a/src/functions/sqrHingeLoss.jl
+++ b/src/functions/sqrHingeLoss.jl
@@ -5,7 +5,7 @@ export SqrHingeLoss
 """
 **Squared Hinge loss**
 
-	SqrHingeLoss(y, μ=1.0)
+    SqrHingeLoss(y, μ=1.0)
 
 Returns the function
 ```math
@@ -14,15 +14,15 @@ f(x) = μ⋅∑_i \\max\\{0, 1 - y_i ⋅ x_i\\}^2,
 where `y` is an array and `μ` is a positive parameter.
 """
 struct SqrHingeLoss{R <: Real, T <: AbstractArray{R}} <: ProximableFunction
-	y::T
-	mu::R
-	function SqrHingeLoss{R, T}(y::T, mu::R) where {R <: Real, T <: AbstractArray{R}}
-		if mu <= 0
-			error("parameter mu must be positive")
-		else
-			new(y, mu)
-		end
-	end
+    y::T
+    mu::R
+    function SqrHingeLoss{R, T}(y::T, mu::R) where {R <: Real, T <: AbstractArray{R}}
+        if mu <= 0
+            error("parameter mu must be positive")
+        else
+            new(y, mu)
+        end
+    end
 end
 
 is_separable(f::SqrHingeLoss) = true
@@ -34,27 +34,27 @@ SqrHingeLoss(b::T, mu::R=1.0) where {R <: Real, T <: AbstractArray{R}} = SqrHing
 (f::SqrHingeLoss)(x::T) where {R <: Real, T <: AbstractArray{R}} = f.mu*sum(max.(R(0), (R(1) .- f.y.*x)).^2)
 
 function gradient!(y::AbstractArray{R}, f::SqrHingeLoss{R, T}, x::AbstractArray{R}) where {R <: Real, T}
-	sum = R(0)
-	for i in eachindex(x)
-		zz = 1-f.y[i]*x[i]
-		z = max(R(0), zz)
-		y[i] = z .> 0 ? -2*f.mu*f.y[i]*zz : 0
-		sum += z^2
-	end
-	return f.mu*sum
+    sum = R(0)
+    for i in eachindex(x)
+        zz = 1-f.y[i]*x[i]
+        z = max(R(0), zz)
+        y[i] = z .> 0 ? -2*f.mu*f.y[i]*zz : 0
+        sum += z^2
+    end
+    return f.mu*sum
 end
 
 function prox!(z::AbstractArray{R}, f::SqrHingeLoss{R, T}, x::AbstractArray{R}, gamma::R=R(1)) where {R, T}
-	v = R(0)
-	for k in eachindex(x)
-		if f.y[k]*x[k] >= 1
-			z[k] = x[k]
-		else
-			z[k] = (x[k] + 2*f.mu*gamma*f.y[k])/(1+2*f.mu*gamma*f.y[k]^2)
-			v += (1-f.y[k]*z[k])^2
-		end
-	end
-	return f.mu*v
+    v = R(0)
+    for k in eachindex(x)
+        if f.y[k]*x[k] >= 1
+            z[k] = x[k]
+        else
+            z[k] = (x[k] + 2*f.mu*gamma*f.y[k])/(1+2*f.mu*gamma*f.y[k]^2)
+            v += (1-f.y[k]*z[k])^2
+        end
+    end
+    return f.mu*v
 end
 
 fun_name(f::SqrHingeLoss) = "squared hinge loss"
@@ -63,8 +63,8 @@ fun_expr(f::SqrHingeLoss) = "x ↦ μ * sum( max(0,1-b*x_i)^2, i=1,...,n )"
 fun_params(f::SqrHingeLoss) = "b = $(typeof(f.y)), μ = $(f.mu)"
 
 function prox_naive(f::SqrHingeLoss{R, T}, x::AbstractArray{R}, gamma::R=R(1)) where {R, T}
-	flag = f.y.*x .<= 1
-	z = copy(x)
-	z[flag] = (x[flag] .+ 2 .* f.mu.*gamma.*f.y[flag])./(1. + 2 .* f.mu.*gamma.*f.y[flag].^2)
-	return z, f.mu*sum(max.(0.0, 1 .- f.y.*z).^2)
+    flag = f.y.*x .<= 1
+    z = copy(x)
+    z[flag] = (x[flag] .+ 2 .* f.mu.*gamma.*f.y[flag])./(1. + 2 .* f.mu.*gamma.*f.y[flag].^2)
+    return z, f.mu*sum(max.(0.0, 1 .- f.y.*z).^2)
 end

--- a/src/functions/sqrHingeLoss.jl
+++ b/src/functions/sqrHingeLoss.jl
@@ -31,21 +31,21 @@ is_smooth(f::SqrHingeLoss) = true
 
 SqrHingeLoss(b::T, mu::R=1.0) where {R <: Real, T <: AbstractArray{R}} = SqrHingeLoss{R, T}(b, mu)
 
-(f::SqrHingeLoss)(x::T) where {R <: Real, T <: AbstractArray{R}} = f.mu*sum(max.(zero(R), (one(R) .- f.y.*x)).^2)
+(f::SqrHingeLoss)(x::T) where {R <: Real, T <: AbstractArray{R}} = f.mu*sum(max.(R(0), (R(1) .- f.y.*x)).^2)
 
 function gradient!(y::AbstractArray{R}, f::SqrHingeLoss{R, T}, x::AbstractArray{R}) where {R <: Real, T}
-	sum = zero(R)
+	sum = R(0)
 	for i in eachindex(x)
 		zz = 1-f.y[i]*x[i]
-		z = max(zero(R), zz)
+		z = max(R(0), zz)
 		y[i] = z .> 0 ? -2*f.mu*f.y[i]*zz : 0
 		sum += z^2
 	end
 	return f.mu*sum
 end
 
-function prox!(z::AbstractArray{R}, f::SqrHingeLoss{R, T}, x::AbstractArray{R}, gamma::R=one(R)) where {R, T}
-	v = zero(R)
+function prox!(z::AbstractArray{R}, f::SqrHingeLoss{R, T}, x::AbstractArray{R}, gamma::R=R(1)) where {R, T}
+	v = R(0)
 	for k in eachindex(x)
 		if f.y[k]*x[k] >= 1
 			z[k] = x[k]
@@ -62,7 +62,7 @@ fun_dom(f::SqrHingeLoss) = "AbstractArray{Real}"
 fun_expr(f::SqrHingeLoss) = "x ↦ μ * sum( max(0,1-b*x_i)^2, i=1,...,n )"
 fun_params(f::SqrHingeLoss) = "b = $(typeof(f.y)), μ = $(f.mu)"
 
-function prox_naive(f::SqrHingeLoss{R, T}, x::AbstractArray{R}, gamma::R=one(R)) where {R, T}
+function prox_naive(f::SqrHingeLoss{R, T}, x::AbstractArray{R}, gamma::R=R(1)) where {R, T}
 	flag = f.y.*x .<= 1
 	z = copy(x)
 	z[flag] = (x[flag] .+ 2 .* f.mu.*gamma.*f.y[flag])./(1. + 2 .* f.mu.*gamma.*f.y[flag].^2)

--- a/src/functions/sqrNormL2.jl
+++ b/src/functions/sqrNormL2.jl
@@ -5,7 +5,7 @@ export SqrNormL2
 """
 **Squared Euclidean norm (weighted)**
 
-    SqrNormL2(λ=1.0)
+	SqrNormL2(λ=1.0)
 
 With a nonnegative scalar `λ`, returns the function
 ```math
@@ -17,14 +17,14 @@ f(x) = \\tfrac{1}{2}∑_i λ_i x_i^2.
 ```
 """
 struct SqrNormL2{T <: Union{Real, AbstractArray}} <: ProximableFunction
-  lambda::T
-  function SqrNormL2{T}(lambda::T) where {T <: Union{Real,AbstractArray}}
-    if any(lambda .< 0)
-      error("coefficients in λ must be nonnegative")
-    else
-      new(lambda)
-    end
-  end
+	lambda::T
+	function SqrNormL2{T}(lambda::T) where {T <: Union{Real,AbstractArray}}
+		if any(lambda .< 0)
+			error("coefficients in λ must be nonnegative")
+		else
+			new(lambda)
+		end
+	end
 end
 
 is_convex(f::SqrNormL2) = true
@@ -38,70 +38,70 @@ SqrNormL2(lambda::T=1.0) where {T <: Real} = SqrNormL2{T}(lambda)
 SqrNormL2(lambda::T) where {T <: AbstractArray} = SqrNormL2{T}(lambda)
 
 function (f::SqrNormL2{S})(x::AbstractArray{T}) where {S <: Real, T <: RealOrComplex}
-  return (f.lambda/2)*norm(x)^2
+	return (f.lambda/2)*norm(x)^2
 end
 
 function (f::SqrNormL2{S})(x::AbstractArray{T}) where {S <: AbstractArray, T <: RealOrComplex}
-  sqnorm = 0.0
-  for k in eachindex(x)
-    sqnorm += f.lambda[k]*abs2(x[k])
-  end
-  return 0.5*sqnorm
+	sqnorm = 0.0
+	for k in eachindex(x)
+		sqnorm += f.lambda[k]*abs2(x[k])
+	end
+	return 0.5*sqnorm
 end
 
 function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: Real, T <: RealOrComplex}
-  sqnx = 0.0
-  for k in eachindex(x)
-    y[k] = f.lambda*x[k]
-    sqnx += abs2(x[k])
-  end
-  return (f.lambda/2)*sqnx
+	sqnx = 0.0
+	for k in eachindex(x)
+		y[k] = f.lambda*x[k]
+		sqnx += abs2(x[k])
+	end
+	return (f.lambda/2)*sqnx
 end
 
 function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: AbstractArray, T <: RealOrComplex}
-  sqnx = 0.0
-  for k in eachindex(x)
-    y[k] = f.lambda[k]*x[k]
-    sqnx += f.lambda[k]*abs2(x[k])
-  end
-  return 0.5*sqnx
+	sqnx = 0.0
+	for k in eachindex(x)
+		y[k] = f.lambda[k]*x[k]
+		sqnx += f.lambda[k]*abs2(x[k])
+	end
+	return 0.5*sqnx
 end
 
 function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::Real=1.0) where {S <: Real, T <: RealOrComplex}
-  gl = gamma*f.lambda
-  sqny = 0.0
-  for k in eachindex(x)
-    y[k] = x[k]/(1+gl)
-    sqny += abs2(y[k])
-  end
-  return (f.lambda/2)*sqny
+	gl = gamma*f.lambda
+	sqny = 0.0
+	for k in eachindex(x)
+		y[k] = x[k]/(1+gl)
+		sqny += abs2(y[k])
+	end
+	return (f.lambda/2)*sqny
 end
 
 function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::Real=1.0) where {S <: AbstractArray, T <: RealOrComplex}
-  wsqny = 0.0
-  for k in eachindex(x)
-    y[k] = x[k]/(1+gamma*f.lambda[k])
-    wsqny += f.lambda[k]*abs2(y[k])
-  end
-  return 0.5*wsqny
+	wsqny = 0.0
+	for k in eachindex(x)
+		y[k] = x[k]/(1+gamma*f.lambda[k])
+		wsqny += f.lambda[k]*abs2(y[k])
+	end
+	return 0.5*wsqny
 end
 
 function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::AbstractArray) where {S <: Real, T <: RealOrComplex}
-  sqny = 0.0
-  for k in eachindex(x)
-    y[k] = x[k]/(1+gamma[k]*f.lambda)
-    sqny += abs2(y[k])
-  end
-  return (f.lambda/2)*sqny
+	sqny = 0.0
+	for k in eachindex(x)
+		y[k] = x[k]/(1+gamma[k]*f.lambda)
+		sqny += abs2(y[k])
+	end
+	return (f.lambda/2)*sqny
 end
 
 function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::AbstractArray) where {S <: AbstractArray, T <: RealOrComplex}
-  wsqny = 0.0
-  for k in eachindex(x)
-    y[k] = x[k]/(1+gamma[k]*f.lambda[k])
-    wsqny += f.lambda[k]*abs2(y[k])
-  end
-  return 0.5*wsqny
+	wsqny = 0.0
+	for k in eachindex(x)
+		y[k] = x[k]/(1+gamma[k]*f.lambda[k])
+		wsqny += f.lambda[k]*abs2(y[k])
+	end
+	return 0.5*wsqny
 end
 
 fun_name(f::SqrNormL2) = "weighted squared Euclidean norm"
@@ -112,6 +112,6 @@ fun_params(f::SqrNormL2{T}) where {T <: Real} = "λ = $(f.lambda)"
 fun_params(f::SqrNormL2{T}) where {T <: AbstractArray} = string("λ = ", typeof(f.lambda), " of size ", size(f.lambda))
 
 function prox_naive(f::SqrNormL2, x::AbstractArray{T}, gamma=1.0) where T <: RealOrComplex
-  y = x./(1.0 .+ f.lambda.*gamma)
-  return y, 0.5*real(dot(f.lambda.*y,y))
+	y = x./(1.0 .+ f.lambda.*gamma)
+	return y, 0.5*real(dot(f.lambda.*y,y))
 end

--- a/src/functions/sqrNormL2.jl
+++ b/src/functions/sqrNormL2.jl
@@ -41,16 +41,16 @@ function (f::SqrNormL2{S})(x::AbstractArray{T}) where {S <: Real, T <: RealOrCom
 	return (f.lambda/2)*norm(x)^2
 end
 
-function (f::SqrNormL2{S})(x::AbstractArray{T}) where {S <: AbstractArray, T <: RealOrComplex}
-	sqnorm = 0.0
+function (f::SqrNormL2{S})(x::AbstractArray{T}) where {S <: AbstractArray, R <: Real, T <: RealOrComplex{R}}
+	sqnorm = R(0)
 	for k in eachindex(x)
 		sqnorm += f.lambda[k]*abs2(x[k])
 	end
 	return 0.5*sqnorm
 end
 
-function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: Real, T <: RealOrComplex}
-	sqnx = 0.0
+function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: Real, R <: Real, T <: RealOrComplex{R}}
+	sqnx = R(0)
 	for k in eachindex(x)
 		y[k] = f.lambda*x[k]
 		sqnx += abs2(x[k])
@@ -58,8 +58,8 @@ function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) wh
 	return (f.lambda/2)*sqnx
 end
 
-function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: AbstractArray, T <: RealOrComplex}
-	sqnx = 0.0
+function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: AbstractArray, R <: Real, T <: RealOrComplex{R}}
+	sqnx = R(0)
 	for k in eachindex(x)
 		y[k] = f.lambda[k]*x[k]
 		sqnx += f.lambda[k]*abs2(x[k])
@@ -67,9 +67,9 @@ function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) wh
 	return 0.5*sqnx
 end
 
-function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::Real=1.0) where {S <: Real, T <: RealOrComplex}
+function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::R=R(1)) where {S <: Real, R <: Real, T <: RealOrComplex{R}}
 	gl = gamma*f.lambda
-	sqny = 0.0
+	sqny = R(0)
 	for k in eachindex(x)
 		y[k] = x[k]/(1+gl)
 		sqny += abs2(y[k])
@@ -77,8 +77,8 @@ function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma:
 	return (f.lambda/2)*sqny
 end
 
-function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::Real=1.0) where {S <: AbstractArray, T <: RealOrComplex}
-	wsqny = 0.0
+function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::R=R(1)) where {S <: AbstractArray, R <: Real, T <: RealOrComplex{R}}
+	wsqny = R(0)
 	for k in eachindex(x)
 		y[k] = x[k]/(1+gamma*f.lambda[k])
 		wsqny += f.lambda[k]*abs2(y[k])
@@ -86,8 +86,8 @@ function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma:
 	return 0.5*wsqny
 end
 
-function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::AbstractArray) where {S <: Real, T <: RealOrComplex}
-	sqny = 0.0
+function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::AbstractArray{R}) where {S <: Real, R <: Real, T <: RealOrComplex{R}}
+	sqny = R(0)
 	for k in eachindex(x)
 		y[k] = x[k]/(1+gamma[k]*f.lambda)
 		sqny += abs2(y[k])
@@ -95,8 +95,8 @@ function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma:
 	return (f.lambda/2)*sqny
 end
 
-function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::AbstractArray) where {S <: AbstractArray, T <: RealOrComplex}
-	wsqny = 0.0
+function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::AbstractArray{R}) where {S <: AbstractArray, R <: Real, T <: RealOrComplex{R}}
+	wsqny = R(0)
 	for k in eachindex(x)
 		y[k] = x[k]/(1+gamma[k]*f.lambda[k])
 		wsqny += f.lambda[k]*abs2(y[k])
@@ -111,7 +111,7 @@ fun_expr(f::SqrNormL2{T}) where {T <: AbstractArray} = "x ↦ (1/2)sum( λ_i (x_
 fun_params(f::SqrNormL2{T}) where {T <: Real} = "λ = $(f.lambda)"
 fun_params(f::SqrNormL2{T}) where {T <: AbstractArray} = string("λ = ", typeof(f.lambda), " of size ", size(f.lambda))
 
-function prox_naive(f::SqrNormL2, x::AbstractArray{T}, gamma=1.0) where T <: RealOrComplex
-	y = x./(1.0 .+ f.lambda.*gamma)
+function prox_naive(f::SqrNormL2, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
+	y = x./(R(1) .+ f.lambda.*gamma)
 	return y, 0.5*real(dot(f.lambda.*y,y))
 end

--- a/src/functions/sqrNormL2.jl
+++ b/src/functions/sqrNormL2.jl
@@ -5,7 +5,7 @@ export SqrNormL2
 """
 **Squared Euclidean norm (weighted)**
 
-	SqrNormL2(λ=1.0)
+    SqrNormL2(λ=1.0)
 
 With a nonnegative scalar `λ`, returns the function
 ```math
@@ -17,14 +17,14 @@ f(x) = \\tfrac{1}{2}∑_i λ_i x_i^2.
 ```
 """
 struct SqrNormL2{T <: Union{Real, AbstractArray}} <: ProximableFunction
-	lambda::T
-	function SqrNormL2{T}(lambda::T) where {T <: Union{Real,AbstractArray}}
-		if any(lambda .< 0)
-			error("coefficients in λ must be nonnegative")
-		else
-			new(lambda)
-		end
-	end
+    lambda::T
+    function SqrNormL2{T}(lambda::T) where {T <: Union{Real,AbstractArray}}
+        if any(lambda .< 0)
+            error("coefficients in λ must be nonnegative")
+        else
+            new(lambda)
+        end
+    end
 end
 
 is_convex(f::SqrNormL2) = true
@@ -38,70 +38,70 @@ SqrNormL2(lambda::T=1.0) where {T <: Real} = SqrNormL2{T}(lambda)
 SqrNormL2(lambda::T) where {T <: AbstractArray} = SqrNormL2{T}(lambda)
 
 function (f::SqrNormL2{S})(x::AbstractArray{T}) where {S <: Real, T <: RealOrComplex}
-	return (f.lambda/2)*norm(x)^2
+    return (f.lambda/2)*norm(x)^2
 end
 
 function (f::SqrNormL2{S})(x::AbstractArray{T}) where {S <: AbstractArray, R <: Real, T <: RealOrComplex{R}}
-	sqnorm = R(0)
-	for k in eachindex(x)
-		sqnorm += f.lambda[k]*abs2(x[k])
-	end
-	return 0.5*sqnorm
+    sqnorm = R(0)
+    for k in eachindex(x)
+        sqnorm += f.lambda[k]*abs2(x[k])
+    end
+    return 0.5*sqnorm
 end
 
 function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: Real, R <: Real, T <: RealOrComplex{R}}
-	sqnx = R(0)
-	for k in eachindex(x)
-		y[k] = f.lambda*x[k]
-		sqnx += abs2(x[k])
-	end
-	return (f.lambda/2)*sqnx
+    sqnx = R(0)
+    for k in eachindex(x)
+        y[k] = f.lambda*x[k]
+        sqnx += abs2(x[k])
+    end
+    return (f.lambda/2)*sqnx
 end
 
 function gradient!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}) where {S <: AbstractArray, R <: Real, T <: RealOrComplex{R}}
-	sqnx = R(0)
-	for k in eachindex(x)
-		y[k] = f.lambda[k]*x[k]
-		sqnx += f.lambda[k]*abs2(x[k])
-	end
-	return 0.5*sqnx
+    sqnx = R(0)
+    for k in eachindex(x)
+        y[k] = f.lambda[k]*x[k]
+        sqnx += f.lambda[k]*abs2(x[k])
+    end
+    return 0.5*sqnx
 end
 
 function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::R=R(1)) where {S <: Real, R <: Real, T <: RealOrComplex{R}}
-	gl = gamma*f.lambda
-	sqny = R(0)
-	for k in eachindex(x)
-		y[k] = x[k]/(1+gl)
-		sqny += abs2(y[k])
-	end
-	return (f.lambda/2)*sqny
+    gl = gamma*f.lambda
+    sqny = R(0)
+    for k in eachindex(x)
+        y[k] = x[k]/(1+gl)
+        sqny += abs2(y[k])
+    end
+    return (f.lambda/2)*sqny
 end
 
 function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::R=R(1)) where {S <: AbstractArray, R <: Real, T <: RealOrComplex{R}}
-	wsqny = R(0)
-	for k in eachindex(x)
-		y[k] = x[k]/(1+gamma*f.lambda[k])
-		wsqny += f.lambda[k]*abs2(y[k])
-	end
-	return 0.5*wsqny
+    wsqny = R(0)
+    for k in eachindex(x)
+        y[k] = x[k]/(1+gamma*f.lambda[k])
+        wsqny += f.lambda[k]*abs2(y[k])
+    end
+    return 0.5*wsqny
 end
 
 function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::AbstractArray{R}) where {S <: Real, R <: Real, T <: RealOrComplex{R}}
-	sqny = R(0)
-	for k in eachindex(x)
-		y[k] = x[k]/(1+gamma[k]*f.lambda)
-		sqny += abs2(y[k])
-	end
-	return (f.lambda/2)*sqny
+    sqny = R(0)
+    for k in eachindex(x)
+        y[k] = x[k]/(1+gamma[k]*f.lambda)
+        sqny += abs2(y[k])
+    end
+    return (f.lambda/2)*sqny
 end
 
 function prox!(y::AbstractArray{T}, f::SqrNormL2{S}, x::AbstractArray{T}, gamma::AbstractArray{R}) where {S <: AbstractArray, R <: Real, T <: RealOrComplex{R}}
-	wsqny = R(0)
-	for k in eachindex(x)
-		y[k] = x[k]/(1+gamma[k]*f.lambda[k])
-		wsqny += f.lambda[k]*abs2(y[k])
-	end
-	return 0.5*wsqny
+    wsqny = R(0)
+    for k in eachindex(x)
+        y[k] = x[k]/(1+gamma[k]*f.lambda[k])
+        wsqny += f.lambda[k]*abs2(y[k])
+    end
+    return 0.5*wsqny
 end
 
 fun_name(f::SqrNormL2) = "weighted squared Euclidean norm"
@@ -112,6 +112,6 @@ fun_params(f::SqrNormL2{T}) where {T <: Real} = "λ = $(f.lambda)"
 fun_params(f::SqrNormL2{T}) where {T <: AbstractArray} = string("λ = ", typeof(f.lambda), " of size ", size(f.lambda))
 
 function prox_naive(f::SqrNormL2, x::AbstractArray{T}, gamma=R(1)) where {R <: Real, T <: RealOrComplex{R}}
-	y = x./(R(1) .+ f.lambda.*gamma)
-	return y, 0.5*real(dot(f.lambda.*y,y))
+    y = x./(R(1) .+ f.lambda.*gamma)
+    return y, 0.5*real(dot(f.lambda.*y,y))
 end

--- a/src/functions/sumLargest.jl
+++ b/src/functions/sumLargest.jl
@@ -13,25 +13,25 @@
 # with IndSimplex(k, 1.0). Note that (1) is proper only if x ∈ Rⁿ for n ⩾ r.
 
 """
-	SumLargest(k::Integer=1, λ::Real=1.0)
+    SumLargest(k::Integer=1, λ::Real=1.0)
 
 Returns the function `g(x) = λ⋅sum(x_[1], ..., x_[k])`, for an integer k ⩾ 1 and `λ ⩾ 0`.
 """
 SumLargest(k::I=1, lambda::R=1.0) where {I <: Integer, R <: Real} = Postcompose(Conjugate(IndSimplex(k)), lambda)
 
 function (f::Conjugate{IndSimplex{I}})(x::AbstractArray{S}) where {I <: Integer, S <: Real}
-	if f.f.a == 1
-		return maximum(x)
-	end
-	v = zero(S)
-	if ndims(x) == 1
-		p = partialsortperm(x, 1:f.f.a, rev=true)
-		v = sum(x[p])
-	else
-		p = partialsortperm(x[:], 1:f.f.a, rev=true)
-		v = sum(x[p])
-	end
-	return v
+    if f.f.a == 1
+        return maximum(x)
+    end
+    v = zero(S)
+    if ndims(x) == 1
+        p = partialsortperm(x, 1:f.f.a, rev=true)
+        v = sum(x[p])
+    else
+        p = partialsortperm(x[:], 1:f.f.a, rev=true)
+        v = sum(x[p])
+    end
+    return v
 end
 
 fun_name(f::Postcompose{Conjugate{IndSimplex{I}}, R}) where {I <: Integer, R <: Real} = "sum of k largest components"

--- a/src/functions/sumLargest.jl
+++ b/src/functions/sumLargest.jl
@@ -3,9 +3,9 @@
 # export SumLargest
 
 # TODO: SumLargest(r) is (the postcomposition of) the conjugate of
-#   (1) ind{0 <= x <= 1 : sum(x) = r},
+#  (1) ind{0 <= x <= 1 : sum(x) = r},
 # where instead IndSimplex(r) corresponds to
-#   (2) ind{0 <= x : sum(x) = r}.
+#  (2) ind{0 <= x : sum(x) = r}.
 # Therefore SumLargest(r) now is only correct when r = 1.
 # To make SumLargest correct we should extend IndSimplex to allow for that
 # additional bound in its definition, by adding a second argument to the
@@ -13,25 +13,25 @@
 # with IndSimplex(k, 1.0). Note that (1) is proper only if x ∈ Rⁿ for n ⩾ r.
 
 """
-  SumLargest(k::Integer=1, λ::Real=1.0)
+	SumLargest(k::Integer=1, λ::Real=1.0)
 
 Returns the function `g(x) = λ⋅sum(x_[1], ..., x_[k])`, for an integer k ⩾ 1 and `λ ⩾ 0`.
 """
 SumLargest(k::I=1, lambda::R=1.0) where {I <: Integer, R <: Real} = Postcompose(Conjugate(IndSimplex(k)), lambda)
 
 function (f::Conjugate{IndSimplex{I}})(x::AbstractArray{S}) where {I <: Integer, S <: Real}
-  if f.f.a == 1
-    return maximum(x)
-  end
-  v = zero(S)
-  if ndims(x) == 1
-    p = partialsortperm(x, 1:f.f.a, rev=true)
-    v = sum(x[p])
-  else
-    p = partialsortperm(x[:], 1:f.f.a, rev=true)
-    v = sum(x[p])
-  end
-  return v
+	if f.f.a == 1
+		return maximum(x)
+	end
+	v = zero(S)
+	if ndims(x) == 1
+		p = partialsortperm(x, 1:f.f.a, rev=true)
+		v = sum(x[p])
+	else
+		p = partialsortperm(x[:], 1:f.f.a, rev=true)
+		v = sum(x[p])
+	end
+	return v
 end
 
 fun_name(f::Postcompose{Conjugate{IndSimplex{I}}, R}) where {I <: Integer, R <: Real} = "sum of k largest components"

--- a/src/functions/sumPositive.jl
+++ b/src/functions/sumPositive.jl
@@ -5,7 +5,7 @@ export SumPositive
 """
 **Sum of the positive coefficients**
 
-	SumPositive()
+    SumPositive()
 
 Returns the function
 ```math
@@ -18,21 +18,21 @@ is_separable(f::SumPositive) = true
 is_convex(f::SumPositive) = true
 
 function (f::SumPositive)(x::AbstractArray{T}) where T <: Real
-	return sum(xi -> max(xi,0), x)
+    return sum(xi -> max(xi,0), x)
 end
 
 function prox!(y::AbstractArray{T}, f::SumPositive, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-	fsum = 0.0
-	for i in eachindex(x)
-		y[i] = x[i] < gamma ? (x[i] > 0.0 ? 0.0 : x[i]) : x[i]-gamma
-		fsum += y[i] > 0.0 ? y[i] : 0.0
-	end
-	return fsum
+    fsum = 0.0
+    for i in eachindex(x)
+        y[i] = x[i] < gamma ? (x[i] > 0.0 ? 0.0 : x[i]) : x[i]-gamma
+        fsum += y[i] > 0.0 ? y[i] : 0.0
+    end
+    return fsum
 end
 
 function gradient!(y::AbstractArray{T}, f::SumPositive, x::AbstractArray{T}) where T <: Real
-	y .= max.(0, sign.(x))
-	return sum(xi -> max(xi,0), x)
+    y .= max.(0, sign.(x))
+    return sum(xi -> max(xi,0), x)
 end
 
 fun_name(f::SumPositive) = "Sum of the positive coefficients"
@@ -40,10 +40,10 @@ fun_dom(f::SumPositive) = "AbstractArray{Real}"
 fun_expr(f::SumPositive) = "x ↦ sum(max(0, x))"
 
 function prox_naive(f::SumPositive, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-	y = copy(x)
-	indpos = x .> 0.0
-	y[indpos] = max.(0.0, x[indpos] .- gamma)
-	return y, sum(max.(0.0, y))
+    y = copy(x)
+    indpos = x .> 0.0
+    y[indpos] = max.(0.0, x[indpos] .- gamma)
+    return y, sum(max.(0.0, y))
 end
 
 # ######################### #
@@ -51,17 +51,17 @@ end
 # ######################### #
 
 function prox!(y::AbstractArray{T}, f::SumPositive, x::AbstractArray{T}, gamma::AbstractArray{T}) where T <: Real
-	fsum = 0.0
-	for i in eachindex(x)
-		y[i] = x[i] < gamma[i] ? (x[i] > 0.0 ? 0.0 : x[i]) : x[i]-gamma[i]
-		fsum += y[i] > 0.0 ? y[i] : 0.0
-	end
-	return fsum
+    fsum = 0.0
+    for i in eachindex(x)
+        y[i] = x[i] < gamma[i] ? (x[i] > 0.0 ? 0.0 : x[i]) : x[i]-gamma[i]
+        fsum += y[i] > 0.0 ? y[i] : 0.0
+    end
+    return fsum
 end
 
 function prox_naive(f::SumPositive, x::AbstractArray{T}, gamma::AbstractArray{T}) where T <: Real
-	y = copy(x)
-	indpos = x .> 0.0
-	y[indpos] = max.(0.0, x[indpos] .- gamma[indpos])
-	return y, sum(max.(0.0, y))
+    y = copy(x)
+    indpos = x .> 0.0
+    y[indpos] = max.(0.0, x[indpos] .- gamma[indpos])
+    return y, sum(max.(0.0, y))
 end

--- a/src/functions/sumPositive.jl
+++ b/src/functions/sumPositive.jl
@@ -5,7 +5,7 @@ export SumPositive
 """
 **Sum of the positive coefficients**
 
-    SumPositive()
+	SumPositive()
 
 Returns the function
 ```math
@@ -18,21 +18,21 @@ is_separable(f::SumPositive) = true
 is_convex(f::SumPositive) = true
 
 function (f::SumPositive)(x::AbstractArray{T}) where T <: Real
-  return sum(xi -> max(xi,0), x)
+	return sum(xi -> max(xi,0), x)
 end
 
 function prox!(y::AbstractArray{T}, f::SumPositive, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-  fsum = 0.0
-  for i in eachindex(x)
-    y[i] = x[i] < gamma ? (x[i] > 0.0 ? 0.0 : x[i]) : x[i]-gamma
-    fsum += y[i] > 0.0 ? y[i] : 0.0
-  end
-  return fsum
+	fsum = 0.0
+	for i in eachindex(x)
+		y[i] = x[i] < gamma ? (x[i] > 0.0 ? 0.0 : x[i]) : x[i]-gamma
+		fsum += y[i] > 0.0 ? y[i] : 0.0
+	end
+	return fsum
 end
 
 function gradient!(y::AbstractArray{T}, f::SumPositive, x::AbstractArray{T}) where T <: Real
-  y .= max.(0, sign.(x))
-  return sum(xi -> max(xi,0), x)
+	y .= max.(0, sign.(x))
+	return sum(xi -> max(xi,0), x)
 end
 
 fun_name(f::SumPositive) = "Sum of the positive coefficients"
@@ -40,10 +40,10 @@ fun_dom(f::SumPositive) = "AbstractArray{Real}"
 fun_expr(f::SumPositive) = "x ↦ sum(max(0, x))"
 
 function prox_naive(f::SumPositive, x::AbstractArray{T}, gamma::Real=1.0) where T <: Real
-  y = copy(x)
-  indpos = x .> 0.0
-  y[indpos] = max.(0.0, x[indpos] .- gamma)
-  return y, sum(max.(0.0, y))
+	y = copy(x)
+	indpos = x .> 0.0
+	y[indpos] = max.(0.0, x[indpos] .- gamma)
+	return y, sum(max.(0.0, y))
 end
 
 # ######################### #
@@ -51,17 +51,17 @@ end
 # ######################### #
 
 function prox!(y::AbstractArray{T}, f::SumPositive, x::AbstractArray{T}, gamma::AbstractArray{T}) where T <: Real
-  fsum = 0.0
-  for i in eachindex(x)
-    y[i] = x[i] < gamma[i] ? (x[i] > 0.0 ? 0.0 : x[i]) : x[i]-gamma[i]
-    fsum += y[i] > 0.0 ? y[i] : 0.0
-  end
-  return fsum
+	fsum = 0.0
+	for i in eachindex(x)
+		y[i] = x[i] < gamma[i] ? (x[i] > 0.0 ? 0.0 : x[i]) : x[i]-gamma[i]
+		fsum += y[i] > 0.0 ? y[i] : 0.0
+	end
+	return fsum
 end
 
 function prox_naive(f::SumPositive, x::AbstractArray{T}, gamma::AbstractArray{T}) where T <: Real
-  y = copy(x)
-  indpos = x .> 0.0
-  y[indpos] = max.(0.0, x[indpos] .- gamma[indpos])
-  return y, sum(max.(0.0, y))
+	y = copy(x)
+	indpos = x .> 0.0
+	y[indpos] = max.(0.0, x[indpos] .- gamma[indpos])
+	return y, sum(max.(0.0, y))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ function call_test(f, x::ArrayOrTuple{R}) where R <: Real
 end
 
 # tests equality of the results of prox, prox! and prox_naive
-function prox_test(f, x::ArrayOrTuple{R}, gamma=one(R)) where R <: Real
+function prox_test(f, x::ArrayOrTuple{R}, gamma=R(1)) where R <: Real
     y, fy = prox(f, x, gamma)
 
     @test typeof(fy) == R

--- a/test/test_calls.jl
+++ b/test/test_calls.jl
@@ -151,8 +151,8 @@ stuff = [
 
   Dict( "constr" => IndSphereL2,
         "wrong"  => ( (-rand(),), ),
-        "params" => ( (rand(),), (sqrt(20),) ),
-        "args"   => ( randn(10), randn(20) )
+        "params" => ( (rand(),), (sqrt(20),), (1,), (1,) ),
+        "args"   => ( randn(10), randn(20), 1e-3*randn(10), randn(Complex{Float64}, 10) )
       ),
 
   Dict( "constr" => IndPSD,

--- a/test/test_calls.jl
+++ b/test/test_calls.jl
@@ -46,20 +46,20 @@ stuff = [
 
   Dict( "constr" => IndBallL0,
         "wrong"  => ( (-4,), ),
-        "params" => ( (5,), (5,), (10, ) ),
-        "args"   => ( randn(25), randn(35), randn(10, 10) )
+        "params" => ( (5,), (5,), (10, ), (5, ) ),
+        "args"   => ( randn(25), randn(35), randn(10, 10), randn(Complex{Float64}, 15) )
       ),
 
   Dict( "constr" => IndBallL1,
         "wrong"  => ( (-rand(),), ),
-        "params" => ( (), (3.0,), (0.4,), (rand() + 0.1,), (rand() + 0.1,) ),
-        "args"   => ( rand(15), randn(25), randn(35), randn(60), randn(20,30) )
+        "params" => ( (), (3.0,), (0.4,), (rand() + 0.1,), (rand() + 0.1,), (1.0,) ),
+        "args"   => ( rand(15), randn(25), randn(35), randn(60), randn(20,30), randn(Complex{Float64}, 20) )
       ),
 
   Dict( "constr" => IndBallL2,
         "wrong"  => ( (-rand(),), ),
-        "params" => ( (rand(),), (sqrt(20),), (0.5,) ),
-        "args"   => ( randn(10), randn(20), 0.1*ones(10) )
+        "params" => ( (rand(),), (sqrt(20),), (0.5,), (1.0, ) ),
+        "args"   => ( randn(10), randn(20), 0.1*ones(10), randn(Complex{Float64}, 20) )
       ),
 
   Dict( "constr" => IndBallRank,
@@ -109,8 +109,8 @@ stuff = [
       ),
 
   Dict( "constr" => IndPoint,
-        "params" => ( (), (randn(20), ) ),
-        "args"   => ( randn(10), randn(20) )
+        "params" => ( (), (randn(20),), (randn(Complex{Float64}, 20),) ),
+        "args"   => ( randn(10), randn(20), randn(Complex{Float64}, 20) )
       ),
 
   Dict( "constr" => IndZero,


### PR DESCRIPTION
**Breaking:**
* Changed default constructor arguments for `IndBinary`: with zero arguments, it will still use `low=0.0` and `high=1.0`, but giving one argument only is not allowed anymore.

**Major:**
* Fixed typing issues in several functions (both in the signatures and in the body), and adding tests for some of them.

**Minor:**
* Indentation set to four spaces across most of `src/`, as suggested by
  1. https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md
  2. https://github.com/johnmyleswhite/Style.jl
* Typed 0, 1, and infinity literals are now uniformly denoted as `R(0)`, `R(1)`, and `R(Inf)` respectively, for `R <: Real`.
* Coveralls was removed from the Travis CI config, CodeCov is enough for the job: code coverage in Julia is currently flawed, so it doesn't make sense to report it to *two* services. This way we also lower the chance of getting unjustified red flags on PRs, like it has happened for several commits in this PR.