### PR TITLE
Extend LeastSquares to matrix RHS

### DIFF
--- a/src/functions/leastSquares.jl
+++ b/src/functions/leastSquares.jl
@@ -33,8 +33,8 @@ function LeastSquares(A::M, b::V, lam::R=R(1); iterative=false) where {R <: Real
     end
 end
 
-infer_shape_of_x(A::AbstractMatrix, ::AbstractVector) = (size(A, 2), )
-infer_shape_of_x(A::AbstractMatrix, b::AbstractMatrix) = (size(A, 2), size(b, 2))
+infer_shape_of_x(A, ::AbstractVector) = (size(A, 2), )
+infer_shape_of_x(A, b::AbstractMatrix) = (size(A, 2), size(b, 2))
 
 ### INCLUDE CONCRETE TYPES
 

--- a/src/functions/leastSquares.jl
+++ b/src/functions/leastSquares.jl
@@ -33,6 +33,9 @@ function LeastSquares(A::M, b::V, lam::R=R(1); iterative=false) where {R <: Real
     end
 end
 
+infer_shape_of_x(A::AbstractMatrix, ::AbstractVector) = (size(A, 2), )
+infer_shape_of_x(A::AbstractMatrix, b::AbstractMatrix) = (size(A, 2), size(b, 2))
+
 ### INCLUDE CONCRETE TYPES
 
 include("leastSquaresDirect.jl")

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -7,7 +7,7 @@ using LinearAlgebra
 using SparseArrays
 using SuiteSparse
 
-mutable struct LeastSquaresDirect{R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractArray{C}, F <: Factorization} <: LeastSquares
+mutable struct LeastSquaresDirect{N, R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractArray{C, N}, F <: Factorization} <: LeastSquares
     A::M # m-by-n
     b::V # m (by-p)
     lambda::R
@@ -15,10 +15,10 @@ mutable struct LeastSquaresDirect{R <: Real, C <: RealOrComplex{R}, M <: Abstrac
     gamma::Union{Nothing, R}
     shape::Symbol
     S::M
-    res::Array{C} # m (by-p)
-    q::Array{C} # n (by-p)
+    res::Array{C, N} # m (by-p)
+    q::Array{C, N} # n (by-p)
     fact::F
-    function LeastSquaresDirect{R, C, M, V, F}(A::M, b::V, lambda::R) where {R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractArray{C}, F <: Factorization}
+    function LeastSquaresDirect{N, R, C, M, V, F}(A::M, b::V, lambda::R) where {N, R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractArray{C, N}, F <: Factorization}
         if size(A, 1) != size(b, 1)
             error("A and b have incompatible dimensions")
         end
@@ -38,35 +38,35 @@ end
 is_convex(f::LeastSquaresDirect) = f.lambda >= 0
 is_concave(f::LeastSquaresDirect) = f.lambda <= 0
 
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: DenseMatrix{C}, V <: AbstractArray{C}}
-    LeastSquaresDirect{R, C, M, V, Cholesky{C, M}}(A, b, lambda)
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {N, R <: Real, C <: Union{R, Complex{R}}, M <: DenseMatrix{C}, V <: AbstractArray{C, N}}
+    LeastSquaresDirect{N, R, C, M, V, Cholesky{C, M}}(A, b, lambda)
 end
 
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: SparseMatrixCSC{C, I}, V <: AbstractArray{C}}
-    LeastSquaresDirect{R, C, M, V, SuiteSparse.CHOLMOD.Factor{C}}(A, b, lambda)
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {N, R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: SparseMatrixCSC{C, I}, V <: AbstractArray{C, N}}
+    LeastSquaresDirect{N, R, C, M, V, SuiteSparse.CHOLMOD.Factor{C}}(A, b, lambda)
 end
 
 # Adjoint/Transpose versions
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: TransposeOrAdjoint{<:DenseMatrix{C}}, V <: AbstractArray{C}}
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {N, R <: Real, C <: Union{R, Complex{R}}, M <: TransposeOrAdjoint{<:DenseMatrix{C}}, V <: AbstractArray{C, N}}
     LeastSquaresDirect(copy(A), b, lambda)
 end
 
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: TransposeOrAdjoint{<:SparseMatrixCSC{C, I}}, V <: AbstractArray{C}}
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {N, R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: TransposeOrAdjoint{<:SparseMatrixCSC{C, I}}, V <: AbstractArray{C, N}}
     LeastSquaresDirect(copy(A), b, lambda)
 end
 
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: AbstractMatrix{C}, V <: AbstractArray{C}}
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {N, R <: Real, C <: Union{R, Complex{R}}, M <: AbstractMatrix{C}, V <: AbstractArray{C, N}}
     @warn "Could not infer type of Factorization for $M in LeastSquaresDirect, this type will be type-unstable"
