### PR TITLE
Fix warnings and test failures on Julia 1.5

### DIFF
--- a/src/ProximalOperators.jl
+++ b/src/ProximalOperators.jl
@@ -113,6 +113,7 @@ is_singleton(f::ProximableFunction) = false
 is_cone(f::ProximableFunction) = false
 is_affine(f::ProximableFunction) = is_singleton(f)
 is_set(f::ProximableFunction) = is_cone(f) || is_affine(f)
+is_support(f::ProximableFunction) = is_convex(f) && is_cone(f)
 is_smooth(f::ProximableFunction) = false
 is_quadratic(f::ProximableFunction) = false
 is_generalized_quadratic(f::ProximableFunction) = is_quadratic(f) || is_affine(f)

--- a/src/calculus/conjugate.jl
+++ b/src/calculus/conjugate.jl
@@ -29,6 +29,8 @@ is_smooth(f::Conjugate) = is_strongly_convex(f.f)
 is_strongly_convex(f::Conjugate) = is_smooth(f.f)
 is_quadratic(f::Conjugate) = is_strongly_convex(f.f) && is_generalized_quadratic(f.f)
 is_generalized_quadratic(f::Conjugate) = is_quadratic(f.f)
+is_set(f::Conjugate) = is_convex(f.f) && is_support(f.f)
+is_support(f::Conjugate) = is_convex(f.f) && is_set(f.f)
 
 fun_dom(f::Conjugate) = fun_dom(f.f)
 
@@ -66,7 +68,7 @@ end
 
 function prox_naive(g::Conjugate, x::AbstractArray{T}, gamma=R(1)) where {R, T <: RealOrComplex{R}}
     y, v = prox_naive(g.f, x/gamma, 1/gamma)
-    return x - gamma * y, real(dot(x, y)) - gamma * real(dot(y, y)) - v
+    return x - gamma * y, if is_set(g) R(0) else real(dot(x, y)) - gamma * real(dot(y, y)) - v end
 end
 
 # TODO: hard-code conjugation rules? E.g. precompose/epicompose

--- a/src/functions/indSphereL2.jl
+++ b/src/functions/indSphereL2.jl
@@ -29,7 +29,7 @@ is_set(f::IndSphereL2) = true
 IndSphereL2(r::R=1.0) where {R <: Real} = IndSphereL2{R}(r)
 
 function (f::IndSphereL2)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
-    if abs(norm(x) - f.r) > f.r*eps(R)
+    if abs(norm(x) - f.r) / f.r > 100 * eps(R)
         return R(Inf)
     end
     return R(0)

--- a/src/functions/normL1.jl
+++ b/src/functions/normL1.jl
@@ -32,6 +32,7 @@ end
 
 is_separable(f::NormL1) = true
 is_convex(f::NormL1) = true
