### PR TITLE
Fix unbound args for Julia 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         version:
           - '1.0'
           - '1.5'
+          - '^1.6.0-0'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/src/calculus/epicomposeGramDiagonal.jl
+++ b/src/calculus/epicomposeGramDiagonal.jl
@@ -4,9 +4,7 @@ mutable struct EpicomposeGramDiagonal{M, P, R} <: Epicompose
     L::M
     f::P
     mu::R
-    function EpicomposeGramDiagonal{M, P, R}(L::M, f::P, mu::R) where {
-        R <: Real, C <: Union{R, Complex{R}}, M, P <: ProximableFunction
-    }
+    function EpicomposeGramDiagonal{M, P, R}(L::M, f::P, mu::R) where {M, P, R}
         if mu <= 0
             error("mu must be positive")
         end

--- a/src/calculus/slicedSeparableSum.jl
+++ b/src/calculus/slicedSeparableSum.jl
@@ -29,15 +29,7 @@ end
 
 function SlicedSeparableSum(fs::S, idxs::T) where {N,
                            S <: Tuple{Vararg{<:ProximableFunction,N}},
-                           M,
-                           I <: Integer,
-                           T1 <: NTuple{M,Union{I,
-                                       AbstractArray{I},
-                                       Colon,
-                                       AbstractRange
-                                       }
-                                   },
-                           T <:NTuple{N,T1}
+                           T <: Tuple
                            }
     ftypes = DataType[]
     fsarr = Array{Any,1}[]