-    LeastSquaresDirect{R, C, M, V, Factorization}(A, b, lambda)
+    LeastSquaresDirect{N, R, C, M, V, Factorization}(A, b, lambda)
 end
 
-function (f::LeastSquaresDirect)(x::AbstractArray)
+function (f::LeastSquaresDirect{N, R, C})(x::AbstractArray{C, N}) where {N, R, C}
     mul!(f.res, f.A, x)
     f.res .-= f.b
     return (f.lambda / 2) * norm(f.res, 2)^2
 end
 
-function prox!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractArray{C}, gamma::R=R(1)) where {R, C, M, V, F}
+function prox!(y::AbstractArray{C, N}, f::LeastSquaresDirect{N, R, C, M, V, F}, x::AbstractArray{C, N}, gamma::R=R(1)) where {N, R, C, M, V, F}
     # if gamma different from f.gamma then call factor_step!
     if gamma != f.gamma
         factor_step!(f, gamma)
@@ -77,17 +77,17 @@ function prox!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::Abs
     return (f.lambda/2)*norm(f.res, 2)^2
 end
 
-function factor_step!(f::LeastSquaresDirect{R, C, M, V, F}, gamma::R) where {R, C, M, V, F}
+function factor_step!(f::LeastSquaresDirect{N, R, C, M, V, F}, gamma::R) where {N, R, C, M, V, F}
     f.fact = cholesky(f.S + I/gamma)
     f.gamma = gamma
 end
 
-function factor_step!(f::LeastSquaresDirect{R, C, M, V, F}, gamma::R) where {R, C, M <: SparseMatrixCSC, V, F}
+function factor_step!(f::LeastSquaresDirect{N, R, C, M, V, F}, gamma::R) where {N, R, C, M <: SparseMatrixCSC, V, F}
     f.fact = ldlt(f.S; shift = R(1)/gamma)
     f.gamma = gamma
 end
 
-function solve_step!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractArray{C}, gamma::R) where {R, C, M, V, F <: Cholesky{C, M}}
+function solve_step!(y::AbstractArray{C, N}, f::LeastSquaresDirect{N, R, C, M, V, F}, x::AbstractArray{C, N}, gamma::R) where {N, R, C, M, V, F <: Cholesky{C, M}}
     f.q .= f.lambdaAtb .+ x./gamma
     # two cases: (1) tall A, (2) fat A
     if f.shape == :Tall
@@ -107,7 +107,7 @@ function solve_step!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, 
     end
 end
 
-function solve_step!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractArray{C}, gamma::R) where {R, C, M, V, F}
+function solve_step!(y::AbstractArray{C, N}, f::LeastSquaresDirect{N, R, C, M, V, F}, x::AbstractArray{C, N}, gamma::R) where {N, R, C, M, V, F}
     f.q .= f.lambdaAtb .+ x./gamma
     # two cases: (1) tall A, (2) fat A
     if f.shape == :Tall
@@ -123,7 +123,7 @@ function solve_step!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, 
     end
 end
 
-function gradient!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractArray{C}) where {R, C, M, V, F}
+function gradient!(y::AbstractArray{C, N}, f::LeastSquaresDirect{N, R, C, M, V, F}, x::AbstractArray{C, N}) where {N, R, C, M, V, F}
     mul!(f.res, f.A, x)
     f.res .-= f.b
     mul!(y, adjoint(f.A), f.res)
@@ -131,7 +131,7 @@ function gradient!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x:
     fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
-function prox_naive(f::LeastSquaresDirect{R, C}, x::AbstractArray{C}, gamma::R=R(1)) where {R, C <: RealOrComplex{R}}
+function prox_naive(f::LeastSquaresDirect{N, R, C}, x::AbstractArray{C, N}, gamma::R=R(1)) where {N, R, C <: RealOrComplex{R}}
     lamgam = f.lambda*gamma
     y = (f.A'*f.A + I/lamgam)\(f.A' * f.b + x/lamgam)
     fy = (f.lambda/2)*norm(f.A*y-f.b)^2

--- a/src/functions/leastSquaresDirect.jl
+++ b/src/functions/leastSquaresDirect.jl
@@ -7,19 +7,19 @@ using LinearAlgebra
 using SparseArrays
 using SuiteSparse
 
