### PR TITLE
Update benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,13 +1,14 @@
 name: Benchmark
 on:
-  - pull_request
+  pull_request_target:
+    branches: [ master ]
+permissions:
+  pull-requests: write    # needed to post comments
 
 jobs:
-  benchmark:
-    name: Benchmark
+  bench:
     runs-on: ubuntu-latest
     steps:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:
           julia-version: '1'
-          job-summary: 'true'


### PR DESCRIPTION
My previous attempts to integrate AirspeedVelocity with the "commenting on PRs" feature might have failed because the action was triggered by the "pull_request" event rather than the "pull_request_target". The "pull_request_target" event has higher privileges, but AirspeedVelocity appears to incorporate sufficient safety countermeasures, as discussed in https://github.com/MilesCranmer/AirspeedVelocity.jl/pull/142.

Unfortunately, this file needs to be merged to take effect and see if it really works.