### PR TITLE
Fix documentation publishing issue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,25 +1,24 @@
-name: Documentation
-
+name: Documenter
 on:
   push:
-    branches:
-      - master
-    tags: "*"
+    branches: master
+    tags: [v*]
   pull_request:
 
 jobs:
-  build:
+  Documenter:
+    permissions:
+      contents: write
+      statuses: write
     name: Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: "1"
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
+          version: '1'
+          show-versioninfo: true               # this causes versioninfo to be printed to the action log
+      - uses: julia-actions/cache@v2           # cache using https://github.com/julia-actions/cache
+      - uses: julia-actions/julia-docdeploy@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ docs/make.jl
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR replaces the explicit call to docs/make.jl in docs.yml (recommended by [Documenter's documentation](https://documenter.juliadocs.org/stable/man/hosting/#GitHub-Actions)) with a specialized GitHub action: https://github.com/julia-actions/julia-docdeploy#usage

This GitHub action seems curated (it is part of julia-actions organization) and maintained (last commit was 6 month ago).

It might fix #155 because it doesn't require `DOCUMENTER_KEY` variable to be set up.