### PR TITLE
Fix nonconvex cases in PrecomposeDiagonal and LeastSquares

### DIFF
--- a/src/calculus/precomposeDiagonal.jl
+++ b/src/calculus/precomposeDiagonal.jl
@@ -11,20 +11,19 @@ Returns the function
 ```math
 g(x) = f(\\mathrm{diag}(a)x + b)
 ```
-where ``f`` is a convex function. Function ``f`` must be separable,
-or `a` must be a scalar, for the `prox` of ``g`` to be computable.
-Parametes `a` and `b` can be arrays of multiple dimensions, according to
-the shape/size of the input `x` that will be provided to the function:
-the way the above expression for ``g`` should be thought of, is
-`g(x) = f(a.*x + b)`.
+Function ``f`` must be convex and separable, or `a` must be a scalar, for the
+`prox` of ``g`` to be computable. Parametes `a` and `b` can be arrays of
+multiple dimensions, according to the shape/size of the input `x` that will be
+provided to the function: the way the above expression for ``g`` should be
+thought of, is `g(x) = f(a.*x + b)`.
 """
 struct PrecomposeDiagonal{T <: ProximableFunction, R <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}} <: ProximableFunction
     f::T
     a::R
     b::S
     function PrecomposeDiagonal{T,R,S}(f::T, a::R, b::S) where {T <: ProximableFunction, R <: Union{Real, AbstractArray}, S <: Union{Real, AbstractArray}}
-        if !is_convex(f)
-            error("`f` must be convex")
+        if R <: AbstractArray && !(is_convex(f) && is_separable(f))
+            error("`f` must be convex and separable since `a` is of type $(R)")
         end
         if !(eltype(a) <: Real)
             error("`a` must have real elements")

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -10,9 +10,9 @@ using SuiteSparse
 mutable struct LeastSquaresDirect{R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractVector{C}, F <: Factorization} <: LeastSquares
     A::M # m-by-n matrix
     b::V
-    Atb::V
     lambda::R
-    gamma::R
+    lambdaAtb::V
+    gamma::Union{Nothing, R}
     shape::Symbol
     S::M
     res::Vector{C} # m-sized buffer
@@ -22,23 +22,20 @@ mutable struct LeastSquaresDirect{R <: Real, C <: RealOrComplex{R}, M <: Abstrac
         if size(A, 1) != length(b)
             error("A and b have incompatible dimensions")
         end
-        if lambda == 0
-            error("lambda must be nonzero")
-        end
         m, n = size(A)
         if m >= n
-            S = A'*A
+            S = lambda * (A' * A)
             shape = :Tall
         else
-            S = A*A'
+            S = lambda * (A * A')
             shape = :Fat
         end
-        new(A, b, A'*b, lambda, -1, shape, S, zeros(C, m), zeros(C, n))
+        new(A, b, lambda, lambda*(A'*b), nothing, shape, S, zeros(C, m), zeros(C, n))
     end
 end
 
-is_convex(f::LeastSquaresDirect) = f.lambda > 0
-is_concave(f::LeastSquaresDirect) = f.lambda < 0
+is_convex(f::LeastSquaresDirect) = f.lambda >= 0
+is_concave(f::LeastSquaresDirect) = f.lambda <= 0
 
 function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: DenseMatrix{C}, V <: AbstractVector{C}}
     LeastSquaresDirect{R, C, M, V, Cholesky{C, M}}(A, b, lambda)
@@ -65,7 +62,7 @@ end
 function (f::LeastSquaresDirect)(x::AbstractVector)
     mul!(f.res, f.A, x)
     f.res .-= f.b
-    return (f.lambda/2)*norm(f.res, 2)^2
+    return (f.lambda / 2) * norm(f.res, 2)^2
 end
 
 function prox!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}, gamma::R=R(1)) where {R, C, M, V, F}
@@ -80,20 +77,17 @@ function prox!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::Ab
 end
 
 function factor_step!(f::LeastSquaresDirect{R, C, M, V, F}, gamma::R) where {R, C, M, V, F}
-    lamgam = f.lambda*gamma
-    f.fact = cholesky(f.S + I/lamgam)
+    f.fact = cholesky(f.S + I/gamma)
     f.gamma = gamma
 end
 
 function factor_step!(f::LeastSquaresDirect{R, C, M, V, F}, gamma::R) where {R, C, M <: SparseMatrixCSC, V, F}
-    lamgam = f.lambda*gamma
-    f.fact = ldlt(f.S; shift = R(1)/lamgam)
+    f.fact = ldlt(f.S; shift = R(1)/gamma)
     f.gamma = gamma
 end
 
 function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}, gamma::R) where {R, C, M, V, F <: Cholesky{C, M}}
-    lamgam = f.lambda*gamma
-    f.q .= f.Atb .+ x./lamgam
+    f.q .= f.lambdaAtb .+ x./gamma
     # two cases: (1) tall A, (2) fat A
     if f.shape == :Tall
         # y .= f.fact\f.q
@@ -101,29 +95,30 @@ function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F},
         LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, y)
         LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, y)
     else # f.shape == :Fat
-        # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+        # y .= gamma*(f.q - lambda*(f.A'*(f.fact\(f.A*f.q))))
         mul!(f.res, f.A, f.q)
         LAPACK.trtrs!('U', 'C', 'N', f.fact.factors, f.res)
         LAPACK.trtrs!('U', 'N', 'N', f.fact.factors, f.res)
         mul!(y, adjoint(f.A), f.res)
-        y .-= f.q
-        y .*= -lamgam
+        y .*= -f.lambda
+        y .+= f.q
+        y .*= gamma
     end
 end
 
 function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}, gamma::R) where {R, C, M, V, F}
-    lamgam = f.lambda*gamma
-    f.q .= f.Atb .+ x./lamgam
+    f.q .= f.lambdaAtb .+ x./gamma
     # two cases: (1) tall A, (2) fat A
     if f.shape == :Tall
         y .= f.fact\f.q
     else # f.shape == :Fat
-        # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+        # y .= gamma*(f.q - lambda*(f.A'*(f.fact\(f.A*f.q))))
         mul!(f.res, f.A, f.q)
         f.res .= f.fact\f.res
         mul!(y, adjoint(f.A), f.res)
-        y .-= f.q
-        y .*= -lamgam
+        y .*= -f.lambda
+        y .+= f.q
+        y .*= gamma
     end
 end
 
@@ -137,7 +132,7 @@ end
 
 function prox_naive(f::LeastSquaresDirect{R, C}, x::AbstractVector{C}, gamma::R=R(1)) where {R, C <: RealOrComplex{R}}
     lamgam = f.lambda*gamma
-    y = (f.A'*f.A + I/lamgam)\(f.Atb + x/lamgam)
+    y = (f.A'*f.A + I/lamgam)\(f.A' * f.b + x/lamgam)
     fy = (f.lambda/2)*norm(f.A*y-f.b)^2
     return y, fy
 end

--- a/src/functions/leastSquaresIterative.jl
+++ b/src/functions/leastSquaresIterative.jl
@@ -1,14 +1,14 @@
 ### CONCRETE TYPE: ITERATIVE PROX EVALUATION
-# prox! is computed using CG on a system with matrix A'A + I/(lambda*gamma)
-# or AA' + I/(lambda*gamma), according to which matrix is smaller.
+# prox! is computed using CG on a system with matrix lambda*A'A + I/gamma
+# or lambda*AA' + I/gamma, according to which matrix is smaller.
 
 using LinearAlgebra
 
 struct LeastSquaresIterative{R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractVector{RC}, O} <: LeastSquares
     A::M # m-by-n operator
     b::V
-    Atb::V
     lambda::R
+    lambdaAtb::V
     shape::Symbol
     S::O
     res::Vector{RC} # m-sized buffer
@@ -17,25 +17,22 @@ struct LeastSquaresIterative{R <: Real, RC <: RealOrComplex{R}, M, V <: Abstract
 end
 
 is_prox_accurate(f::LeastSquaresIterative) = false
-is_convex(f::LeastSquaresIterative) = f.lambda > 0
-is_concave(f::LeastSquaresIterative) = f.lambda < 0
+is_convex(f::LeastSquaresIterative) = f.lambda >= 0
+is_concave(f::LeastSquaresIterative) = f.lambda <= 0
 
 function LeastSquaresIterative(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractVector{RC}}
     if size(A, 1) != length(b)
         error("A and b have incompatible dimensions")
     end
-    if lambda == 0
-        error("lambda must nonzero")
-    end
     m, n = size(A)
     if m >= n
         shape = :Tall
         S = AcA(A)
-        LeastSquaresIterative{R, RC, M, V, AcA}(A, b, A'*b, lambda, shape, S, zeros(RC, m), [], zeros(RC, n))
+        LeastSquaresIterative{R, RC, M, V, AcA}(A, b, lambda, lambda*(A'*b), shape, S, zeros(RC, m), [], zeros(RC, n))
     else
         shape = :Fat
         S = AAc(A)
-        LeastSquaresIterative{R, RC, M, V, AAc}(A, b, A'*b, lambda, shape, S, zeros(RC, m), zeros(RC, m), zeros(RC, n))
+        LeastSquaresIterative{R, RC, M, V, AAc}(A, b, lambda, lambda*(A'*b), shape, S, zeros(RC, m), zeros(RC, m), zeros(RC, n))
     end
 end
 
@@ -46,21 +43,21 @@ function (f::LeastSquaresIterative{R, RC, M, V})(x::AbstractVector{RC}) where {R
 end
 
 function prox!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}, gamma::R=R(1)) where {R, RC, M, V, D <: RealOrComplex{R}}
-    lamgam = f.lambda*gamma
-    f.q .= f.Atb .+ x./lamgam
+    f.q .= f.lambdaAtb .+ x./gamma
     # two cases: (1) tall A, (2) fat A
     if f.shape == :Tall
         y .= x
-        op = Shift(f.S, R(1)/lamgam)
+        op = ScaleShift(f.lambda, f.S, R(1)/gamma)
         IterativeSolvers.cg!(y, op, f.q)
     else # f.shape == :Fat
-        # y .= lamgam*(f.q - (f.A'*(f.fact\(f.A*f.q))))
+        # y .= gamma*(f.q - lambda*(f.A'*(f.fact\(f.A*f.q))))
         mul!(f.res, f.A, f.q)
-        op = Shift(f.S, R(1)/lamgam)
+        op = ScaleShift(f.lambda, f.S, R(1)/gamma)
         IterativeSolvers.cg!(f.res2, op, f.res)
         mul!(y, adjoint(f.A), f.res2)
-        y .-= f.q
-        y .*= -lamgam
+        y .*= -f.lambda
+        y .+= f.q
+        y .*= gamma
     end
     mul!(f.res, f.A, y)
     f.res .-= f.b
@@ -76,8 +73,7 @@ function gradient!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, 
 end
 
 function prox_naive(f::LeastSquaresIterative, x::AbstractVector{D}, gamma::R=R(1)) where {R, D <: RealOrComplex{R}}
-    lamgam = f.lambda*gamma
-    y = IterativeSolvers.cg(f.A'*f.A + I/lamgam, f.Atb + x/lamgam)
+    y = IterativeSolvers.cg(f.lambda*f.A'*f.A + I/gamma, f.lambda*f.A'*f.b + x/gamma)
     fy = (f.lambda/2)*norm(f.A*y-f.b)^2
     return y, fy
 end

--- a/src/functions/quadraticIterative.jl
+++ b/src/functions/quadraticIterative.jl
@@ -26,7 +26,7 @@ end
 function prox!(y::AbstractArray{R}, f::QuadraticIterative{R, M, V}, x::AbstractArray{R}, gamma::R=R(1)) where {R, M, V}
     y .= x
     f.temp .= x./gamma .- f.q
-    op = Shift(f.Q, R(1)/gamma)
+    op = ScaleShift(R(1), f.Q, R(1)/gamma)
     IterativeSolvers.cg!(y, op, f.temp)
     mul!(f.temp, f.Q, y)
     fy = 0.5*dot(y, f.temp) + dot(y, f.q)

--- a/src/utilities/linops.jl
+++ b/src/utilities/linops.jl
@@ -63,28 +63,31 @@ eltype(Op::AcA) = eltype(Op.A)
 
 # Shifted symmetric linear operator
 
-struct Shift{M, T} <: LinOp
+struct ScaleShift{M, T} <: LinOp
+  alpha::T
   A::M
   rho::T
-  function Shift{M, T}(A::M, rho::T) where {M, T}
+  function ScaleShift{M, T}(alpha::T, A::M, rho::T) where {M, T}
     if eltype(A) != T
-      error("type of rho is incompatible with A")
+      error("type of alpha, rho is incompatible with A")
     end
-    new(A, rho)
+    new(alpha, A, rho)
   end
 end
 
-Shift(A::M, rho::T) where {M, T} = Shift{M, T}(A, rho)
+ScaleShift(alpha::T, A::M, rho::T) where {M, T} = ScaleShift{M, T}(alpha, A, rho)
 
-function mul!(y, Op::Shift, x)
+function mul!(y, Op::ScaleShift, x)
   mul!(y, Op.A, x)
+  y .*= Op.alpha
   y .+= Op.rho .* x
 end
 
-function mul!(y, Op::Adjoint{Shift}, x)
+function mul!(y, Op::Adjoint{ScaleShift}, x)
   mul!(y, adjoint(Op.A), x)
+  y .*= Op.alpha
   y .+= Op.rho .* x
 end
 
-size(Op::Shift) = size(Op.A, 2), size(Op.A, 2)
-eltype(Op::Shift) = eltype(Op.A)
+size(Op::ScaleShift) = size(Op.A, 2), size(Op.A, 2)
+eltype(Op::ScaleShift) = eltype(Op.A)


### PR DESCRIPTION
PrecomposeDiagonal works fine for nonconvex f as long as the specified diagonal is a scalar (i.e. a constant diagonal). This PR is fixing the check that was raising an error instead.

**Edit:** Also, LeastSquares required some refactoring to work properly in the concave case (i.e. when lambda < 0).