-mutable struct LeastSquaresDirect{R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractVector{C}, F <: Factorization} <: LeastSquares
-    A::M # m-by-n matrix
-    b::V
+mutable struct LeastSquaresDirect{R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractArray{C}, F <: Factorization} <: LeastSquares
+    A::M # m-by-n
+    b::V # m (by-p)
     lambda::R
     lambdaAtb::V
     gamma::Union{Nothing, R}
     shape::Symbol
     S::M
-    res::Vector{C} # m-sized buffer
-    q::Vector{C} # n-sized buffer
+    res::Array{C} # m (by-p)
+    q::Array{C} # n (by-p)
     fact::F
-    function LeastSquaresDirect{R, C, M, V, F}(A::M, b::V, lambda::R) where {R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractVector{C}, F <: Factorization}
-        if size(A, 1) != length(b)
+    function LeastSquaresDirect{R, C, M, V, F}(A::M, b::V, lambda::R) where {R <: Real, C <: RealOrComplex{R}, M <: AbstractMatrix{C}, V <: AbstractArray{C}, F <: Factorization}
+        if size(A, 1) != size(b, 1)
             error("A and b have incompatible dimensions")
         end
         m, n = size(A)
@@ -30,42 +30,43 @@ mutable struct LeastSquaresDirect{R <: Real, C <: RealOrComplex{R}, M <: Abstrac
             S = lambda * (A * A')
             shape = :Fat
         end
-        new(A, b, lambda, lambda*(A'*b), nothing, shape, S, zeros(C, m), zeros(C, n))
+        x_shape = infer_shape_of_x(A, b)
+        new(A, b, lambda, lambda*(A'*b), nothing, shape, S, zero(b), zeros(C, x_shape))
     end
 end
 
 is_convex(f::LeastSquaresDirect) = f.lambda >= 0
 is_concave(f::LeastSquaresDirect) = f.lambda <= 0
 
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: DenseMatrix{C}, V <: AbstractVector{C}}
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: DenseMatrix{C}, V <: AbstractArray{C}}
     LeastSquaresDirect{R, C, M, V, Cholesky{C, M}}(A, b, lambda)
 end
 
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: SparseMatrixCSC{C, I}, V <: AbstractVector{C}}
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: SparseMatrixCSC{C, I}, V <: AbstractArray{C}}
     LeastSquaresDirect{R, C, M, V, SuiteSparse.CHOLMOD.Factor{C}}(A, b, lambda)
 end
 
 # Adjoint/Transpose versions
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: TransposeOrAdjoint{<:DenseMatrix{C}}, V <: AbstractVector{C}}
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: TransposeOrAdjoint{<:DenseMatrix{C}}, V <: AbstractArray{C}}
     LeastSquaresDirect(copy(A), b, lambda)
 end
 
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: TransposeOrAdjoint{<:SparseMatrixCSC{C, I}}, V <: AbstractVector{C}}
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, I <: Integer, M <: TransposeOrAdjoint{<:SparseMatrixCSC{C, I}}, V <: AbstractArray{C}}
     LeastSquaresDirect(copy(A), b, lambda)
 end
 
-function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: AbstractMatrix{C}, V <: AbstractVector{C}}
+function LeastSquaresDirect(A::M, b::V, lambda::R) where {R <: Real, C <: Union{R, Complex{R}}, M <: AbstractMatrix{C}, V <: AbstractArray{C}}
     @warn "Could not infer type of Factorization for $M in LeastSquaresDirect, this type will be type-unstable"
     LeastSquaresDirect{R, C, M, V, Factorization}(A, b, lambda)
 end
 
-function (f::LeastSquaresDirect)(x::AbstractVector)
+function (f::LeastSquaresDirect)(x::AbstractArray)
     mul!(f.res, f.A, x)
     f.res .-= f.b
     return (f.lambda / 2) * norm(f.res, 2)^2
 end
 
-function prox!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}, gamma::R=R(1)) where {R, C, M, V, F}
+function prox!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractArray{C}, gamma::R=R(1)) where {R, C, M, V, F}
     # if gamma different from f.gamma then call factor_step!
     if gamma != f.gamma
         factor_step!(f, gamma)
