### PR TITLE
Fix implementations of epi-composition

### DIFF
--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -12,6 +12,7 @@ const ArrayOrTuple{R} = Union{
     TupleOfArrays{R}
 }
 const TransposeOrAdjoint{M} = Union{Transpose{C,M} where C, Adjoint{C,M} where C}
+const Maybe{T} = Union{T, Nothing}
 
 export ProximableFunction
 export prox, prox!, gradient, gradient!
@@ -69,7 +70,7 @@ include("functions/crossEntropy.jl")
 # Calculus rules
 
 include("calculus/conjugate.jl")
-# include("calculus/epicompose.jl")
+include("calculus/epicompose.jl")
 include("calculus/distL2.jl")
 include("calculus/moreauEnvelope.jl")
 include("calculus/postcompose.jl")

--- a/src/calculus/conjugate.jl
+++ b/src/calculus/conjugate.jl
@@ -68,3 +68,5 @@ function prox_naive(g::Conjugate, x::AbstractArray{T}, gamma=R(1)) where {R, T <
     y, v = prox_naive(g.f, x/gamma, 1/gamma)
     return x - gamma * y, real(dot(x, y)) - gamma * real(dot(y, y)) - v
 end
+
+# TODO: hard-code conjugation rules? E.g. precompose/epicompose

--- a/src/calculus/epicomposeGramDiagonal.jl
+++ b/src/calculus/epicomposeGramDiagonal.jl
@@ -1,0 +1,35 @@
+using LinearAlgebra
+
+mutable struct EpicomposeGramDiagonal{M, P, R} <: Epicompose
+    L::M
+    f::P
+    mu::R
+    function EpicomposeGramDiagonal{M, P, R}(L::M, f::P, mu::R) where {
+        R <: Real, C <: Union{R, Complex{R}}, M <: AbstractMatrix{C}, P <: ProximableFunction
+    }
+        if mu <= 0
+            error("mu must be positive")
+        end
+        new(L, f, mu)
+    end
+end
+
+EpicomposeGramDiagonal(L, f, mu) = EpicomposeGramDiagonal{typeof(L), typeof(f), typeof(mu)}(L, f, mu)
+
+function prox!(y::AbstractArray{C}, g::EpicomposeGramDiagonal, x::AbstractArray{C}, gamma::R=one(R)) where {
+    R <: Real, C <: Union{R, Complex{R}}
+}
+    z = (g.L'*x)/g.mu
+    p, v = prox(g.f, z, gamma/g.mu)
+    mul!(y, g.L, p)
+    return v
+end
+
+function prox_naive(g::EpicomposeGramDiagonal, x::AbstractArray{C}, gamma::R=one(R)) where {
+    R <: Real, C <: Union{R, Complex{R}}
+}
+    z = (g.L'*x)/g.mu
+    p, v = prox_naive(g.f, z, gamma/g.mu)
+    y = g.L*p
+    return y, v
+end

--- a/src/calculus/epicomposeQuadratic.jl
+++ b/src/calculus/epicomposeQuadratic.jl
@@ -1,0 +1,64 @@
+using LinearAlgebra
+
+mutable struct EpicomposeQuadratic{F, M, P, V, R} <: Epicompose
+    L::M
+    Q::P
+    q::V
+    gamma::Maybe{R}
+    fact::Maybe{F}
+    function EpicomposeQuadratic{F, M, P, V, R}(L::M, Q::P, q::V) where {
+        R <: Real,
+        M <: AbstractMatrix{R},
+        P <: AbstractMatrix{R},
+        V <: AbstractVector{R},
+        F <: Factorization,
+    }
+        new(L, Q, q, nothing, nothing)
+    end
+end
+
+function EpicomposeQuadratic(L, Q::P, q) where {R, P <: DenseMatrix{R}}
+    return EpicomposeQuadratic{
+        LinearAlgebra.Cholesky{R}, typeof(L), P, typeof(q), real(eltype(L))
+    }(L, Q, q)
+end
+
+function EpicomposeQuadratic(L, Q::P, q) where {R, P <: SparseMatrixCSC{R}}
+    return EpicomposeQuadratic{
+        SuiteSparse.CHOLMOD.Factor{R}, typeof(L), P, typeof(q), real(eltype(L))
+    }(L, Q, q)
+end
+
+# TODO: enable construction from other types of quadratics, e.g. LeastSquares
+# TODO: probably some access methods are needed to obtain Hessian and linear term?
+
+function EpicomposeQuadratic(L, f::Q) where {Q <: Quadratic}
+    return EpicomposeQuadratic(L, f.Q, f.q)
+end
+
+function factor_step!(g::EpicomposeQuadratic, gamma::R) where {R <: Real}
+    g.gamma = gamma
+    g.fact = cholesky(g.Q + (g.L' * g.L)/gamma)
+end
+
+function prox!(y::AbstractArray{R}, g::EpicomposeQuadratic, x::AbstractArray{R}, gamma::R=one(R)) where {
+    R <: Real
+}
+    if g.gamma === nothing || !isapprox(gamma, g.gamma)
+        factor_step!(g, gamma)
+    end
+    p = g.fact\((g.L' * x) / gamma - g.q)
+    fy = dot(p, g.Q * p)/2 + dot(p, g.q)
+    mul!(y, g.L, p)
+    return fy
+end
+
+function prox_naive(g::EpicomposeQuadratic, x::AbstractArray{R}, gamma::R=one(R)) where {
+    R <: Real
+}
+    S = g.Q + (g.L' * g.L) / gamma
+    p = S\((g.L' * x) / gamma - g.q)
+    fy = dot(p, g.Q * p)/2 + dot(p, g.q)
+    y = g.L * p
+    return y, fy
+end

--- a/src/calculus/precompose.jl
+++ b/src/calculus/precompose.jl
@@ -11,11 +11,17 @@ Returns the function
 ```math
 g(x) = f(Lx + b)
 ```
-where ``f`` is a convex function and ``L`` is a linear mapping: this must satisfy ``LL^* = μI`` for ``μ ⩾ 0``. Furthermore, either ``f`` is separable or parameter `μ` is a scalar, for the `prox` of ``g`` to be computable.
+where ``f`` is a convex function and ``L`` is a linear mapping: this must
+satisfy ``LL^* = μI`` for ``μ > 0``. Furthermore, either ``f`` is separable or
+parameter `μ` is a scalar, for the `prox` of ``g`` to be computable.
 
-Parameter `L` defines ``L`` through the `mul!` method. Therefore `L` can be an `AbstractMatrix` for example, but not necessarily.
+Parameter `L` defines ``L`` through the `mul!` method. Therefore `L` can be an
+`AbstractMatrix` for example, but not necessarily.
 
-In this case, `prox` and `prox!` are computed according to Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd edition, 2016. The same result is Prop. 23.32 in the 1st edition of the same book.
+In this case, `prox` and `prox!` are computed according to Prop. 24.14 in
+Bauschke, Combettes "Convex Analysis and Monotone Operator Theory in Hilbert
+Spaces", 2nd edition, 2016. The same result is Prop. 23.32 in the 1st edition
+of the same book.
 """
 struct Precompose{T <: ProximableFunction, R <: Real, C <: Union{R, Complex{R}}, U <: Union{C, AbstractArray{C}}, V <: Union{C, AbstractArray{C}}, M} <: ProximableFunction
     f::T
@@ -61,7 +67,7 @@ function gradient!(y::AbstractArray{T}, g::Precompose, x::AbstractArray{T}) wher
 end
 
 function prox!(y::AbstractArray{C}, g::Precompose, x::AbstractArray{C}, gamma::R=R(1)) where {R <: Real, C <: Union{R, Complex{R}}}
-    # See Prop. 24.14 in Bauschke, Combettes "Convex Analisys and Monotone Operator Theory in Hilbert Spaces", 2nd ed., 2016.
+    # See Prop. 24.14 in Bauschke, Combettes "Convex Analysis and Monotone Operator Theory in Hilbert Spaces", 2nd ed., 2016.
     # The same result is Prop. 23.32 in the 1st ed. of the same book.
     #
     # This case has an additional translation: if f(x) = h(x + b) then

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,7 @@ end
 
 @testset "Calculus rules" begin
   include("test_calculus.jl")
+  include("test_epicompose.jl")
   include("test_moreauEnvelope.jl")
   include("test_precompose.jl")
   include("test_pointwiseMinimum.jl")

--- a/test/test_cubeNormL2.jl
+++ b/test/test_cubeNormL2.jl
@@ -2,8 +2,6 @@ using Test
 using Random
 using ProximalOperators
 
-Random.seed!(0)
-
 @testset "CubeNormL2" begin
 
 for R in [Float16, Float32, Float64]

--- a/test/test_epicompose.jl
+++ b/test/test_epicompose.jl
@@ -1,0 +1,51 @@
+using Test
+using LinearAlgebra
+using SparseArrays
+using ProximalOperators
+
+@testset "Epicompose (Gram-diagonal)" begin
+
+n = 5
+
+for R in [Float64] # TODO: enable Float32?
+    for T in [R, Complex{R}]
+        A = randn(T, n, n)
+        Q, _ = qr(A)
+        mu = R(2)
+        L = mu*Q
+        Lfs = [
+            (L, NormL1(R(1))),
+            (sparse(L), NormL1(R(1))),
+        ]
+        for (L, f) in Lfs
+            g = Epicompose(L, f, mu)
+            x = randn(T, n)
+            prox_test(g, x, R(2))
+        end
+    end
+end
+
+end
+
+@testset "Epicompose (Quadratic)" begin
+
+n = 5
+m = 3
+
+for R in [Float64] # TODO: enable Float32?
+    W = randn(R, n, n)
+    Q = W' * W
+    q = randn(R, n)
+    L = randn(R, m, n)
+    Lfs = [
+        (L, Quadratic(Q, q)),
+        (sparse(L), Quadratic(sparse(Q), q)),
+    ]
+    for (L, f) in Lfs
+        g = Epicompose(L, f)
+        x = randn(R, m)
+        prox_test(g, x, R(2))
+    end
+end
+
+end


### PR DESCRIPTION
This PR fixes the implementation of epi-composition in case f is quadratic or L'L = mu*I, following the implementation in https://github.com/kul-forbes/drn/tree/master/%40EpiCompose

The quadratic case could be generalized to other types of quadratic f, not just Quadratic, but this is left to future PRs.