### PR TITLE
Added Transpose and Adjoint functions for LeastSquaresDirect

### DIFF
--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -11,6 +11,7 @@ const ArrayOrTuple{R} = Union{
     AbstractArray{C, N} where {C <: RealOrComplex{R}, N},
     TupleOfArrays{R}
 }
+const TransposeOrAdjoint{M} = Union{Transpose{C,M} where C, Adjoint{C,M} where C}
 
 export ProximableFunction
 export prox, prox!, gradient, gradient!

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -108,7 +108,7 @@ function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F},
     end
 end
 
-function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}, gamma::R) where {R, C, M, V, F <: SuiteSparse.CHOLMOD.Factor{C}}
+function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}, gamma::R) where {R, C, M, V, F}
     lamgam = f.lambda*gamma
     f.q .= f.Atb .+ x./lamgam
     # two cases: (1) tall A, (2) fat A

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -76,7 +76,7 @@ function prox!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::Ab
     return (f.lambda/2)*norm(f.res, 2)^2
 end
 
-function factor_step!(f::LeastSquaresDirect{R, C, M, V, F}, gamma::R) where {R, C, M <: DenseMatrix, V, F}
+function factor_step!(f::LeastSquaresDirect{R, C, M, V, F}, gamma::R) where {R, C, M, V, F}
     lamgam = f.lambda*gamma
     f.fact = cholesky(f.S + I/lamgam)
     f.gamma = gamma

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -45,8 +45,17 @@ function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{
     LeastSquaresDirect{R, C, M, V, SuiteSparse.CHOLMOD.Factor{C}}(A, b, lambda)
 end
 
+# Adjoint/Transpose versions
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: TransposeOrAdjoint{<:DenseMatrix{C}}, V <: AbstractVector{C}}
+    LeastSquaresDirect(copy(A), b, lambda)
+end
+
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: TransposeOrAdjoint{<:SparseMatrixCSC{C, I}}, V <: AbstractVector{C}}
+    LeastSquaresDirect(copy(A), b, lambda)
+end
+
 function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: AbstractMatrix{C}, V <: AbstractVector{C}}
-    warn("Could not infer type of Factorization for $M in LeastSquaresDirect, this type will be type-unstable")
+    @warn "Could not infer type of Factorization for $M in LeastSquaresDirect, this type will be type-unstable"
     LeastSquaresDirect{R, C, M, V, Factorization}(A, b, lambda)
 end
 

--- a/test/test_leastSquares.jl
+++ b/test/test_leastSquares.jl
@@ -261,3 +261,70 @@ grad_gx, gx = gradient(g, x)
 call_test(g, x)
 prox_test(g, x)
 prox_test(g, x, 2.1)
+
+# Tall full adjoint matrix
+
+m, n = 30, 10
+A = randn(n, m)
+b = randn(m)
+x = randn(n)
+
+f = LeastSquares(A', b)
+@test ProximalOperators.is_smooth(f) == true
+@test ProximalOperators.is_quadratic(f) == true
+@test ProximalOperators.is_generalized_quadratic(f) == true
+@test ProximalOperators.is_convex(f) == true
+
+grad_fx, fx = gradient(f, x)
+lsres = A'*x - b
+@test abs(fx - 0.5*norm(lsres)^2) <= 1e-12
+@test norm(grad_fx - (A*lsres), Inf) <= 1e-12
+
+call_test(f, x)
+prox_test(f, x)
+prox_test(f, x, 1.5)
+
+lam = 0.1 + rand()
+f = LeastSquares(A', b, lam)
+@test ProximalOperators.is_smooth(f) == true
+@test ProximalOperators.is_quadratic(f) == true
+@test ProximalOperators.is_generalized_quadratic(f) == true
+@test ProximalOperators.is_convex(f) == true
+
+grad_fx, fx = gradient(f, x)
+@test abs(fx - (lam/2)*norm(lsres)^2) <= 1e-12
+@test norm(grad_fx - lam*(A*lsres), Inf) <= 1e-12
+
+call_test(f, x)
+prox_test(f, x)
+prox_test(f, x, 2.1)
+
+
+# Wide sparse adjoint matrix
+
+m, n = 10, 30
+A = sprandn(n, m, 0.5)
+b = randn(m)
+x = randn(n)
+
+f = LeastSquares(A', b)
+
+grad_fx, fx = gradient(f, x)
+lsres = A'*x - b
+@test abs(fx - 0.5*norm(lsres)^2) <= 1e-12
+@test norm(grad_fx - (A*lsres), Inf) <= 1e-12
+
+call_test(f, x)
+prox_test(f, x)
+prox_test(f, x, 1.5)
+
+lam = 0.1 + rand()
+f = LeastSquares(A', b, lam)
+
+grad_fx, fx = gradient(f, x)
+@test abs(fx - (lam/2)*norm(lsres)^2) <= 1e-12
+@test norm(grad_fx - lam*(A*lsres), Inf) <= 1e-12
+
+call_test(f, x)
+prox_test(f, x)
+prox_test(f, x, 2.1)


### PR DESCRIPTION
`LeastSquares(A', b, lambda)` threw an error since `warn` is not defined.

Updated to `@warn` macro to fix bug, and added case to catch Adjoint and Transposes by dong a copy.

Copy was needed since the type is defined to have:
`A::M` and `S::M` where `S = A'*A`, which does not hold for transposes/adjoints.