@@ -86,7 +87,7 @@ function factor_step!(f::LeastSquaresDirect{R, C, M, V, F}, gamma::R) where {R, 
     f.gamma = gamma
 end
 
-function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}, gamma::R) where {R, C, M, V, F <: Cholesky{C, M}}
+function solve_step!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractArray{C}, gamma::R) where {R, C, M, V, F <: Cholesky{C, M}}
     f.q .= f.lambdaAtb .+ x./gamma
     # two cases: (1) tall A, (2) fat A
     if f.shape == :Tall
@@ -106,7 +107,7 @@ function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F},
     end
 end
 
-function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}, gamma::R) where {R, C, M, V, F}
+function solve_step!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractArray{C}, gamma::R) where {R, C, M, V, F}
     f.q .= f.lambdaAtb .+ x./gamma
     # two cases: (1) tall A, (2) fat A
     if f.shape == :Tall
@@ -122,7 +123,7 @@ function solve_step!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F},
     end
 end
 
-function gradient!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractVector{C}) where {R, C, M, V, F}
+function gradient!(y::AbstractArray{C}, f::LeastSquaresDirect{R, C, M, V, F}, x::AbstractArray{C}) where {R, C, M, V, F}
     mul!(f.res, f.A, x)
     f.res .-= f.b
     mul!(y, adjoint(f.A), f.res)
