### PR TITLE
add prox for MoreauEnvelope

### DIFF
--- a/src/calculus/moreauEnvelope.jl
+++ b/src/calculus/moreauEnvelope.jl
@@ -40,6 +40,16 @@ function gradient!(grad::AbstractArray, f::MoreauEnvelope, x::AbstractArray)
     return fx
 end
 
+function prox!(u::AbstractArray{T}, f::MoreauEnvelope, x::AbstractArray{T}, gamma::R=one(R)) where {R <: Real, T <: Union{R, Complex{R}}}
+    # See: Thm. 6.63 in A. Beck, "First-Order Methods in Optimization", MOS-SIAM Series on Optimization, SIAM, 2017
+    gamlam = gamma + f.lambda
+    y, fy = prox(f.g, x, gamlam)
+    gam_gamlam = gamma/gamlam
+    lam_gamlam = f.lambda/gamlam
+    u .= (lam_gamlam .* x) .+ (gam_gamlam .* y)
+    return fy + 1 / (2 * f.lambda) * norm(u .- y)^2
+end
+
 fun_name(f::MoreauEnvelope,i::Int64) =
 "f$(i)(prox{λ$(i),f$(i)}(A$(i)x))+ 1/2 ‖x - prox{λ$(i),f$(i)}(A$(i)x)‖²"
 

--- a/test/test_moreauEnvelope.jl
+++ b/test/test_moreauEnvelope.jl
@@ -1,39 +1,62 @@
-# Moreau envelope of box indicator
+using Test
+using LinearAlgebra
 
-f = IndBox(-1, 1)
-g = MoreauEnvelope(f, 1e-2)
+@testset "Moreau envelope" begin
 
-predicates_test(g)
+@testset "Box indicator" begin
 
-@test ProximalOperators.is_smooth(g) == true
-@test ProximalOperators.is_quadratic(g) == false
-@test ProximalOperators.is_set(g) == false
+    f = IndBox(-1, 1)
+    g = MoreauEnvelope(f, 1e-2)
 
-x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    predicates_test(g)
 
-grad_g_x, g_x = gradient(g, x)
+    @test ProximalOperators.is_smooth(g) == true
+    @test ProximalOperators.is_quadratic(g) == false
+    @test ProximalOperators.is_set(g) == false
 
-# Moreau envelope of L2 norm = (circulant) Huber loss (for some parameters)
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
 
-rho = 1e-1
-mu = 1e0
-f = NormL2(mu)
-g = MoreauEnvelope(f, rho)
-h = HuberLoss(rho, mu/rho)
+    grad_g_x, g_x = gradient(g, x)
 
-predicates_test(g)
+    y, g_y = prox(g, x, 0.5)
+    grad_g_y, _ = gradient(g, y)
 
-@test ProximalOperators.is_smooth(g) == true
-@test ProximalOperators.is_quadratic(g) == false
-@test ProximalOperators.is_set(g) == false
+    @test y + 0.5 * grad_g_y ≈ x
+    @test g(y) ≈ g_y
 
-x = [1.0, 2.0, 3.0, 4.0, 5.0]
+end
 
-@test abs(g(x) - h(x)) <= 1e-12
+@testset "L2 norm" begin
 
-grad_g_x, g_x = gradient(g, x)
-grad_h_x, h_x = gradient(h, x)
+    rho = 1e-1
+    mu = 1e0
+    f = NormL2(mu)
+    g = MoreauEnvelope(f, rho)
+    h = HuberLoss(rho, mu/rho)
 
-@test abs(g_x - g(x)) <= 1e-12
-@test abs(h_x - h(x)) <= 1e-12
-@test norm(grad_g_x - grad_h_x, Inf) <= 1e-12
+    predicates_test(g)
+
+    @test ProximalOperators.is_smooth(g) == true
+    @test ProximalOperators.is_quadratic(g) == false
+    @test ProximalOperators.is_set(g) == false
+
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    @test abs(g(x) - h(x)) <= 1e-12
+
+    grad_g_x, g_x = gradient(g, x)
+    grad_h_x, h_x = gradient(h, x)
+
+    @test abs(g_x - g(x)) <= 1e-12
+    @test abs(h_x - h(x)) <= 1e-12
+    @test norm(grad_g_x - grad_h_x, Inf) <= 1e-12
+
+    y, g_y = prox(g, x, 0.5)
+    grad_g_y, _ = gradient(g, y)
+
+    @test y + 0.5 * grad_g_y ≈ x
+    @test g(y) ≈ g_y
+
+end
+
+end


### PR DESCRIPTION
This adds the implementation of `prox!` for the `MoreauEnvelope` type. The implementation follows Thm 6.64 [here](https://archive.siam.org/books/mo25/mo25_ch6.pdf); assertions are added to two existing test cases which verify the optimality condition of prox, and that check the correctness of the function value at the proximal point.