### PR TITLE
Make prox on QuadraticDirect type stable

### DIFF
--- a/src/functions/quadraticDirect.jl
+++ b/src/functions/quadraticDirect.jl
@@ -25,7 +25,7 @@ function QuadraticDirect(Q::M, q::V) where {R <: Real, I <: Integer, M <: Sparse
 end
 
 function QuadraticDirect(Q::M, q::V) where {R <: Real, M <: DenseMatrix{R}, V <: AbstractVector{R}}
-    QuadraticDirect{R, M, V, Cholesky{R, typeof(Q)}}(Q, q)
+    QuadraticDirect{R, M, V, Cholesky{R, M}}(Q, q)
 end
 
 function (f::QuadraticDirect{R, M, V, F})(x::AbstractArray{R}) where {R, M, V, F}

--- a/src/functions/quadraticDirect.jl
+++ b/src/functions/quadraticDirect.jl
@@ -25,7 +25,7 @@ function QuadraticDirect(Q::M, q::V) where {R <: Real, I <: Integer, M <: Sparse
 end
 
 function QuadraticDirect(Q::M, q::V) where {R <: Real, M <: DenseMatrix{R}, V <: AbstractVector{R}}
-    QuadraticDirect{R, M, V, Cholesky{R}}(Q, q)
+    QuadraticDirect{R, M, V, Cholesky{R, typeof(Q)}}(Q, q)
 end
 
 function (f::QuadraticDirect{R, M, V, F})(x::AbstractArray{R}) where {R, M, V, F}


### PR DESCRIPTION
`Cholesky{R}` is an abstract type if the second type parameter is not specified. With this fix, a significant speedup is obtained for small Q where the dynamic dispatch is relatively expensive.