@@ -130,7 +131,7 @@ function gradient!(y::AbstractVector{C}, f::LeastSquaresDirect{R, C, M, V, F}, x
     fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
-function prox_naive(f::LeastSquaresDirect{R, C}, x::AbstractVector{C}, gamma::R=R(1)) where {R, C <: RealOrComplex{R}}
+function prox_naive(f::LeastSquaresDirect{R, C}, x::AbstractArray{C}, gamma::R=R(1)) where {R, C <: RealOrComplex{R}}
     lamgam = f.lambda*gamma
     y = (f.A'*f.A + I/lamgam)\(f.A' * f.b + x/lamgam)
     fy = (f.lambda/2)*norm(f.A*y-f.b)^2

--- a/src/functions/leastSquaresIterative.jl
+++ b/src/functions/leastSquaresIterative.jl
@@ -4,45 +4,46 @@
 
 using LinearAlgebra
 
-struct LeastSquaresIterative{R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractVector{RC}, O} <: LeastSquares
+struct LeastSquaresIterative{R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractArray{RC}, O} <: LeastSquares
     A::M # m-by-n operator
-    b::V
+    b::V # m (by-p)
     lambda::R
     lambdaAtb::V
     shape::Symbol
     S::O
-    res::Vector{RC} # m-sized buffer
-    res2::Vector{RC} # m-sized buffer
-    q::Vector{RC} # n-sized buffer
+    res::Array{RC} # m (by-p)
+    res2::Array{RC} # m (by-p)
+    q::Array{RC} # n (by-p)
 end
 
 is_prox_accurate(f::LeastSquaresIterative) = false
 is_convex(f::LeastSquaresIterative) = f.lambda >= 0
 is_concave(f::LeastSquaresIterative) = f.lambda <= 0
 
-function LeastSquaresIterative(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractVector{RC}}
-    if size(A, 1) != length(b)
+function LeastSquaresIterative(A::M, b::V, lambda::R) where {R <: Real, RC <: RealOrComplex{R}, M, V <: AbstractArray{RC}}
+    if size(A, 1) != size(b, 1)
         error("A and b have incompatible dimensions")
     end
     m, n = size(A)
+    x_shape = infer_shape_of_x(A, b)
     if m >= n
         shape = :Tall
         S = AcA(A)
-        LeastSquaresIterative{R, RC, M, V, AcA}(A, b, lambda, lambda*(A'*b), shape, S, zeros(RC, m), [], zeros(RC, n))
+        LeastSquaresIterative{R, RC, M, V, AcA}(A, b, lambda, lambda*(A'*b), shape, S, zero(b), [], zeros(RC, x_shape))
     else
         shape = :Fat
         S = AAc(A)
-        LeastSquaresIterative{R, RC, M, V, AAc}(A, b, lambda, lambda*(A'*b), shape, S, zeros(RC, m), zeros(RC, m), zeros(RC, n))
+        LeastSquaresIterative{R, RC, M, V, AAc}(A, b, lambda, lambda*(A'*b), shape, S, zero(b), zero(b), zeros(RC, x_shape))
     end
 end
 
-function (f::LeastSquaresIterative{R, RC, M, V})(x::AbstractVector{RC}) where {R, RC, M, V}
+function (f::LeastSquaresIterative{R, RC, M, V})(x::AbstractArray{RC}) where {R, RC, M, V}
     mul!(f.res, f.A, x)
     f.res .-= f.b
     return (f.lambda/2)*norm(f.res, 2)^2
 end
 
-function prox!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}, gamma::R=R(1)) where {R, RC, M, V, D <: RealOrComplex{R}}
+function prox!(y::AbstractArray{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractArray{D}, gamma::R=R(1)) where {R, RC, M, V, D <: RealOrComplex{R}}
     f.q .= f.lambdaAtb .+ x./gamma
     # two cases: (1) tall A, (2) fat A
     if f.shape == :Tall
@@ -64,7 +65,7 @@ function prox!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::A
     return (f.lambda/2)*norm(f.res, 2)^2
 end
 
-function gradient!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractVector{D}) where {R, RC, M, V, D <: Union{R, Complex{R}}}
+function gradient!(y::AbstractArray{D}, f::LeastSquaresIterative{R, RC, M, V}, x::AbstractArray{D}) where {R, RC, M, V, D <: Union{R, Complex{R}}}
     mul!(f.res, f.A, x)
     f.res .-= f.b
     mul!(y, adjoint(f.A), f.res)
@@ -72,7 +73,7 @@ function gradient!(y::AbstractVector{D}, f::LeastSquaresIterative{R, RC, M, V}, 
     fy = (f.lambda/2)*dot(f.res, f.res)
 end
 
-function prox_naive(f::LeastSquaresIterative, x::AbstractVector{D}, gamma::R=R(1)) where {R, D <: RealOrComplex{R}}
+function prox_naive(f::LeastSquaresIterative, x::AbstractArray{D}, gamma::R=R(1)) where {R, D <: RealOrComplex{R}}
     y = IterativeSolvers.cg(f.lambda*f.A'*f.A + I/gamma, f.lambda*f.A'*f.b + x/gamma)
     fy = (f.lambda/2)*norm(f.A*y-f.b)^2
     return y, fy

--- a/src/utilities/linops.jl
+++ b/src/utilities/linops.jl
@@ -1,17 +1,15 @@
 # Utility operators for computing prox iteratively, e.g. using CG
-#
-# The idea is that whatever type has the A_mul_B!, Ac_mul_B!, size and eltype
-# methods implemented is a linear operator.
 
 import Base: *, size, eltype
 import LinearAlgebra: mul!
 
 abstract type LinOp end
 
+infer_shape_of_y(Op, ::AbstractVector) = (size(Op, 1), )
+infer_shape_of_y(Op, x::AbstractMatrix) = (size(Op, 1), size(x, 2))
+
 function (*)(Op::LinOp, x)
-    # Is this the right thing to do?
-    # Or maybe just: y = zeros(eltype(x), size(Op, 1))
-    y = zeros(promote_type(eltype(Op), eltype(x)), size(Op, 1))
+    y = zeros(promote_type(eltype(Op), eltype(x)), infer_shape_of_y(Op, x))
     mul!(y, Op, x)
 end
 

--- a/src/utilities/linops.jl
+++ b/src/utilities/linops.jl
@@ -9,29 +9,33 @@ import LinearAlgebra: mul!
 abstract type LinOp end
 
 function (*)(Op::LinOp, x)
-  # Is this the right thing to do?
-  # Or maybe just: y = zeros(eltype(x), size(Op, 1))
-  y = zeros(promote_type(eltype(Op), eltype(x)), size(Op, 1))
-  mul!(y, Op, x)
+    # Is this the right thing to do?
+    # Or maybe just: y = zeros(eltype(x), size(Op, 1))
+    y = zeros(promote_type(eltype(Op), eltype(x)), size(Op, 1))
+    mul!(y, Op, x)
 end
 
 size(Op::LinOp, i::Integer) = i <= 2 ? size(Op)[i] : 1
 
 # AAc (Gram matrix)
 
-struct AAc{M, T} <: LinOp
-  A::M
-  buf::AbstractArray{T}
-  function AAc{M, T}(A::M) where {M, T}
-    new(A, zeros(T, size(A, 2)))
-  end
+mutable struct AAc{M, T} <: LinOp
+    A::M
+    buf::Maybe{AbstractArray{T}}
+    function AAc{M, T}(A::M) where {M, T}
+        new(A, nothing)
+    end
 end
 
 AAc(A::M) where {M} = AAc{M, eltype(A)}(A)
 
 function mul!(y, Op::AAc, x)
-  mul!(Op.buf, adjoint(Op.A), x)
-  mul!(y, Op.A, Op.buf)
+    if Op.buf === nothing
+        Op.buf = adjoint(Op.A) * x
+    else
+        mul!(Op.buf, adjoint(Op.A), x)
+    end
+    mul!(y, Op.A, Op.buf)
 end
 
 mul!(y, Op::Adjoint{AAc}, x) = mul!(y, adjoint(Op), x)
@@ -41,19 +45,23 @@ eltype(Op::AAc) = eltype(Op.A)
 
 # AcA (Covariance matrix)
 
-struct AcA{M, T} <: LinOp
-  A::M
-  buf::AbstractArray{T}
-  function AcA{M, T}(A::M) where {M, T}
-    new(A, zeros(T, size(A, 1)))
-  end
+mutable struct AcA{M, T} <: LinOp
+    A::M
+    buf::Maybe{AbstractArray{T}}
+    function AcA{M, T}(A::M) where {M, T}
+        new(A, nothing)
+    end
 end
 
 AcA(A::M) where {M} = AcA{M, eltype(A)}(A)
 
 function mul!(y, Op::AcA, x)
-  mul!(Op.buf, Op.A, x)
-  mul!(y, adjoint(Op.A), Op.buf)
+    if Op.buf === nothing
+        Op.buf = Op.A * x
+    else
+        mul!(Op.buf, Op.A, x)
+    end
+    mul!(y, adjoint(Op.A), Op.buf)
 end
 
 mul!(y, Op::Adjoint{AcA}, x) = mul!(y, adjoint(Op), x)
@@ -64,29 +72,29 @@ eltype(Op::AcA) = eltype(Op.A)
 # Shifted symmetric linear operator
 
 struct ScaleShift{M, T} <: LinOp
-  alpha::T
-  A::M
-  rho::T
-  function ScaleShift{M, T}(alpha::T, A::M, rho::T) where {M, T}
-    if eltype(A) != T
-      error("type of alpha, rho ($T) is different from that of A ($(eltype(A)))")
+    alpha::T
+    A::M
+    rho::T
+    function ScaleShift{M, T}(alpha::T, A::M, rho::T) where {M, T}
+        if eltype(A) != T
+            error("type of alpha, rho ($T) is different from that of A ($(eltype(A)))")
+        end
+        new(alpha, A, rho)
     end
-    new(alpha, A, rho)
-  end
 end
 
 ScaleShift(alpha::T, A::M, rho::T) where {M, T} = ScaleShift{M, T}(alpha, A, rho)
 
 function mul!(y, Op::ScaleShift, x)
-  mul!(y, Op.A, x)
-  y .*= Op.alpha
-  y .+= Op.rho .* x
+    mul!(y, Op.A, x)
+    y .*= Op.alpha
+    y .+= Op.rho .* x
 end
 
 function mul!(y, Op::Adjoint{ScaleShift}, x)
-  mul!(y, adjoint(Op.A), x)
-  y .*= Op.alpha
-  y .+= Op.rho .* x
+    mul!(y, adjoint(Op.A), x)
+    y .*= Op.alpha
+    y .+= Op.rho .* x
 end
 
 size(Op::ScaleShift) = size(Op.A, 2), size(Op.A, 2)

--- a/test/test_calls.jl
+++ b/test/test_calls.jl
@@ -236,6 +236,11 @@ stuff = [
         "params" => ( (randn(10,25), randn(10)), (randn(40,13), randn(40), rand()), (rand(Complex{Float64},25,10), rand(Complex{Float64},25)), (sprandn(100,1000,0.05), randn(100), rand()) ),
         "args"   => ( randn(25), randn(13), rand(Complex{Float64},10), randn(1000) )
       ),
+
+  Dict( "constr" => LeastSquares,
+        "params" => ( (randn(10,15), randn(10,4)), (rand(Complex{Float64},10,4), rand(Complex{Float64},10,15)), ),
+        "args"   => ( randn(15,4), rand(Complex{Float64},4, 15), )
+      ),
   
   # Dict( "constr" => SumLargest,
   #       "wrong"  => ( (-1,), (0,), (1, -2.0), (2, 0.0), (2, -rand()) ),


### PR DESCRIPTION
Fixes LeastSquares to support the case where RHS is a matrix instead of a vector.

*Note:* this only works with `iterative=False` (the default) due to a limitation of `cg!` in IterativeSolvers, see https://github.com/JuliaMath/IterativeSolvers.jl/issues/248, so the test for the case `iterative=True` is skipped until a fix for that is merged.