+is_support(f::NormL1) = true
 
 """
     NormL1(λ::Real=1.0)

--- a/src/functions/normL2.jl
+++ b/src/functions/normL2.jl
@@ -24,6 +24,7 @@ struct NormL2{R <: Real} <: ProximableFunction
 end
 
 is_convex(f::NormL2) = true
+is_support(f::NormL2) = true
 
 NormL2(lambda::R=1.0) where {R <: Real} = NormL2{R}(lambda)
 

--- a/src/utilities/tuples.jl
+++ b/src/utilities/tuples.jl
@@ -2,7 +2,7 @@
 
 import Base: isapprox, similar, zero
 
-isapprox(x::Tuple, y::Tuple) = all(isapprox.(x, y))
+isapprox(x::Tuple, y::Tuple, args...; kwargs...) = all(isapprox.(x, y, args...; kwargs...))
 
 similar(x::Tuple) = similar.(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ function prox_test(f, x::ArrayOrTuple{R}, gamma=R(1)) where R <: Real
 
     @test typeof(fy_naive) == R
     
-    rtol = sqrt(eps(R)) if ProximalOperators.is_prox_accurate(f) else 1e-4
+    rtol = if ProximalOperators.is_prox_accurate(f) sqrt(eps(R)) else 1e-4 end
 
     if ProximalOperators.is_convex(f)
         @test isapprox(y_prealloc, y, rtol=rtol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,11 +69,11 @@ end
 # i.e., that more specific properties imply less specific ones
 # e.g., the indicator of a subspace is the indicator of a set in particular
 function predicates_test(f)
-  # is_quadratic => is_(generalized_quadratic && smooth)
+  # quadratic => generalized_quadratic && smooth
   @test !is_quadratic(f) || (is_generalized_quadratic(f) && is_smooth(f))
-  # is_(singleton || cone || affine) => is_set
+  # (singleton || cone || affine) => set
   @test !(is_singleton(f) || is_cone(f) || is_affine(f)) || is_set(f)
-  # is_strongly_convex => is_convex
+  # strongly_convex => convex
   @test !is_strongly_convex(f) || is_convex(f)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,10 +44,12 @@ function prox_test(f, x::ArrayOrTuple{R}, gamma=R(1)) where R <: Real
     y_naive, fy_naive = ProximalOperators.prox_naive(f, x, gamma)
 
     @test typeof(fy_naive) == R
+    
+    rtol = sqrt(eps(R)) if ProximalOperators.is_prox_accurate(f) else 1e-4
 
     if ProximalOperators.is_convex(f)
-        @test y_prealloc ≈ y
-        @test y_naive ≈ y
+        @test isapprox(y_prealloc, y, rtol=rtol)
+        @test isapprox(y_naive, y, rtol=rtol)
         if ProximalOperators.is_set(f)
             @test fy_prealloc == 0
         end

--- a/test/test_calculus.jl
+++ b/test/test_calculus.jl
@@ -1,9 +1,8 @@
 # Test equivalence of functions and prox mappings by means of calculus rules
 
 using LinearAlgebra
-using Random
-
-Random.seed!(0)
+using ProximalOperators
+using Test
 
 stuff = [
   Dict( "funcs"  => (IndBallLinf(), Conjugate(NormL1())),
@@ -11,113 +10,113 @@ stuff = [
         "gammas" => ( 1.0, )
       ),
 
-  Dict( "funcs"  => (lambda -> (NormL1(lambda), Conjugate(IndBallLinf(lambda))))(0.1+10.0*rand()),
+  Dict( "funcs"  => (lambda -> (NormL1(lambda), Conjugate(IndBallLinf(lambda))))(0.1 + 10.0*rand()),
         "args"   => ( 5.0*sign.(randn(10)) + 5.0*randn(10),
                       5.0*sign.(randn(20)) + 5.0*randn(20) ),
         "gammas" => ( 0.5+rand(), 0.5+rand() )
       ),
-
-  Dict( "funcs"  => (lambda -> (IndBallLinf(lambda), Conjugate(NormL1(lambda))))(0.1+10.0*rand()),
+  
+  Dict( "funcs"  => (lambda -> (IndBallLinf(lambda), Conjugate(NormL1(lambda))))(0.1 + 10.0*rand()),
         "args"   => ( 5.0*sign.(randn(10)) + 5.0*randn(10),
                       5.0*sign.(randn(20)) + 5.0*randn(20) ),
         "gammas" => ( 0.5+rand(), 0.5+rand() )
       ),
-
+  
   Dict( "funcs"  => (lambda -> (NormL1(lambda), Conjugate(IndBox(-lambda,lambda))))(0.1 .+ 10.0*rand(30)),
         "args"   => ( 5.0*sign.(randn(30)) + 5.0*randn(30), ),
         "gammas" => ( 0.5+rand(), 0.5+rand() )
       ),
-
+  
   Dict( "funcs"  => (lambda -> (IndBox(-lambda,lambda), Conjugate(NormL1(lambda))))(0.1 .+ 10.0*rand(30)),
         "args"   => ( 5.0*sign.(randn(30)) + 5.0*randn(30), ),
         "gammas" => ( 0.5+rand(), 0.5+rand() )
       ),
-
+  
   Dict( "funcs"  => (lambda -> (NormL2(lambda), Conjugate(IndBallL2(lambda))))(0.1 .+ 10.0*rand()),
         "args"   => ( 5.0*sign.(randn(10)) + 5.0*randn(10),
                       5.0*sign.(randn(20)) + 5.0*randn(20) ),
         "gammas" => ( 0.5+rand(), 0.5+rand() )
       ),
-
+  
   Dict( "funcs"  => (lambda -> (IndBallL2(lambda), Conjugate(NormL2(lambda))))(0.1 .+ 10.0*rand()),
         "args"   => ( 5.0*sign.(randn(10)) + 5.0*randn(10),
                       5.0*sign.(randn(20)) + 5.0*randn(20) ),
         "gammas" => ( 0.5+rand(), 0.5+rand() )
       ),
-
+  
   Dict( "funcs"  => ((a, b, mu) -> (LogBarrier(a, b, mu), Postcompose(PrecomposeDiagonal(LogBarrier(), a, b), mu)))(2.0, 0.5, 1.0),
         "args"   => ( rand(10), rand(10) ),
         "gammas" => ( 0.5+rand(), 0.5+rand() )
       ),
-
+  
   Dict( "funcs"  => (p -> (IndPoint(p), IndBox(p, p)))(randn(50)),
         "args"   => ( randn(50), randn(50), randn(50) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => (IndZero(), IndBox(0, 0)),
         "args"   => ( randn(50), randn(50), randn(50) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => (IndFree(), IndBox(-Inf, +Inf)) ,
         "args"   => ( randn(50), randn(50), randn(50) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => (IndNonnegative(), IndBox(0.0, Inf)),
         "args"   => ( randn(50), randn(50), randn(50) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => (IndNonpositive(), IndBox(-Inf, 0.0)),
         "args"   => ( randn(50), randn(50), randn(50) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => (lambda -> (SqrNormL2(lambda), Conjugate(SqrNormL2(1.0/lambda))))(0.1 .+ 5.0*rand()),
         "args"   => ( randn(50), randn(50), randn(50) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => ((A, b) -> (LeastSquares(A, b), Tilt(LeastSquares(A, zeros(size(A, 1))), -A'*b, 0.5*dot(b, b))))(randn(10,20), randn(10)),
         "args"   => ( randn(20), randn(20), randn(20) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => ((lambda, rho) -> (ElasticNet(lambda,rho), Regularize(NormL1(lambda),rho)))(rand(), rand()),
         "args"   => ( randn(20), randn(20), randn(20) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => ((b, mu) -> (HingeLoss(b, mu), Postcompose(PrecomposeDiagonal(SumPositive(), -b, 1.0), mu)))([0.5 .+ rand(10); -0.5 .- rand(10)], 0.5+rand()),
         "args"   => ( randn(20), randn(20), randn(20) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       ),
-
+  
   Dict( "funcs"  => ((A, b) -> (Postcompose(LeastSquares(A, b), 15.0, 6.5), Postcompose(Postcompose(LeastSquares(A, b), 5.0, 1.5), 3.0, 2.0)))(randn(10, 20), randn(10)),
         "args"   => ( randn(20), randn(20), randn(20) ),
         "gammas" => ( 1.0, rand(), 5.0*rand() )
       )
 ]
 
-for i = 1:length(stuff)
-  f = stuff[i]["funcs"][1]
-  g = stuff[i]["funcs"][2]
+@testset "$i" for i = 1:length(stuff)
+    f = stuff[i]["funcs"][1]
+    g = stuff[i]["funcs"][2]
 
-  for j = 1:length(stuff[i]["args"])
-    x = stuff[i]["args"][j]
-    gamma = stuff[i]["gammas"][j]
+    for j = 1:length(stuff[i]["args"])
+        x = stuff[i]["args"][j]
+        gamma = stuff[i]["gammas"][j]
 
-    # compare the three versions (for f)
-    yf, fy = prox_test(f, x, gamma)
+        # compare the three versions (for f)
+        yf, fy = prox_test(f, x, gamma)
 
-    # compare the three versions (for g)
-    yg, gy = prox_test(g, x, gamma)
+        # compare the three versions (for g)
+        yg, gy = prox_test(g, x, gamma)
 
-    # compare results of f and g
-    @test norm(yf-yg, Inf)/(1+norm(yf, Inf)) <= TOL_ASSERT
-    @test fy == gy || abs(fy-gy)/(1+abs(fy)) <= TOL_ASSERT
-  end
+        # compare results of f and g
+        @test norm(yf-yg, Inf)/(1+norm(yf, Inf)) <= TOL_ASSERT
+        @test fy == gy || abs(fy-gy)/(1+abs(fy)) <= TOL_ASSERT
+    end
 
 end

--- a/test/test_condition.jl
+++ b/test/test_condition.jl
@@ -1,10 +1,9 @@
 # test whether prox satisfies some conditions
 
-using Random
 using LinearAlgebra
 using SparseArrays
-
-Random.seed!(0)
+using ProximalOperators
+using Test
 
 stuff = [
   Dict( "constr" => LeastSquares,
@@ -48,18 +47,15 @@ stuff = [
       ),
 ]
 
-for i = 1:length(stuff)
-  constr = stuff[i]["constr"]
-  params = stuff[i]["params"]
-  args = stuff[i]["args"]
-  gammas = stuff[i]["gammas"]
-  test = stuff[i]["test"]
-  for i = 1:length(params)
-    # println("----------------------------------------------------------")
-    # println(constr)
-    f = constr(params[i]...)
-    # println(f)
-    y, fy = prox(f, args[i], gammas[i])
-    @test test(f, args[i], gammas[i], y)
-  end
+@testset "$(d["constr"])" for d in stuff
+      constr = d["constr"]
+      params = d["params"]
+      args = d["args"]
+      gammas = d["gammas"]
+      test = d["test"]
+      for i = 1:length(params)
+            f = constr(params[i]...)
+            y, fy = prox(f, args[i], gammas[i])
+            @test test(f, args[i], gammas[i], y)
+      end
 end

--- a/test/test_equivalences.jl
+++ b/test/test_equivalences.jl
@@ -2,14 +2,16 @@
 
 using Random
 using SparseArrays
-
-Random.seed!(0)
+using ProximalOperators
+using Test
 
 ################################################################################
 ### testing consistency of simplex/L1 ball
 ################################################################################
 # Inspired by Condat, "Fast projection onto the simplex and the l1 ball", Mathematical Programming, 158:575–585, 2016.
 # See Prop. 2.1 there and following remarks.
+
+@testset "IndSimplex/IndBallL1" begin
 
 n = 20
 N = 10
@@ -41,9 +43,13 @@ for i = 1:N
   @test y1 ≈ y2
 end
 
+end
+
 ################################################################################
 ### testing consistency of hinge loss/box indicator
 ################################################################################
+
+@testset "HingeLoss/IndBox" begin
 
 n = 20
 N = 10
@@ -70,9 +76,13 @@ for i = 1:N
   @test y1 ≈ y2
 end
 
+end
+
 ################################################################################
 ### testing regularize
 ################################################################################
+
+@testset "Regularize/ElasticNet" begin
 
 lambda = rand()
 rho = rand()
@@ -85,9 +95,13 @@ y2,f2 = prox(ElasticNet(lambda,rho),x)
 @test f ≈ f2
 @test y ≈ y2
 
+end
+
 ################################################################################
 ### testing IndAffine
 ################################################################################
+
+@testset "IndAffine (sparse/dense)" begin
 
 A = sprand(50,100, 0.1)
 b = randn(50)
@@ -101,3 +115,5 @@ y2, f2 = prox(g2, x)
 
 @test f1 ≈ f2
 @test y1 ≈ y2
+
+end

--- a/test/test_huberLoss.jl
+++ b/test/test_huberLoss.jl
@@ -1,7 +1,8 @@
 using LinearAlgebra
-using Random
+using ProximalOperators
+using Test
 
-Random.seed!(0)
+@testset "HuberLoss" begin
 
 f = HuberLoss(1.5, 0.7)
 
@@ -30,3 +31,5 @@ grad_fx, fx = gradient(f, x)
 
 @test abs(fx - f(x)) <= 1e-12
 @test norm(0.7*x - grad_fx, Inf) <= 1e-12
+
+end

--- a/test/test_indAffine.jl
+++ b/test/test_indAffine.jl
@@ -1,8 +1,10 @@
 using LinearAlgebra
 using SparseArrays
 using Random
+using ProximalOperators
+using Test
 
-Random.seed!(0)
+@testset "IndAffine" begin
 
 # Full matrix
 
@@ -49,3 +51,5 @@ call_test(f, x)
 y, fy = prox_test(f, x)
 
 @test f(y) == 0.0
+
+end

--- a/test/test_indPolyhedral.jl
+++ b/test/test_indPolyhedral.jl
@@ -1,6 +1,7 @@
-using Random
+using ProximalOperators
+using Test
 
-Random.seed!(0)
+@testset "IndPolyhedral" begin
 
 # set dimensions
 
@@ -20,9 +21,7 @@ l = A*x0 .- 0.1
 x = 10 .* randn(n)
 p = similar(x)
 
-# define test cases
-
-constructors_positive = [
+@testset "valid" for constr in [
     () -> IndPolyhedral(l, A),
     () -> IndPolyhedral(l, A, xmin, xmax),
     () -> IndPolyhedral(A, u),
@@ -30,16 +29,6 @@ constructors_positive = [
     () -> IndPolyhedral(l, A, u),
     () -> IndPolyhedral(l, A, u, xmin, xmax),
 ]
-
-constructors_negative = [
-    () -> IndPolyhedral(l, A, xmax, xmin),
-    () -> IndPolyhedral(A, u, xmax, xmin),
-    () -> IndPolyhedral(l, A, u, xmax, xmin),
-]
-
-# run positive tests
-
-for constr in constructors_positive
     f = constr()
     @test ProximalOperators.is_convex(f) == true
     @test ProximalOperators.is_set(f) == true
@@ -47,8 +36,12 @@ for constr in constructors_positive
     p, fp = prox_test(f, x)
 end
 
-# run negative tests
-
-for constr in constructors_negative
+@testset "invalid" for constr in [
+    () -> IndPolyhedral(l, A, xmax, xmin),
+    () -> IndPolyhedral(A, u, xmax, xmin),
+    () -> IndPolyhedral(l, A, u, xmax, xmin),
+]
     @test_throws ErrorException constr()
+end
+
 end

--- a/test/test_leastSquares.jl
+++ b/test/test_leastSquares.jl
@@ -1,8 +1,9 @@
 using LinearAlgebra
 using SparseArrays
-using Random
+using ProximalOperators
+using Test
 
-Random.seed!(0)
+@testset "LeastSquares" begin
 
 # Wide full matrix
 
@@ -328,3 +329,5 @@ grad_fx, fx = gradient(f, x)
 call_test(f, x)
 prox_test(f, x)
 prox_test(f, x, 2.1)
+
+end

--- a/test/test_logisticLoss.jl
+++ b/test/test_logisticLoss.jl
@@ -1,4 +1,8 @@
 using LinearAlgebra
+using Test
+using ProximalOperators
+
+@testset "LogisticLoss" begin
 
 y = [1.0, -1.0, 1.0, -1.0, 1.0]
 mu = 1.5
@@ -26,3 +30,5 @@ z2, f_z2 = prox(f, x, 2.0)
 grad_f_z2, = gradient(f, z2)
 
 @test norm((x - z2)./2.0 - grad_f_z2, Inf)/norm(grad_f_z2, Inf) <= 1e-4
+
+end

--- a/test/test_quadratic.jl
+++ b/test/test_quadratic.jl
@@ -1,8 +1,9 @@
 using LinearAlgebra
 using SparseArrays
-using Random
+using Test
+using ProximalOperators
 
-Random.seed!(0)
+@testset "Quadratic" begin
 
 # Test with full matrices
 
@@ -57,3 +58,5 @@ f = Quadratic(Q, q, iterative=true)
 call_test(f, x)
 prox_test(f, x)
 prox_test(f, x, 1.3)
+
+end

--- a/test/test_results.jl
+++ b/test/test_results.jl
@@ -1,6 +1,8 @@
 # Test the correctness of f(x) and prox(f,x,gamma) for a few hardcoded cases
 
 using LinearAlgebra
+using ProximalOperators
+using Test
 
 stuff = [
   Dict( "f"      => NormL2(0.5),
@@ -319,7 +321,7 @@ stuff = [
       )
 ]
 
-for i = 1:length(stuff)
+@testset "$(i)" for i = 1:length(stuff)
 
     f = stuff[i]["f"]
     x = stuff[i]["x"]


### PR DESCRIPTION
Fixes #105. A nice by-product of this is the introduction of the `is_support` predicate indicating whether a function is the support function of some set. Default definition of this, and conjugation rules, are introduced after Rockafellar, Convex Analysis, Thm 13.2.