### PR TITLE
Implement more efficient projection on simplex and L1 ball

### DIFF
--- a/src/functions/indBallL1.jl
+++ b/src/functions/indBallL1.jl
@@ -30,7 +30,7 @@ is_prox_accurate(f::IndBallL1) = false
 
 IndBallL1(r::R=1.0) where R = IndBallL1{R}(r)
 
-function (f::IndBallL1)(x::AbstractArray{R}) where R
+function (f::IndBallL1)(x::AbstractArray{T}) where {R <: Real, T <: RealOrComplex{R}}
     if norm(x, 1) - f.r > f.r*eps(R)
         return R(Inf)
     end
@@ -63,7 +63,7 @@ function prox!(y::AbstractArray{T}, f::IndBallL1, x::AbstractArray{T}, _::R=R(1)
 end
 
 fun_name(f::IndBallL1) = "indicator of an L1 norm ball"
-fun_dom(f::IndBallL1) = "AbstractArray{Real}"
+fun_dom(f::IndBallL1) = "AbstractArray{Real}, AbstractArray{Complex}"
 fun_expr(f::IndBallL1) = "x ↦ 0 if ‖x‖_1 ⩽ r, +∞ otherwise"
 fun_params(f::IndBallL1) = "r = $(f.r)"
 

--- a/src/functions/indSimplex.jl
+++ b/src/functions/indSimplex.jl
@@ -62,15 +62,15 @@ function simplex_proj_condat!(y::AbstractArray{R}, a, x::AbstractArray{R}) where
             rho += (z - rho) / length(v)
         end
     end
-    v_changes = true
-    while v_changes == true
-        v_changes = false
+    v_changed = true
+    while v_changed == true
+        v_changed = false
         k = 1
         while k <= length(v)
             z = v[k]
             if z <= rho
-                popat!(v, k)
-                v_changes = true
+                deleteat!(v, k)
+                v_changed = true
                 rho += (rho - z) / length(v)
             else
                 k = k + 1

--- a/test/test_calls.jl
+++ b/test/test_calls.jl
@@ -109,6 +109,7 @@ test_cases_spec = [
         ],
         "right" => [
             ( (), [0.1, -0.2, 0.3, -0.39] ),
+            ( (), Complex{Float64}[0.1, -0.2, 0.3, -0.39] ),
             ( (), rand(Float32, 5) ),
             ( (), rand(Float64, 5) ),
             ( (), rand(Complex{Float32}, 5) ),

--- a/test/test_calls.jl
+++ b/test/test_calls.jl
@@ -108,6 +108,7 @@ test_cases_spec = [
             (-rand(),),
         ],
         "right" => [
+            ( (), [0.1, -0.2, 0.3, -0.39] ),
             ( (), rand(Float32, 5) ),
             ( (), rand(Float64, 5) ),
             ( (), rand(Complex{Float32}, 5) ),

--- a/test/test_optimality_conditions.jl
+++ b/test/test_optimality_conditions.jl
@@ -65,6 +65,12 @@ test_cases = [
     ),
 
     Dict(
+        "f" => IndSimplex(5.0),
+        "x" => [0.5, 0.5, 1.0, 1.0, 2.0] * 3,
+        "gamma" => rand(),
+    ),
+
+    Dict(
         "f" => IndSimplex(rand()),
         "x" => randn(10),
         "gamma" => rand(),
@@ -72,25 +78,31 @@ test_cases = [
 
     Dict(
         "f" => IndBallL1(),
-        "x" => randn(10),
+        "x" => [-0.39, 0.1, -0.2, 0.3],
+        "gamma" => rand(),
+    ),
+
+    Dict(
+        "f" => IndBallL1(),
+        "x" => [0.1, -0.1, 0.2, -0.3, 0.4, 0.5],
         "gamma" => rand(),
     ),
 
     Dict(
         "f" => IndBallL1(1.7),
-        "x" => randn(10),
+        "x" => [0.1, -0.1, 0.2, -0.3, 0.4, 0.5],
         "gamma" => rand(),
     ),
 
     Dict(
-        "f" => IndBallL1(5.0),
-        "x" => randn(10),
+        "f" => IndBallL1(1.7),
+        "x" => [0.4, 0.1, 0.6, 0.2, -0.1, -0.3, 0.5],
         "gamma" => rand(),
     ),
 
     Dict(
-        "f" => IndBallL1(rand()),
-        "x" => randn(10),
+        "f" => IndBallL1(1.7),
+        "x" => [0.5, 0.1, -0.1, 0.4, 0.6, -0.3, 0.2] * 10,
         "gamma" => rand(),
     ),
 
@@ -141,6 +153,7 @@ test_cases = [
     @testset "$(typeof(d["f"]))" for d in test_cases
         f, x, gamma = d["f"], d["x"], d["gamma"]
         y, fy = prox(f, x, gamma)
+        @test fy ≈ f(y)
         @test check_optimality(f, x, gamma, y)
     end
 end


### PR DESCRIPTION
This replaces the current algorithm for projecting onto simplexes and L1 norm balls with Condat's algorithm proposed in https://hal.archives-ouvertes.fr/hal-01056171v2