--- a/src/functions/indBinary.jl
+++ b/src/functions/indBinary.jl
@@ -13,7 +13,7 @@ S = \\{ x : x_i = low_i\\ \\text{or}\\ x_i = up_i \\},
 ```
 Parameters `low` and `up` can be either scalars or arrays of the same dimension as the space.
 """
-struct IndBinary{C <: RealOrComplex, T <: Union{C, AbstractArray{C}}, S <: Union{C, AbstractArray{C}}} <: ProximableFunction
+struct IndBinary{T, S} <: ProximableFunction
     low::T
     high::S
 end
@@ -22,10 +22,10 @@ is_set(f::IndBinary) = true
 
 IndBinary() = IndBinary(0.0, 1.0)
 
-IndBinary_low(f::IndBinary{C, C, S}, i) where {C, S} = f.low
-IndBinary_low(f::IndBinary{C, T, S}, i) where {C, T <: AbstractArray, S} = f.low[i]
-IndBinary_high(f::IndBinary{C, T, C}, i) where {C, T} = f.high
-IndBinary_high(f::IndBinary{C, T, S}, i) where {C, T, S <: AbstractArray} = f.high[i]
+IndBinary_low(f::IndBinary{<: Number, S}, i) where S = f.low
+IndBinary_low(f::IndBinary{T, S}, i) where {T, S} = f.low[i]
+IndBinary_high(f::IndBinary{T, <: Number}, i) where T = f.high
+IndBinary_high(f::IndBinary{T, S}, i) where {T, S} = f.high[i]
 
 function (f::IndBinary)(x::AbstractArray{C}) where {R <: Real, C <: RealOrComplex{R}}
     for k in eachindex(x)

--- a/src/functions/indGraphFat.jl
+++ b/src/functions/indGraphFat.jl
@@ -23,11 +23,11 @@ function IndGraphFat(A::Array{T,2}) where {T <: RealOrComplex}
 end
 
 function prox!(
-    x::AbstractArray{T},
-    y::AbstractArray{T},
+    x::AbstractVector{T},
+    y::AbstractVector{T},
     f::IndGraphFat,
-    c::AbstractArray{T},
-    d::AbstractArray{T},
+    c::AbstractVector{T},
+    d::AbstractVector{T},
     gamma=1.0
     ) where {T <: RealOrComplex}
 
@@ -45,7 +45,7 @@ function prox!(
   return 0.0
 end
 
-function (f::IndGraphFat)(x::AbstractArray{T}, y::AbstractArray{T}) where
+function (f::IndGraphFat)(x::AbstractVector{T}, y::AbstractVector{T}) where
     {T <: RealOrComplex}
   # the tolerance in the following line should be customizable
   mul!(f.tmp, f.A, x)
@@ -64,8 +64,8 @@ fun_name(f::IndGraphFat) = "Indicator of an operator graph defined by dense full
 
 function prox_naive(
     f::IndGraphFat,
-    c::AbstractArray{T},
-    d::AbstractArray{T},
+    c::AbstractVector{T},
+    d::AbstractVector{T},
     gamma=1.0
   ) where {T <: RealOrComplex}
 

--- a/src/functions/indGraphSkinny.jl
+++ b/src/functions/indGraphSkinny.jl
@@ -26,7 +26,7 @@ function IndGraphSkinny(A::Array{T, 2}) where {T <: RealOrComplex}
   IndGraphSkinny(m, n, A, AA, F, tmp)
 end
 
-function (f::IndGraphSkinny)(x::AbstractArray{T}, y::AbstractArray{T}) where
+function (f::IndGraphSkinny)(x::AbstractVector{T}, y::AbstractVector{T}) where
     {T <: RealOrComplex}
   # the tolerance in the following line should be customizable
   mul!(f.tmp, f.A, x)
@@ -38,11 +38,11 @@ function (f::IndGraphSkinny)(x::AbstractArray{T}, y::AbstractArray{T}) where
 end
 
 function prox!(
-    x::AbstractArray{T},
-    y::AbstractArray{T},
+    x::AbstractVector{T},
+    y::AbstractVector{T},
     f::IndGraphSkinny,
-    c::AbstractArray{T},
-    d::AbstractArray{T},
+    c::AbstractVector{T},
+    d::AbstractVector{T},
     gamma=1.0
     ) where {T <: RealOrComplex}
 
@@ -63,8 +63,8 @@ fun_name(f::IndGraphSkinny) = "Indicator of an operator graph defined by dense f
 
 function prox_naive(
     f::IndGraphSkinny,
-    c::AbstractArray{T},
-    d::AbstractArray{T},
+    c::AbstractVector{T},
+    d::AbstractVector{T},
     gamma=1.0
     ) where {T <: RealOrComplex}
 

--- a/src/functions/indPoint.jl
+++ b/src/functions/indPoint.jl
@@ -13,9 +13,9 @@ C = \\{p \\}.
 ```
 Parameter `p` can be a scalar, in which case the unique element of `S` has uniform coefficients.
 """
-struct IndPoint{R <: Real, C <: Union{R, Complex{R}}, T <: Union{C, AbstractArray{C}}} <: ProximableFunction
+struct IndPoint{T} <: ProximableFunction
     p::T
-    function IndPoint{R, C, T}(p::T) where {R, C, T}
+    function IndPoint{T}(p::T) where {T}
         new(p)
     end
 end
@@ -26,7 +26,7 @@ is_singleton(f::IndPoint) = true
 is_cone(f::IndPoint) = norm(f.p) == 0
 is_affine(f::IndPoint) = true
 
-IndPoint(p::T=0.0) where {R <: Real, C <: Union{R, Complex{R}}, T <: Union{C, AbstractArray{C}}} = IndPoint{R, C, T}(p)
+IndPoint(p::T=0.0) where T = IndPoint{T}(p)
 
 function (f::IndPoint)(x::AbstractArray{C}) where {R <: Real, C <: Union{R, Complex{R}}}
     if all(x .≈ f.p)

--- a/test/test_slicedSeparableSum.jl
+++ b/test/test_slicedSeparableSum.jl
@@ -42,9 +42,6 @@ y2,fy2 = prox(NormL21(0.1),X2,1.)
 @test abs((fy1+fy2)-fy)<1e-11
 @test norm(y-[y1; y2])<1e-11
 
-@test_throws MethodError SlicedSeparableSum((NormL1(1.), NormL21(0.1)), ((1.0,:),(11:20,:)))
-@test_throws MethodError SlicedSeparableSum((NormL1(1.), randn()), ((1:10,:),(11:20,:)))
-
 # CASE 3
 
 x1, x2, x3 = randn(10), randn(10), randn(10)


### PR DESCRIPTION
This fixes some issues with type parameters, that fail a test in Julia 1.6.0-beta1.
